### PR TITLE
Enhance init db script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,21 @@ uv sync
 # Initialize the database
 uv run ezrules init-db
 
+# Initialize database with automatic deletion of existing database (non-interactive)
+uv run ezrules init-db --auto-delete
+
 # Set up permissions and default roles
 uv run ezrules init-permissions
 
 # Add a user
 uv run ezrules add-user --user-email admin@example.com --password admin
 ```
+
+The `init-db` command automatically handles database creation and provides options for managing existing databases:
+
+- **Interactive mode** (default): Prompts if you want to delete and recreate existing databases
+- **Auto-delete mode** (`--auto-delete`): Automatically deletes existing databases without prompting
+- **Smart creation**: Only creates the database if it doesn't already exist
 
 ### Start Services
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -7,6 +7,7 @@ v0.9
 * List and outcomes are now editable
 * User managemetn UI
 * Role and permissions managemnt UI
+* Enhanced init-db script with interactive database management and --auto-delete option
 
 v0.7
 


### PR DESCRIPTION
This pull request enhances the database initialization process in the CLI by adding interactive and non-interactive options for managing existing databases, improving error handling, and updating documentation to reflect these changes. The main focus is to give users more flexibility and safety when initializing the database, especially in development or automation scenarios.

**Database initialization improvements:**

* Added `--auto-delete` option to the `init-db` CLI command, allowing automatic deletion of existing databases without user prompts. If not specified, the command interactively prompts the user before deleting an existing database. The initialization also now checks if the database exists and only creates it if necessary. [[1]](diffhunk://#diff-ea37e62f410b2b2a2841ed066d43588fda5e17931faae66f793246464781f6deL66-R151) [[2]](diffhunk://#diff-ea37e62f410b2b2a2841ed066d43588fda5e17931faae66f793246464781f6deR33-R64)
* Improved error handling in the `init-db` command, providing clearer logging and exiting gracefully on connection or schema initialization failures.

**Documentation updates:**

* Updated `README.md` to document the new `--auto-delete` option and explain the interactive and smart creation behaviors of the `init-db` command.
* Added a note about the enhanced `init-db` script to the `docs/whatsnew.rst` changelog.

**Internal refactoring:**

* Introduced helper functions `_drop_database` and `_create_database` to encapsulate database management logic, including safe connection termination and existence checks.
* Added necessary imports (`sys`, `urlparse`, `OperationalError`, `text`) to support the new logic in database initialization.