### PR TITLE
Basic dashboard

### DIFF
--- a/ezrules/backend/ezruleapp.py
+++ b/ezrules/backend/ezruleapp.py
@@ -1,3 +1,4 @@
+import datetime
 import difflib
 import json
 import logging
@@ -57,6 +58,7 @@ from ezrules.models.backend_core import (
     RuleEngineConfigHistory,
     RuleHistory,
     TestingRecordLog,
+    TestingResultsLog,
     User,
 )
 from ezrules.models.backend_core import Rule as RuleModel
@@ -809,3 +811,38 @@ def mark_event():
 @csrf.exempt
 def ping():
     return "OK"
+
+
+@app.route("/dashboard", methods=["GET"])
+@conditional_decorator(not app.config["TESTING"], auth_required())
+@conditional_decorator(not app.config["TESTING"], requires_permission(PermissionAction.VIEW_RULES))
+def dashboard():
+    """Display dashboard with key metrics."""
+    # Count active rules
+    active_rules_count = db_session.query(RuleModel).count()
+
+    # Get today's start (midnight)
+    today_start = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # Count transactions processed today
+    transactions_today = db_session.query(TestingRecordLog).filter(TestingRecordLog.created_at >= today_start).count()
+
+    # Count outcomes triggered by type (today)
+    outcomes_by_type = {}
+    outcomes_today = (
+        db_session.query(TestingResultsLog.rule_result, sqlalchemy.func.count(TestingResultsLog.rule_result))
+        .join(TestingRecordLog, TestingRecordLog.tl_id == TestingResultsLog.tl_id)
+        .filter(TestingRecordLog.created_at >= today_start)
+        .group_by(TestingResultsLog.rule_result)
+        .all()
+    )
+
+    for outcome, count in outcomes_today:
+        outcomes_by_type[outcome] = count
+
+    return render_template(
+        "dashboard.html",
+        active_rules_count=active_rules_count,
+        transactions_today=transactions_today,
+        outcomes_by_type=outcomes_by_type,
+    )

--- a/ezrules/backend/templates/dashboard.html
+++ b/ezrules/backend/templates/dashboard.html
@@ -1,0 +1,100 @@
+{% include "user_header.html" %}
+{% extends "layout.html" %}
+{% block head %}
+
+<head>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous">
+        </script>
+    <title>Dashboard</title>
+    <style>
+        .container-fluid {
+            padding-left: 15px;
+            padding-right: 15px;
+        }
+        .metric-card {
+            margin-bottom: 20px;
+        }
+        .metric-value {
+            font-size: 2.5rem;
+            font-weight: bold;
+            color: #0d6efd;
+        }
+        .metric-label {
+            font-size: 1.2rem;
+            color: #6c757d;
+        }
+    </style>
+</head>
+{% endblock %}
+{% block body %}
+
+<body>
+    <div class="container-fluid mt-3">
+        <h1>Dashboard</h1>
+        <div class="mb-3">
+            <a href="{{ url_for('rules') }}" class="btn btn-primary">Rules</a>
+            <a href="{{ url_for('verified_outcomes') }}" class="btn btn-secondary">Outcomes</a>
+            <a href="{{ url_for('label_management') }}" class="btn btn-secondary">Labels</a>
+            <a href="{{ url_for('upload_labels') }}" class="btn btn-success">Upload Labels</a>
+            <a href="{{ url_for('user_lists') }}" class="btn btn-secondary">Lists</a>
+            <a href="{{ url_for('user_management') }}" class="btn btn-secondary">Users</a>
+            <a href="{{ url_for('role_management') }}" class="btn btn-secondary">Roles</a>
+        </div>
+
+        <div class="row mt-4">
+            <div class="col-md-4">
+                <div class="card metric-card">
+                    <div class="card-body text-center">
+                        <div class="metric-value">{{ active_rules_count }}</div>
+                        <div class="metric-label">Active Rules</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="card metric-card">
+                    <div class="card-body text-center">
+                        <div class="metric-value">{{ transactions_today }}</div>
+                        <div class="metric-label">Transactions Today</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h5>Outcomes Triggered Today</h5>
+                    </div>
+                    <div class="card-body">
+                        {% if outcomes_by_type %}
+                        <table class="table table-striped">
+                            <thead>
+                                <tr>
+                                    <th>Outcome Type</th>
+                                    <th>Count</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for outcome, count in outcomes_by_type.items() %}
+                                <tr>
+                                    <td>{{ outcome }}</td>
+                                    <td>{{ count }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        {% else %}
+                        <p class="text-muted">No outcomes triggered today.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+{% endblock %}

--- a/ezrules/backend/templates/rules.html
+++ b/ezrules/backend/templates/rules.html
@@ -36,6 +36,7 @@
             </div>
         </div>
         <div class="mb-3">
+            <a href="{{ url_for('dashboard') }}" class="btn btn-info">Dashboard</a>
             <a href="{{ url_for('create_rule') }}" class="btn btn-primary">Add Rule</a>
             <a href="{{ url_for('verified_outcomes') }}" class="btn btn-secondary">Outcomes</a>
             <a href="{{ url_for('label_management') }}" class="btn btn-secondary">Labels</a>


### PR DESCRIPTION
This pull request introduces a new dashboard feature to the application, providing users with a summary view of key system metrics such as the number of active rules, transactions processed today, and outcomes triggered by type. It includes backend logic, a new dashboard template, navigation updates, and comprehensive tests to ensure correct functionality.

**Dashboard feature implementation:**

* Added a new `/dashboard` route in `ezruleapp.py` that displays metrics including active rules count, today's transactions, and outcomes triggered by type, using data from `RuleModel`, `TestingRecordLog`, and `TestingResultsLog`.
* Created a new `dashboard.html` template that presents these metrics in a visually organized format using Bootstrap, and provides navigation links to other key pages.

**Navigation updates:**

* Updated the `rules.html` template to include a button linking to the new dashboard for improved accessibility.

**Backend and model integration:**

* Imported `TestingResultsLog` in `ezruleapp.py` to support outcome metrics calculations on the dashboard.
* Added import of `datetime` in `ezruleapp.py` to facilitate time-based queries for dashboard metrics.

**Testing:**

* Added new tests in `test_ezruleapp.py` to verify that the dashboard page loads, displays the correct number of active rules, shows today's transactions, and lists outcomes by type.