### PR TITLE
Clarify rule audit activation metadata

### DIFF
--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -103,15 +103,15 @@ Rule lifecycle fields on rule responses:
 - `evaluation_lane`: `main` or `allowlist`
 - `execution_order`: integer serving order used by main rules; lower values run earlier
 - `effective_from`: activation timestamp for active versions
-- `approved_by` / `approved_at`: approver audit metadata for promotions
+- `approved_by` / `approved_at`: the user and timestamp recorded for the last promote/resume/auto-promote action. The field names are kept for API compatibility; ezrules does not have a separate approval workflow. Audit endpoints use `action`, `changed_by`, `changed`, and `to_status` for event timelines.
 - `POST /api/v2/rules` creates draft rules.
 - `PUT /api/v2/rules/{id}` saves edits as draft by default and requires promotion to reactivate.
 - `POST /api/v2/rules/{id}/pause` moves an active rule out of live production evaluation without archiving it.
-- `POST /api/v2/rules/{id}/resume` returns a paused rule to `active` and records fresh approver metadata.
+- `POST /api/v2/rules/{id}/resume` returns a paused rule to `active` and records fresh activation metadata.
 - Editing a paused rule keeps it paused; it does not silently reactivate.
 - If runtime setting `auto_promote_active_rule_updates` is enabled for the caller's org, editing an already active rule keeps it active and updates production immediately, but the caller still needs `PROMOTE_RULES`.
 - `POST /api/v2/rules/{id}/rollback` restores the selected historical revision's logic and description into a brand new draft version, preserving the full revision chain.
-- Rule audit entries (`GET /api/v2/audit/rules*`) now include `action` (`updated`, `reordered`, `promoted`, `paused`, `resumed`, `deactivated`, `rolled_back`, `deleted`), `execution_order`, and `to_status` to show lifecycle transitions such as `draft -> active` or `active -> paused`.
+- Rule audit entries (`GET /api/v2/audit/rules*`) are event-log records. They include `action` (`updated`, `reordered`, `promoted`, `paused`, `resumed`, `deactivated`, `rolled_back`, `deleted`), `changed_by`, `changed`, `execution_order`, and `to_status` to show lifecycle transitions such as `draft -> active` or `active -> paused`; they do not expose `approved_by` or `approved_at`.
 - Deleting a rule preserves its history so `GET /api/v2/audit/rules/{rule_id}` remains available after deletion.
 - Rules with an active shadow deployment or rollout cannot be edited, paused, archived, deleted, directly promoted, resumed, or rolled back until the candidate deployment is removed or promoted.
 - Allowlist rules are first-class production rules. They cannot be deployed to shadow or rollout.
@@ -305,8 +305,8 @@ Field type config note:
 | Method | Path | Auth | Notes |
 |---|---|---|---|
 | `GET` | `/api/v2/audit` | Bearer + permission | Summary for the caller's org |
-| `GET` | `/api/v2/audit/rules` | Bearer + permission | Rule history (`limit`, `offset`, filters) |
-| `GET` | `/api/v2/audit/rules/{rule_id}` | Bearer + permission | Full history for one rule |
+| `GET` | `/api/v2/audit/rules` | Bearer + permission | Rule event history (`limit`, `offset`, filters) with action, actor, timestamp, and status transition |
+| `GET` | `/api/v2/audit/rules/{rule_id}` | Bearer + permission | Full event history for one rule |
 | `GET` | `/api/v2/audit/config` | Bearer + permission | Config history (`limit`, `offset`, filters) |
 | `GET` | `/api/v2/audit/user-lists` | Bearer + permission | User-list history |
 | `GET` | `/api/v2/audit/outcomes` | Bearer + permission | Outcome history |

--- a/docs/blog/ai-rule-authoring.md
+++ b/docs/blog/ai-rule-authoring.md
@@ -209,7 +209,7 @@ AI-assisted rule authoring in ezrules does exactly that:
 - native engine syntax
 - explicit validation
 - visual review aids
-- human approval before save
+- human acceptance before save
 
 That is a much better fit for production transaction monitoring than a fully automatic rule-writing workflow.
 

--- a/docs/blog/rule-lifecycle-management.md
+++ b/docs/blog/rule-lifecycle-management.md
@@ -5,7 +5,7 @@ Rule engines usually fail at one of two extremes:
 - Every edit is live immediately, which is fast but risky.
 - Every edit requires an external process, which is safe but slow.
 
-ezrules now supports an explicit lifecycle so teams can move fast without losing control: `draft` -> `active` -> `paused` -> `active` or `archived`, with promotion approvals captured in the audit trail and rollback available when a historical revision needs to be restored as a new draft.
+ezrules now supports an explicit lifecycle so teams can move fast without losing control: `draft` -> `active` -> `paused` -> `active` or `archived`, with lifecycle events captured in the audit trail and rollback available when a historical revision needs to be restored as a new draft.
 
 ## Why lifecycle controls matter
 
@@ -26,19 +26,19 @@ Each rule now includes lifecycle metadata:
 
 - `status`: `draft`, `active`, `paused`, or `archived`
 - `effective_from`: when the active version became effective
-- `approved_by`: user id who approved promotion
-- `approved_at`: when promotion was approved
+- `approved_by`: user id recorded when the current rule version was activated or reactivated
+- `approved_at`: timestamp recorded when the current rule version was activated
 
-The same metadata is snapshotted into `rules_history`, so lifecycle transitions and approver chain context are preserved in historical revisions.
+There is no separate approval workflow. The `approved_*` field names are kept for API compatibility and refer to promote, resume, or auto-promote actions. The audit trail exposes lifecycle transitions as event-log rows: action, actor, timestamp, and status transition.
 
 ## API behavior by lifecycle
 
 The lifecycle is enforced by API behavior:
 
 - `POST /api/v2/rules` creates a `draft` rule
-- `PUT /api/v2/rules/{id}` saves edits as `draft` and clears previous approval metadata by default
+- `PUT /api/v2/rules/{id}` saves edits as `draft` and clears previous activation metadata by default
 - `POST /api/v2/rules/{id}/rollback` restores a historical revision's logic and description into a brand new `draft`
-- `POST /api/v2/rules/{id}/promote` moves `draft` to `active` and records approver + approval timestamp
+- `POST /api/v2/rules/{id}/promote` moves `draft` to `active` and records the activation actor + timestamp
 - `POST /api/v2/rules/{id}/pause` moves `active` to `paused` without archiving the rule and requires a dedicated pause permission
 - `POST /api/v2/rules/{id}/resume` moves `paused` back to `active`
 - `POST /api/v2/rules/{id}/archive` moves a rule to `archived`
@@ -73,12 +73,12 @@ In the rule list, the lifecycle state stays visible next to the rule, alongside 
 
 ![Rule list with draft, active, and shadow lifecycle badges](../assets/readme/rule-lifecycle-statuses.png)
 
-## Promotion is a first-class approval step
+## Promotion is a first-class activation step
 
 Promotion is no longer an implicit side effect of editing. It is an explicit operation that records:
 
-- who approved
-- when it was approved
+- who activated the rule
+- when it was activated
 - when it became effective
 
 That gives you a defensible trail for internal governance and external audits, while keeping authoring fast for rule editors.
@@ -156,7 +156,7 @@ A practical sequence is:
 1. Edit rule in draft
 2. (Optional) deploy to shadow for live validation
 3. Roll back to a known-good revision if a newer draft or active version proves wrong
-4. Promote when approved
+4. Promote when ready to activate
 5. Archive when rule is retired
 
 ## Net effect
@@ -165,7 +165,7 @@ You get a cleaner rule lifecycle without adding operational friction:
 
 - safer releases through explicit promotion
 - faster recovery through auditable rollback
-- auditable approval chain
+- auditable activation trail
 - clear operational state in UI and API
 - predictable retirement path through archive
 

--- a/docs/user-guide/admin-guide.md
+++ b/docs/user-guide/admin-guide.md
@@ -126,7 +126,7 @@ Use audit endpoints during incident review or compliance checks:
 
 Operational tips:
 
-- Capture `changed_by` values and timestamps when preparing incident timelines
+- Capture actor (`changed_by`) values and timestamps when preparing incident timelines
 - Watch for `rolled_back` rule actions when reconstructing emergency change timelines
 - Watch for `reordered` rule actions when investigating decision-order changes in first-match mode
 - Field type changes affect rule evaluation behavior; review `GET /api/v2/audit/field-types` when investigating unexpected rule outcomes

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.18.1
+
+* **Rule audit trail clarified**: Rule audit rows now read as event-log entries with action, actor, timestamp, and status transition, while activation metadata stays on rule snapshots instead of appearing as misleading Approved By / Approved At audit columns.
+* **Activation field wording**: Rule response fields named `approved_by` and `approved_at` are now documented as API-compatible names for promote/resume/auto-promote activation metadata, not evidence of a separate approval workflow.
+
 ## v1.18.0
 
 * **Canonical evaluation ledgers**: Live evaluation now writes append-only event versions and immutable served-decision records as the default persistence contract, so repeated business events can be represented as ordered versions instead of ad hoc duplicate rows.
@@ -202,11 +207,11 @@
 ## v0.18
 
 * **Rule lifecycle states**: Rules now carry lifecycle metadata with `status` (`draft`, `active`, `archived`), `effective_from`, `approved_by`, and `approved_at`.
-* **Promotion workflow**: Added `POST /api/v2/rules/{id}/promote` to transition draft rules to active with approver audit attribution.
+* **Promotion workflow**: Added `POST /api/v2/rules/{id}/promote` to transition draft rules to active with activation actor attribution.
 * **Archive workflow**: Added `POST /api/v2/rules/{id}/archive` to archive rules and remove active rules from production evaluation.
 * **Delete endpoint documented and permissioned**: `DELETE /api/v2/rules/{id}` is explicitly documented and guarded by `DELETE_RULE`.
 * **UI lifecycle controls**: Rule list now shows lifecycle badges and includes promote/archive actions.
-* **Audit trail enrichment**: Rule history entries now persist lifecycle/approval metadata plus explicit rule actions (`promoted`, `deactivated`, `deleted`) with target status transitions; deleted rules retain audit history and remain queryable via `GET /api/v2/audit/rules/{rule_id}`.
+* **Audit trail enrichment**: Rule history entries now persist lifecycle activation metadata plus explicit rule actions (`promoted`, `deactivated`, `deleted`) with target status transitions; deleted rules retain audit history and remain queryable via `GET /api/v2/audit/rules/{rule_id}`.
 * **E2E setup guardrail**: Frontend e2e docs now explicitly require starting API with `EZRULES_TESTING=false` for invite/reset email flows; testing mode disables SMTP delivery and causes those tests to fail.
 
 ## v0.17

--- a/ezrules/backend/api_v2/routes/audit.py
+++ b/ezrules/backend/api_v2/routes/audit.py
@@ -82,8 +82,6 @@ def rule_history_to_response(history: RuleHistory) -> RuleHistoryEntry:
         status=history.status,
         to_status=history.to_status,
         effective_from=history.effective_from if history.effective_from is not None else None,  # type: ignore[arg-type]
-        approved_by=int(history.approved_by) if history.approved_by is not None else None,
-        approved_at=history.approved_at if history.approved_at is not None else None,  # type: ignore[arg-type]
         changed=changed,  # type: ignore[arg-type]
         changed_by=str(history.changed_by) if history.changed_by else None,
     )

--- a/ezrules/backend/api_v2/routes/rules.py
+++ b/ezrules/backend/api_v2/routes/rules.py
@@ -805,7 +805,7 @@ def promote_rule(
     current_org_id: int = Depends(get_current_org_id),
     db: Any = Depends(get_db),
 ) -> RuleMutationResponse:
-    """Promote a draft rule to active and record approver metadata."""
+    """Promote a draft rule to active and record who activated it."""
     rule_manager = get_rule_manager(db, current_org_id)
     config_producer = get_config_producer(db, current_org_id)
     rule = rule_manager.load_rule(rule_id)

--- a/ezrules/backend/api_v2/schemas/audit.py
+++ b/ezrules/backend/api_v2/schemas/audit.py
@@ -42,11 +42,9 @@ class RuleHistoryEntry(BaseModel):
     action: str = Field(..., description="Action type (updated, promoted, deactivated, deleted, reordered)")
     status: RuleStatus = Field(..., description="Rule lifecycle status at this version")
     to_status: RuleStatus | None = Field(default=None, description="Target status for lifecycle transitions")
-    effective_from: datetime | None = Field(default=None, description="Activation timestamp for this version")
-    approved_by: int | None = Field(default=None, description="User ID that approved this version")
-    approved_at: datetime | None = Field(default=None, description="Approval timestamp for this version")
-    changed: datetime | None = Field(default=None, description="When this version was created")
-    changed_by: str | None = Field(default=None, description="Who made this change")
+    effective_from: datetime | None = Field(default=None, description="Activation timestamp captured on the rule")
+    changed: datetime | None = Field(default=None, description="When this audit event was recorded")
+    changed_by: str | None = Field(default=None, description="Actor that caused this audit event")
 
     model_config = {"from_attributes": True}
 

--- a/ezrules/backend/api_v2/schemas/rules.py
+++ b/ezrules/backend/api_v2/schemas/rules.py
@@ -117,8 +117,20 @@ class RuleResponse(BaseModel):
     evaluation_lane: str = Field(..., description="Evaluation lane for this rule")
     status: RuleStatus = Field(..., description="Rule lifecycle status")
     effective_from: datetime | None = Field(None, description="When the currently active version became effective")
-    approved_by: int | None = Field(None, description="User ID that approved promotion to active")
-    approved_at: datetime | None = Field(None, description="When the rule was approved for activation")
+    approved_by: int | None = Field(
+        None,
+        description=(
+            "User ID recorded when the rule was last activated through promote, resume, or auto-promote. "
+            "This field is named for API compatibility; ezrules has no separate approval workflow."
+        ),
+    )
+    approved_at: datetime | None = Field(
+        None,
+        description=(
+            "Timestamp recorded when the rule was last activated through promote, resume, or auto-promote. "
+            "This field is named for API compatibility; ezrules has no separate approval workflow."
+        ),
+    )
     created_at: datetime | None = None
     revisions: list[RuleRevisionSummary] = Field(default_factory=list)
     revision_number: int | None = Field(None, description="Revision number (only for historical revisions)")
@@ -137,8 +149,20 @@ class RuleListItem(BaseModel):
     evaluation_lane: str = Field(..., description="Evaluation lane for this rule")
     status: RuleStatus = Field(..., description="Rule lifecycle status")
     effective_from: datetime | None = Field(None, description="When the currently active version became effective")
-    approved_by: int | None = Field(None, description="User ID that approved promotion to active")
-    approved_at: datetime | None = Field(None, description="When the rule was approved for activation")
+    approved_by: int | None = Field(
+        None,
+        description=(
+            "User ID recorded when the rule was last activated through promote, resume, or auto-promote. "
+            "This field is named for API compatibility; ezrules has no separate approval workflow."
+        ),
+    )
+    approved_at: datetime | None = Field(
+        None,
+        description=(
+            "Timestamp recorded when the rule was last activated through promote, resume, or auto-promote. "
+            "This field is named for API compatibility; ezrules has no separate approval workflow."
+        ),
+    )
     created_at: datetime | None = None
     in_shadow: bool = False
     in_rollout: bool = False
@@ -164,8 +188,20 @@ class RuleHistoryEntry(BaseModel):
     evaluation_lane: str = Field(..., description="Evaluation lane for this revision")
     status: RuleStatus = Field(..., description="Rule lifecycle status in this revision")
     effective_from: datetime | None = Field(None, description="When this revision became effective")
-    approved_by: int | None = Field(None, description="User ID that approved this revision")
-    approved_at: datetime | None = Field(None, description="When this revision was approved")
+    approved_by: int | None = Field(
+        None,
+        description=(
+            "User ID captured when this revision was activated. This field is named for API compatibility; "
+            "ezrules has no separate approval workflow."
+        ),
+    )
+    approved_at: datetime | None = Field(
+        None,
+        description=(
+            "Timestamp captured when this revision was activated. This field is named for API compatibility; "
+            "ezrules has no separate approval workflow."
+        ),
+    )
     created_at: datetime | None = None
     is_current: bool = False
 

--- a/ezrules/frontend/e2e/tests/audit-trail.spec.ts
+++ b/ezrules/frontend/e2e/tests/audit-trail.spec.ts
@@ -139,11 +139,7 @@ test.describe('Audit Trail Page', () => {
       const rowCount = await auditTrailPage.getRuleHistoryRowCount();
       if (rowCount > 0) {
         const headers = await auditTrailPage.getRuleHistoryColumnHeaders();
-        expect(headers).toContain('Version');
-        expect(headers).toContain('Rule ID');
-        expect(headers).toContain('Description');
-        expect(headers).toContain('Changed By');
-        expect(headers).toContain('Changed');
+        expect(headers).toEqual(['Version', 'Rule ID', 'Action', 'Status Transition', 'Actor', 'Timestamp']);
       }
     });
   });

--- a/ezrules/frontend/src/app/audit-trail/audit-trail.component.html
+++ b/ezrules/frontend/src/app/audit-trail/audit-trail.component.html
@@ -57,13 +57,10 @@
                   <tr>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Version</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rule ID</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status Transition</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Approved By</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Approved At</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Changed By</th>
-                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Changed</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actor</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Timestamp</th>
                   </tr>
                 </thead>
                 <tbody class="bg-white divide-y divide-gray-200">
@@ -74,7 +71,6 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm font-mono">
                       <a [routerLink]="['/rules', entry.r_id]" class="text-blue-600 hover:text-blue-800 hover:underline">{{ entry.rid }}</a>
                     </td>
-                    <td class="px-6 py-4 text-sm text-gray-600" [title]="entry.description">{{ truncateDescription(entry.description) }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm">
                       <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium" [ngClass]="ruleActionClass(entry.action)">
                         {{ formatAction(entry.action) }}
@@ -83,8 +79,6 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
                       {{ formatStatus(entry.status) }}<span *ngIf="entry.to_status"> → {{ formatStatus(entry.to_status) }}</span>
                     </td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ entry.approved_by ?? '—' }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ formatDate(entry.approved_at) }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ entry.changed_by || '—' }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ formatDate(entry.changed) }}</td>
                   </tr>

--- a/ezrules/frontend/src/app/services/audit.service.ts
+++ b/ezrules/frontend/src/app/services/audit.service.ts
@@ -12,8 +12,6 @@ export interface RuleHistoryEntry {
   action: string;
   status: 'draft' | 'active' | 'paused' | 'archived';
   to_status: 'draft' | 'active' | 'paused' | 'archived' | null;
-  approved_by: number | null;
-  approved_at: string | null;
   changed: string | null;
   changed_by: string | null;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.18.0"
+version = "1.18.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_api_v2_audit.py
+++ b/tests/test_api_v2_audit.py
@@ -238,6 +238,34 @@ class TestListRuleHistory:
         item = response.json()["items"][0]
         assert "action" in item
         assert "to_status" in item
+        assert "changed_by" in item
+        assert "changed" in item
+
+    def test_list_rule_history_does_not_expose_rule_activation_snapshot_fields(
+        self, audit_test_client, sample_rule_with_history
+    ):
+        """Rule audit payload should expose event metadata, not stored rule activation metadata."""
+        token = audit_test_client.test_data["token"]
+        session = audit_test_client.test_data["session"]
+        user = audit_test_client.test_data["user"]
+
+        sample = session.query(RuleHistory).filter(RuleHistory.r_id == sample_rule_with_history.r_id).first()
+        assert sample is not None
+        sample.action = "promoted"
+        sample.status = RuleStatus.DRAFT
+        sample.to_status = RuleStatus.ACTIVE
+        sample.approved_by = user.id
+        session.commit()
+
+        response = audit_test_client.get(
+            f"/api/v2/audit/rules?rule_id={sample_rule_with_history.r_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert "approved_by" not in item
+        assert "approved_at" not in item
 
 
 # =============================================================================
@@ -267,6 +295,8 @@ class TestGetRuleAudit:
         # History should be ordered by version ascending
         assert data["history"][0]["version"] == 1
         assert data["history"][1]["version"] == 2
+        assert "approved_by" not in data["history"][0]
+        assert "approved_at" not in data["history"][0]
 
     def test_get_rule_audit_not_found(self, audit_test_client):
         """Should return 404 for non-existent rule."""

--- a/tests/test_api_v2_rules.py
+++ b/tests/test_api_v2_rules.py
@@ -583,7 +583,7 @@ class TestUpdateRule:
 class TestRuleLifecycleAudit:
     """Tests for lifecycle actions recorded in rule audit history."""
 
-    def test_promote_records_audit_transition_and_approver(self, rules_test_client):
+    def test_promote_records_audit_transition_and_activation_metadata(self, rules_test_client):
         token = rules_test_client.test_data["token"]
         session = rules_test_client.test_data["session"]
         user = rules_test_client.test_data["user"]

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.18.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- simplify the rule audit trail to event-log columns: action, actor, timestamp, and status transition
- stop exposing rule activation snapshot fields from `/api/v2/audit/rules*`
- document `approved_by` / `approved_at` as API-compatible names for promote/resume/auto-promote activation metadata, not a separate approval workflow

## Verification
- `uv run pytest -q tests/test_api_v2_audit.py tests/test_api_v2_rules.py tests/test_api_v2_rule_active_update_auto_promote.py`
- `uv run poe check`
- `uv run mkdocs build --strict`
- `npm run build`
- `E2E_BASE_URL=http://localhost:48961 E2E_API_BASE_URL=http://localhost:48960 npx playwright test e2e/tests/audit-trail.spec.ts --project=chromium --workers=1 --repeat-each=5` twice
- full backend suite: `641 passed`

## Notes
- API fields `approved_by` / `approved_at` remain on rule responses for compatibility.
- Audit endpoint consumers should use `action`, `changed_by`, `changed`, and `to_status` for event timelines.