### PR TITLE
[codex] Add permission-gated Event Tester dry runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The result is stored for review in the UI, including the winning outcome and the
 ## Core Workflows
 
 - **Rule authoring:** write rule logic with validation, observed field references, configured outcomes, and list references.
+- **Event testing:** dry-run JSON events against the active rule set without storing them in Tested Events or analytics.
 - **Shadow deployment:** observe what a rule would do on live traffic without changing production outcomes.
 - **Rule rollouts:** send a stable percentage of traffic through a candidate rule before full promotion.
 - **Backtesting:** compare proposed logic against historical events before release.

--- a/alembic/versions/20260429_0028_submit_test_events_permission.py
+++ b/alembic/versions/20260429_0028_submit_test_events_permission.py
@@ -1,0 +1,132 @@
+"""Add dedicated submit-test-events permission.
+
+Revision ID: 20260429_0028
+Revises: 20260429_0027
+Create Date: 2026-04-29 16:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260429_0028"
+down_revision = "20260429_0027"
+branch_labels = None
+depends_on = None
+
+
+ACTION_NAME = "submit_test_events"
+ACTION_DESCRIPTION = "Submit dry-run test events"
+RESOURCE_TYPE = "rule"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO actions (name, description, resource_type, created_at)
+            SELECT :name, :description, :resource_type, NOW()
+            WHERE EXISTS (
+                SELECT 1
+                FROM actions
+            )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM actions
+                WHERE name = :name
+            )
+            """
+        ),
+        {
+            "name": ACTION_NAME,
+            "description": ACTION_DESCRIPTION,
+            "resource_type": RESOURCE_TYPE,
+        },
+    )
+
+    action_id = conn.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM actions
+            WHERE name = :name
+            """
+        ),
+        {"name": ACTION_NAME},
+    ).scalar_one_or_none()
+
+    if action_id is None:
+        return
+
+    admin_role_ids = conn.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM "role"
+            WHERE name = :role_name
+            """
+        ),
+        {"role_name": "admin"},
+    ).scalars()
+
+    for role_id in admin_role_ids:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO role_actions (role_id, action_id, resource_id, created_at)
+                SELECT :role_id, :action_id, NULL, NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM role_actions
+                    WHERE role_id = :role_id
+                      AND action_id = :action_id
+                      AND resource_id IS NULL
+                )
+                """
+            ),
+            {
+                "role_id": int(role_id),
+                "action_id": int(action_id),
+            },
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    action_id = conn.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM actions
+            WHERE name = :name
+            """
+        ),
+        {"name": ACTION_NAME},
+    ).scalar_one_or_none()
+
+    if action_id is None:
+        return
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM role_actions
+            WHERE action_id = :action_id
+            """
+        ),
+        {"action_id": int(action_id)},
+    )
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM actions
+            WHERE id = :action_id
+            """
+        ),
+        {"action_id": int(action_id)},
+    )

--- a/docs/api-reference/evaluator-api.md
+++ b/docs/api-reference/evaluator-api.md
@@ -14,7 +14,7 @@ It executes the active rule set against one event payload and stores results.
 ## Authentication
 
 `/api/v2/evaluate` requires credentials on every request.
-Two methods are accepted:
+Two methods are accepted for live evaluation:
 
 ### API Key (recommended for service-to-service)
 
@@ -40,6 +40,8 @@ curl -X POST http://localhost:8888/api/v2/evaluate \
   -H "Content-Type: application/json" \
   -d '{"event_id": "evt_1", "event_timestamp": 1700000000, "event_data": {}}'
 ```
+
+`/api/v2/event-tests` accepts bearer-token user sessions only and requires the `submit_test_events` permission.
 
 ## Endpoint
 
@@ -148,6 +150,72 @@ Nested lookups return the full dotted path in the same format:
 ```
 
 Field observations are also recorded on each successful call, contributing to the **Observed Fields** data visible in the UI. Observations include canonical dotted nested paths as well as parent objects. Live evaluation now buffers those observation writes through Redis and a periodic Celery drain, so observation listings are eventually consistent rather than immediate.
+
+### Test Event
+
+`POST /api/v2/event-tests`
+
+Dry-runs an event against the current rule configuration without writing event versions, served-decision records, Tested Events rows, rollout/shadow logs, or field observations.
+
+This endpoint uses the same request fields as `POST /api/v2/evaluate`, applies the same field normalization rules, honors allowlist short-circuiting, uses the configured main-rule execution mode, applies active rollout selection, and resolves the final outcome with the configured outcome hierarchy.
+
+#### Required Permission
+
+`submit_test_events`
+
+#### Example Request
+
+```bash
+curl -X POST http://localhost:8888/api/v2/event-tests \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "event_id": "dry_run_123",
+    "event_timestamp": 1700000000,
+    "event_data": {
+      "amount": 15000,
+      "user_id": "user_42",
+      "country": "US"
+    }
+  }'
+```
+
+#### Example Response
+
+```json
+{
+  "dry_run": true,
+  "skipped_main_rules": false,
+  "outcome_counters": {
+    "HOLD": 1
+  },
+  "outcome_set": [
+    "HOLD"
+  ],
+  "resolved_outcome": "HOLD",
+  "rule_results": {
+    "7": "HOLD"
+  },
+  "event_version": null,
+  "evaluation_decision_id": null,
+  "all_rule_results": {
+    "7": "HOLD",
+    "8": null
+  },
+  "evaluated_rules": [
+    {
+      "r_id": 7,
+      "rid": "HIGH_AMOUNT",
+      "description": "Hold high amount transactions",
+      "evaluation_lane": "main",
+      "outcome": "HOLD",
+      "matched": true
+    }
+  ]
+}
+```
+
+`event_version` and `evaluation_decision_id` are always `null` for dry runs.
 
 #### Status Codes
 

--- a/docs/user-guide/creating-rules.md
+++ b/docs/user-guide/creating-rules.md
@@ -69,6 +69,8 @@ Checkpoint:
    - one payload that should trigger
    - one payload that should not trigger
 
+Use **Event Tester** when you want to dry-run a full event against the currently active rule set instead of testing one rule's source in isolation. Event Tester requires `submit_test_events` and does not store the submitted event in Tested Events, analytics, or evaluation ledgers.
+
 !!! tip "Type casting in Test Rule"
     The **Test Rule** panel applies the same field type casting as live evaluation. If you have configured field types (under **Settings → Field Types**), values will be cast before the rule runs. Test JSON also contributes to field observations, helping you discover which types your fields carry.
     See [Field Type Management](field-types.md) for details.

--- a/docs/user-guide/field-types.md
+++ b/docs/user-guide/field-types.md
@@ -107,6 +107,7 @@ Once a field is configured, normalization happens before rule execution:
 
 - `/api/v2/evaluate` — required fields are validated first, then values are cast before rules run. If a required field is missing/`null`, or if casting fails (for example a non-numeric string cast to `integer`), the request returns `HTTP 400` with a description of which field failed. Field observations from live traffic are buffered asynchronously, so they may appear shortly after the request succeeds.
 - **Test Rule** panel — the same required-field validation and casting rules apply before the rule is tested. Errors are shown inline in the result panel.
+- **Event Tester** — the same required-field validation and casting rules apply to full rule-set dry runs, but submitted dry-run payloads do not create field observations.
 
 !!! warning "CastError on invalid values"
     If an event arrives with a value that cannot be cast to the configured type, evaluation will be rejected with an error. Ensure upstream systems send values consistent with the configured types, or use `compare_as_is` to bypass casting.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.19.0
+
+* **Event Tester dry runs**: Operators with the new `submit_test_events` permission can now use **Event Tester** to run a JSON event against the current rule set from the UI without storing the event or adding it to Tested Events.
+* **Non-persistent event-test API**: Added `POST /api/v2/event-tests`, which mirrors live evaluator normalization, allowlist short-circuiting, main-rule execution, rollout selection, and outcome resolution while returning no `event_version` or `evaluation_decision_id`.
+* **Dedicated test-event permission**: `submit_test_events` separates dry-run event submission from general rule viewing, so teams can grant this workflow without exposing broader admin capabilities.
+
 ## v1.18.0
 
 * **Canonical evaluation ledgers**: Live evaluation now writes append-only event versions and immutable served-decision records as the default persistence contract, so repeated business events can be represented as ordered versions instead of ad hoc duplicate rows.

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -14,14 +14,21 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ezrules.backend import data_utils
-from ezrules.backend.api_v2.auth.dependencies import get_current_evaluator_org_id, get_db
-from ezrules.backend.api_v2.schemas.evaluator import EvaluateRequest, EvaluateResponse
+from ezrules.backend.api_v2.auth.dependencies import get_current_evaluator_org_id, get_db, require_permission
+from ezrules.backend.api_v2.schemas.evaluator import (
+    EvaluateRequest,
+    EvaluateResponse,
+    EventTestResponse,
+    EventTestRuleResult,
+)
 from ezrules.backend.data_utils import Event
 from ezrules.backend.observation_queue import enqueue_observations
 from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
 from ezrules.backend.runtime_settings import get_main_rule_execution_mode
 from ezrules.backend.shadow_evaluation_queue import enqueue_shadow_evaluation
 from ezrules.backend.utils import load_cast_configs, record_observations
+from ezrules.core.outcomes import DatabaseOutcome
+from ezrules.core.permissions_constants import PermissionAction
 from ezrules.core.rule import MissingFieldLookupError, RuleFactory
 from ezrules.core.rule_engine import RULE_EXECUTION_MODE_FIRST_MATCH
 from ezrules.core.rule_updater import (
@@ -34,6 +41,7 @@ from ezrules.core.rule_updater import (
 )
 from ezrules.core.type_casting import CastError, RequiredFieldError, normalize_event
 from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.models.backend_core import Rule as RuleModel
 from ezrules.models.backend_core import RuleDeploymentResultsLog
 from ezrules.settings import app_settings
 
@@ -102,6 +110,47 @@ def _build_response_from_all_results(all_rule_results: dict[Any, Any]) -> dict[s
         "outcome_counters": outcome_counters,
         "outcome_set": sorted(set(outcome_counters.keys())),
     }
+
+
+def _resolve_dry_run_response(db: Any, o_id: int, result: dict[str, Any]) -> dict[str, Any]:
+    result["outcome_set"] = sorted(result.get("outcome_set") or [])
+    result["resolved_outcome"] = DatabaseOutcome(db_session=db, o_id=o_id).resolve_outcome(result["outcome_counters"])
+    result["event_version"] = None
+    result["evaluation_decision_id"] = None
+    return result
+
+
+def _serialize_rule_result(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _build_event_test_rule_results(db: Any, o_id: int, all_rule_results: dict[Any, Any]) -> list[EventTestRuleResult]:
+    rule_ids = [int(rule_id) for rule_id in all_rule_results if str(rule_id).isdigit()]
+    rules_by_id = {
+        int(rule.r_id): rule
+        for rule in db.query(RuleModel).filter(RuleModel.o_id == o_id, RuleModel.r_id.in_(rule_ids)).all()
+    }
+
+    results: list[EventTestRuleResult] = []
+    for rule_id, outcome in all_rule_results.items():
+        if not str(rule_id).isdigit():
+            continue
+        numeric_rule_id = int(rule_id)
+        rule = rules_by_id.get(numeric_rule_id)
+        if rule is None:
+            continue
+        serialized_outcome = _serialize_rule_result(outcome)
+        results.append(
+            EventTestRuleResult(
+                r_id=numeric_rule_id,
+                rid=str(rule.rid),
+                description=str(rule.description),
+                evaluation_lane=str(rule.evaluation_lane),
+                outcome=serialized_outcome,
+                matched=serialized_outcome is not None,
+            )
+        )
+    return results
 
 
 def _evaluate_rollout_result(
@@ -299,4 +348,82 @@ def evaluate(
         rule_results={str(k): str(v) for k, v in result["rule_results"].items()},
         event_version=result.get("event_version"),
         evaluation_decision_id=result.get("evaluation_decision_id"),
+    )
+
+
+@router.post("/event-tests", response_model=EventTestResponse)
+def test_event(
+    request_data: EvaluateRequest,
+    lre: LocalRuleExecutorSQL = Depends(_get_rule_executor),
+    allowlist_lre: LocalRuleExecutorSQL = Depends(_get_allowlist_executor),
+    db: Any = Depends(get_db),
+    _: None = Depends(require_permission(PermissionAction.SUBMIT_TEST_EVENTS)),
+) -> EventTestResponse:
+    """
+    Dry-run an event against the current rule engine configuration.
+
+    This mirrors live evaluation behavior but does not store the event, write
+    rollout/shadow logs, enqueue shadow work, or record field observations.
+    """
+    configs = load_cast_configs(db, lre.o_id)
+    try:
+        event_data = normalize_event(request_data.event_data, configs)
+    except (CastError, RequiredFieldError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    event = Event(
+        event_id=request_data.event_id,
+        event_timestamp=request_data.event_timestamp,
+        event_data=event_data,
+    )
+
+    skipped_main_rules = False
+    result: dict[str, Any]
+    try:
+        allowlist_result = allowlist_lre.evaluate_rules(event.event_data)
+        if allowlist_result.get("rule_results"):
+            result = _build_response_from_all_results(dict(allowlist_result.get("all_rule_results", {})))
+            skipped_main_rules = True
+        else:
+            production_result = lre.evaluate_rules(event.event_data)
+            rollout_entries = list_candidate_deployments(db, lre.o_id, ROLLOUT_CONFIG_LABEL)
+            if rollout_entries:
+                result, rollout_logs = _evaluate_rollout_result(
+                    event_data=event.event_data,
+                    lre=lre,
+                    rollout_entries=rollout_entries,
+                    assignment_key=_get_assignment_key(event),
+                    list_provider=PersistentUserListManager(db, lre.o_id),
+                )
+                del rollout_logs
+            else:
+                result = production_result
+    except MissingFieldLookupError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Event test failed",
+        ) from exc
+
+    result = _resolve_dry_run_response(db, lre.o_id, result)
+    all_rule_results = dict(result.get("all_rule_results") or result.get("rule_results") or {})
+
+    return EventTestResponse(
+        dry_run=True,
+        skipped_main_rules=skipped_main_rules,
+        outcome_counters=result["outcome_counters"],
+        outcome_set=result["outcome_set"],
+        resolved_outcome=result.get("resolved_outcome"),
+        rule_results={str(k): str(v) for k, v in result["rule_results"].items()},
+        event_version=None,
+        evaluation_decision_id=None,
+        all_rule_results={str(k): _serialize_rule_result(v) for k, v in all_rule_results.items()},
+        evaluated_rules=_build_event_test_rule_results(db, lre.o_id, all_rule_results),
     )

--- a/ezrules/backend/api_v2/schemas/evaluator.py
+++ b/ezrules/backend/api_v2/schemas/evaluator.py
@@ -47,3 +47,29 @@ class EvaluateResponse(BaseModel):
     rule_results: dict[str, str] = Field(..., description="Mapping of rule_id to its outcome")
     event_version: int | None = Field(None, description="Canonical append-only version for this business event")
     evaluation_decision_id: int | None = Field(None, description="Immutable served-decision ledger identifier")
+
+
+class EventTestRuleResult(BaseModel):
+    """Rule result details returned by a dry-run event test."""
+
+    r_id: int = Field(..., description="Internal numeric rule identifier")
+    rid: str = Field(..., description="External rule identifier")
+    description: str = Field(..., description="Rule description")
+    evaluation_lane: str = Field(..., description="Rule evaluation lane")
+    outcome: str | None = Field(None, description="Outcome returned by the rule, if any")
+    matched: bool = Field(..., description="Whether the rule returned an outcome")
+
+
+class EventTestResponse(EvaluateResponse):
+    """Response from a non-persistent rule-set event test."""
+
+    dry_run: bool = Field(True, description="Always true for event test responses")
+    skipped_main_rules: bool = Field(False, description="Whether allowlist rules short-circuited main rule evaluation")
+    all_rule_results: dict[str, str | None] = Field(
+        default_factory=dict,
+        description="Mapping of evaluated rule IDs to their outcome, including non-matches",
+    )
+    evaluated_rules: list[EventTestRuleResult] = Field(
+        default_factory=list,
+        description="Metadata for all rules evaluated during the dry run",
+    )

--- a/ezrules/core/permissions_constants.py
+++ b/ezrules/core/permissions_constants.py
@@ -12,6 +12,7 @@ class PermissionAction(Enum):
     PROMOTE_RULES = "promote_rules"
     DELETE_RULE = "delete_rule"
     VIEW_RULES = "view_rules"
+    SUBMIT_TEST_EVENTS = "submit_test_events"
 
     # Outcome Management
     CREATE_OUTCOME = "create_outcome"
@@ -68,6 +69,7 @@ class PermissionAction(Enum):
             (cls.PROMOTE_RULES.value, "Promote draft or shadow rules to production", "rule"),
             (cls.DELETE_RULE.value, "Delete rules", "rule"),
             (cls.VIEW_RULES.value, "View rules", "rule"),
+            (cls.SUBMIT_TEST_EVENTS.value, "Submit dry-run test events", "rule"),
             (cls.CREATE_OUTCOME.value, "Create new outcomes", "outcome"),
             (cls.MODIFY_OUTCOME.value, "Modify existing outcomes", "outcome"),
             (cls.DELETE_OUTCOME.value, "Delete outcomes", "outcome"),

--- a/ezrules/frontend/e2e/pages/event-tester.page.ts
+++ b/ezrules/frontend/e2e/pages/event-tester.page.ts
@@ -1,0 +1,41 @@
+import { Locator, Page } from '@playwright/test';
+
+export class EventTesterPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly eventIdInput: Locator;
+  readonly timestampInput: Locator;
+  readonly payloadTextarea: Locator;
+  readonly runButton: Locator;
+  readonly resetButton: Locator;
+  readonly resolvedOutcome: Locator;
+  readonly matchedCount: Locator;
+  readonly ledgerState: Locator;
+  readonly ruleResults: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.locator('h1');
+    this.eventIdInput = page.getByTestId('event-test-id');
+    this.timestampInput = page.getByTestId('event-test-timestamp');
+    this.payloadTextarea = page.getByTestId('event-test-payload');
+    this.runButton = page.getByTestId('event-test-run');
+    this.resetButton = page.getByTestId('event-test-reset');
+    this.resolvedOutcome = page.getByTestId('event-test-resolved-outcome');
+    this.matchedCount = page.getByTestId('event-test-matched-count');
+    this.ledgerState = page.getByTestId('event-test-ledger-state');
+    this.ruleResults = page.getByTestId('event-test-rule-result');
+    this.errorMessage = page.getByTestId('event-test-error');
+  }
+
+  async goto() {
+    await this.page.goto('/event-tester');
+  }
+
+  async runTest(eventId: string, payload: Record<string, unknown>) {
+    await this.eventIdInput.fill(eventId);
+    await this.payloadTextarea.fill(JSON.stringify(payload, null, 2));
+    await this.runButton.click();
+  }
+}

--- a/ezrules/frontend/e2e/tests/event-tester.spec.ts
+++ b/ezrules/frontend/e2e/tests/event-tester.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test';
+import { EventTesterPage } from '../pages/event-tester.page';
+import { getApiBaseUrl, getAuthToken } from '../support/config';
+
+const API_BASE = getApiBaseUrl();
+
+test.describe('Event Tester Page', () => {
+  let eventTesterPage: EventTesterPage;
+
+  test.beforeEach(async ({ page }) => {
+    eventTesterPage = new EventTesterPage(page);
+  });
+
+  test('should load the event tester page successfully', async ({ page }) => {
+    await eventTesterPage.goto();
+
+    await expect(page).toHaveURL(/.*event-tester/);
+    await expect(eventTesterPage.heading).toHaveText('Event Tester');
+    await expect(eventTesterPage.payloadTextarea).toBeVisible();
+    await expect(eventTesterPage.runButton).toBeVisible();
+  });
+
+  test('should be reachable from sidebar navigation', async ({ page }) => {
+    await page.goto('/rules');
+
+    const eventTesterLink = page.locator('a:has-text("Event Tester")');
+    await expect(eventTesterLink).toBeVisible();
+    await eventTesterLink.click();
+
+    await expect(page).toHaveURL(/.*event-tester/);
+    await expect(eventTesterPage.heading).toHaveText('Event Tester');
+  });
+
+  test('should run the stock event payload without missing-field errors', async () => {
+    await eventTesterPage.goto();
+    await eventTesterPage.runButton.click();
+
+    await expect(eventTesterPage.errorMessage).toBeHidden();
+    await expect(eventTesterPage.ledgerState).toHaveText('None');
+    await expect(eventTesterPage.resolvedOutcome).not.toHaveText('No result');
+  });
+
+  test('should dry-run an event without storing it', async ({ request }) => {
+    const eventId = `e2e-dry-run-${Date.now()}`;
+    const headers = { Authorization: `Bearer ${getAuthToken()}` };
+    const createResponse = await request.post(`${API_BASE}/api/v2/rules`, {
+      headers,
+      data: {
+        rid: `E2E_EVENT_TEST_${Date.now()}`,
+        description: 'E2E event tester rule',
+        logic: 'return !RELEASE',
+        evaluation_lane: 'allowlist',
+      },
+    });
+    expect(createResponse.ok()).toBeTruthy();
+    const createdRule = await createResponse.json();
+    const ruleId = createdRule.rule.r_id;
+
+    const promoteResponse = await request.post(`${API_BASE}/api/v2/rules/${ruleId}/promote`, { headers });
+    expect(promoteResponse.ok()).toBeTruthy();
+
+    try {
+      await eventTesterPage.goto();
+      await eventTesterPage.runTest(eventId, {
+        amount: 15000,
+        currency: 'USD',
+        customer_country: 'US',
+        customer_id: 'e2e_customer',
+      });
+
+      await expect(eventTesterPage.ledgerState).toHaveText('None');
+      await expect(eventTesterPage.resolvedOutcome).toHaveText('RELEASE');
+      await expect(eventTesterPage.ruleResults.filter({ hasText: 'E2E event tester rule' })).toBeVisible();
+
+      const testedEventsResponse = await request.get(`${API_BASE}/api/v2/tested-events?limit=200`, {
+        headers,
+      });
+      expect(testedEventsResponse.ok()).toBeTruthy();
+      const testedEvents = await testedEventsResponse.json();
+      expect(testedEvents.events.some((event: { event_id: string }) => event.event_id === eventId)).toBe(false);
+    } finally {
+      await request.delete(`${API_BASE}/api/v2/rules/${ruleId}`, { headers });
+    }
+  });
+});

--- a/ezrules/frontend/src/app/app.routes.ts
+++ b/ezrules/frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { ShadowRulesComponent } from './shadow-rules/shadow-rules.component';
 import { RolloutsComponent } from './rollouts/rollouts.component';
 import { ApiKeysComponent } from './api-keys/api-keys.component';
 import { TestedEventsComponent } from './tested-events/tested-events.component';
+import { EventTesterComponent } from './event-tester/event-tester.component';
 import { authGuard } from './auth/auth.guard';
 import { ForgotPasswordComponent } from './forgot-password/forgot-password.component';
 import { ResetPasswordComponent } from './reset-password/reset-password.component';
@@ -92,6 +93,12 @@ export const routes: Routes = [
     component: TestedEventsComponent,
     canActivate: [authGuard, permissionGuard],
     data: { permissionRequirement: ROUTE_PERMISSION_REQUIREMENTS.testedEvents }
+  },
+  {
+    path: 'event-tester',
+    component: EventTesterComponent,
+    canActivate: [authGuard, permissionGuard],
+    data: { permissionRequirement: ROUTE_PERMISSION_REQUIREMENTS.eventTester }
   },
   {
     path: 'user-lists',

--- a/ezrules/frontend/src/app/auth/permissions.ts
+++ b/ezrules/frontend/src/app/auth/permissions.ts
@@ -7,6 +7,7 @@ export const ROUTE_PERMISSION_REQUIREMENTS = {
   dashboard: { allOf: ['view_rules', 'view_outcomes'] },
   rules: { allOf: ['view_rules'] },
   ruleCreate: { allOf: ['create_rule'] },
+  eventTester: { allOf: ['view_rules', 'submit_test_events'] },
   labels: { allOf: ['view_labels'] },
   outcomes: { allOf: ['view_outcomes'] },
   testedEvents: { allOf: ['view_rules'] },
@@ -50,6 +51,7 @@ export const ACTION_PERMISSION_REQUIREMENTS = {
   modifyFieldTypes: { allOf: ['modify_field_types'] },
   deleteFieldType: { allOf: ['delete_field_type'] },
   manageApiKeys: { allOf: ['manage_api_keys'] },
+  submitTestEvents: { allOf: ['submit_test_events'] },
 } as const satisfies Record<string, PermissionRequirement>;
 
 export const PERMISSION_LABELS: Record<string, string> = {
@@ -60,6 +62,7 @@ export const PERMISSION_LABELS: Record<string, string> = {
   promote_rules: 'Promote rules',
   delete_rule: 'Delete rules',
   view_rules: 'View rules',
+  submit_test_events: 'Submit test events',
   create_outcome: 'Create outcomes',
   modify_outcome: 'Modify outcomes',
   delete_outcome: 'Delete outcomes',

--- a/ezrules/frontend/src/app/components/sidebar.component.ts
+++ b/ezrules/frontend/src/app/components/sidebar.component.ts
@@ -66,6 +66,14 @@ import { PermissionRequirement, ROUTE_PERMISSION_REQUIREMENTS, hasPermissionRequ
           <span>Tested Events</span>
         </a>
 
+        <a *ngIf="canAccess(routePermissions.eventTester)" href="/event-tester" [ngClass]="linkClasses('/event-tester')">
+          <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5a3 3 0 006 0M9 13l2 2 4-4" />
+          </svg>
+          <span>Event Tester</span>
+        </a>
+
         <a *ngIf="canAccess(routePermissions.userLists)" href="/user-lists" [ngClass]="linkClasses('/user-lists')">
           <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />

--- a/ezrules/frontend/src/app/event-tester/event-tester.component.html
+++ b/ezrules/frontend/src/app/event-tester/event-tester.component.html
@@ -1,0 +1,199 @@
+<div class="flex min-h-screen bg-gray-50">
+  <app-sidebar></app-sidebar>
+
+  <div class="ml-64 flex-1">
+    <div class="p-8">
+      <div class="flex flex-wrap items-start justify-between gap-4 mb-8">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-900">Event Tester</h1>
+          <p class="text-gray-600 mt-1">Dry-run event evaluation against the current rule set</p>
+        </div>
+
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-sky-100 text-sky-800">
+          Dry run only
+        </span>
+      </div>
+
+      <div class="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(380px,520px)]">
+        <section class="bg-white border border-gray-200 rounded-lg p-6">
+          <div class="flex items-start justify-between gap-4 mb-6">
+            <div>
+              <h2 class="text-xl font-semibold text-gray-900">Test Event</h2>
+              <p class="text-sm text-gray-500 mt-1">Submitted payloads are not written to Tested Events.</p>
+            </div>
+          </div>
+
+          <div class="grid gap-4 md:grid-cols-2 mb-4">
+            <div>
+              <label for="event-test-id" class="block text-sm font-medium text-gray-700 mb-1">Event ID</label>
+              <input
+                id="event-test-id"
+                [(ngModel)]="eventId"
+                class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                data-testid="event-test-id"
+              />
+            </div>
+
+            <div>
+              <label for="event-test-timestamp" class="block text-sm font-medium text-gray-700 mb-1">Unix Timestamp</label>
+              <input
+                id="event-test-timestamp"
+                type="number"
+                [(ngModel)]="eventTimestamp"
+                class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                data-testid="event-test-timestamp"
+              />
+              <p class="text-xs text-gray-500 mt-1">{{ formatTimestamp(eventTimestamp) }}</p>
+            </div>
+          </div>
+
+          <div>
+            <label for="event-test-payload" class="block text-sm font-medium text-gray-700 mb-1">Event Payload</label>
+            <textarea
+              id="event-test-payload"
+              [(ngModel)]="eventJson"
+              (keydown)="handleTextareaTab($event)"
+              rows="18"
+              spellcheck="false"
+              class="w-full px-3 py-2 border border-gray-300 rounded-lg font-mono text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              data-testid="event-test-payload"
+            ></textarea>
+          </div>
+
+          <div *ngIf="error" class="mt-4 bg-red-50 border border-red-200 rounded-lg p-4" data-testid="event-test-error">
+            <p class="text-sm font-medium text-red-800">{{ error }}</p>
+          </div>
+
+          <div class="flex flex-wrap gap-3 pt-5">
+            <button
+              type="button"
+              (click)="runTest()"
+              [disabled]="testing || !eventJson"
+              class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+              data-testid="event-test-run"
+            >
+              <svg *ngIf="testing" class="animate-spin h-4 w-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span>{{ testing ? 'Running...' : 'Run Test' }}</span>
+            </button>
+
+            <button
+              type="button"
+              (click)="resetExample()"
+              class="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+              data-testid="event-test-reset"
+            >
+              Reset Example
+            </button>
+          </div>
+        </section>
+
+        <section class="bg-white border border-gray-200 rounded-lg p-6" data-testid="event-test-results">
+          <div class="flex items-center justify-between gap-4 mb-6">
+            <h2 class="text-xl font-semibold text-gray-900">Result</h2>
+            <span
+              class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium"
+              [ngClass]="outcomeBadgeClass(result?.resolved_outcome ?? null)"
+              data-testid="event-test-resolved-outcome"
+            >
+              {{ result?.resolved_outcome ?? 'No result' }}
+            </span>
+          </div>
+
+          <div *ngIf="!result" class="border border-dashed border-gray-300 rounded-lg py-16 text-center">
+            <p class="text-sm text-gray-500">Run a test to see the rule-set result.</p>
+          </div>
+
+          <div *ngIf="result" class="space-y-6">
+            <div class="grid gap-3 sm:grid-cols-2">
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                <p class="text-sm text-gray-500">Matched rules</p>
+                <p class="text-2xl font-semibold text-gray-900 mt-2" data-testid="event-test-matched-count">{{ matchedRules().length }}</p>
+              </div>
+
+              <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                <p class="text-sm text-gray-500">Ledger record</p>
+                <p class="text-2xl font-semibold text-gray-900 mt-2" data-testid="event-test-ledger-state">
+                  {{ result.evaluation_decision_id === null ? 'None' : result.evaluation_decision_id }}
+                </p>
+              </div>
+            </div>
+
+            <div *ngIf="result.skipped_main_rules" class="bg-green-50 border border-green-200 rounded-lg p-4" data-testid="event-test-allowlist-short-circuit">
+              <p class="text-sm font-medium text-green-800">Allowlist matched. Main rules were skipped.</p>
+            </div>
+
+            <div>
+              <h3 class="text-sm font-semibold text-gray-900 mb-3">Outcome counters</h3>
+              <div *ngIf="outcomeEntries().length === 0" class="text-sm text-gray-500">No outcomes returned.</div>
+              <div *ngIf="outcomeEntries().length > 0" class="space-y-2">
+                <div *ngFor="let entry of outcomeEntries()" class="flex items-center justify-between border border-gray-200 rounded-lg px-3 py-2">
+                  <span class="text-sm font-medium text-gray-900">{{ entry[0] }}</span>
+                  <span class="text-sm text-gray-600">{{ entry[1] }}</span>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <h3 class="text-sm font-semibold text-gray-900 mb-3">Matched rules</h3>
+              <div *ngIf="matchedRules().length === 0" class="text-sm text-gray-500">No rules matched this event.</div>
+              <div *ngIf="matchedRules().length > 0" class="space-y-3">
+                <div
+                  *ngFor="let rule of matchedRules()"
+                  class="border border-blue-200 bg-blue-50 rounded-lg p-4"
+                  data-testid="event-test-rule-result"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <a [routerLink]="['/rules', rule.r_id]" class="text-sm font-medium text-blue-700 hover:text-blue-800 hover:underline">
+                        {{ rule.rid }}
+                      </a>
+                      <p class="text-xs text-gray-500 mt-1">{{ rule.description }}</p>
+                      <p class="text-xs text-gray-500 mt-2">{{ rule.evaluation_lane === 'allowlist' ? 'Allowlist rules' : 'Main rules' }}</p>
+                    </div>
+
+                    <span
+                      class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap"
+                      [ngClass]="outcomeBadgeClass(rule.outcome)"
+                    >
+                      {{ rule.outcome }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <details *ngIf="nonMatchedRules().length > 0" class="border border-gray-200 rounded-lg p-4">
+              <summary class="cursor-pointer text-sm font-semibold text-gray-900">
+                Non-matching evaluated rules ({{ nonMatchedRules().length }})
+              </summary>
+              <div class="mt-3 space-y-3">
+                <div
+                  *ngFor="let rule of nonMatchedRules()"
+                  class="border border-gray-200 bg-white rounded-lg p-4"
+                  data-testid="event-test-nonmatch-rule"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <a [routerLink]="['/rules', rule.r_id]" class="text-sm font-medium text-blue-700 hover:text-blue-800 hover:underline">
+                        {{ rule.rid }}
+                      </a>
+                      <p class="text-xs text-gray-500 mt-1">{{ rule.description }}</p>
+                      <p class="text-xs text-gray-500 mt-2">{{ rule.evaluation_lane === 'allowlist' ? 'Allowlist rules' : 'Main rules' }}</p>
+                    </div>
+
+                    <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap bg-gray-200 text-gray-700">
+                      No match
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>

--- a/ezrules/frontend/src/app/event-tester/event-tester.component.ts
+++ b/ezrules/frontend/src/app/event-tester/event-tester.component.ts
@@ -1,0 +1,195 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { SidebarComponent } from '../components/sidebar.component';
+import { EventTestResponse, EventTestRuleResult, EventTestService } from '../services/event-test.service';
+
+const DEFAULT_EVENT_PAYLOAD: Record<string, unknown> = {
+  account_age_days: 7,
+  amount: 875.5,
+  beneficiary_age_days: 1,
+  beneficiary_country: 'IR',
+  billing_country: 'US',
+  card_present: 0,
+  channel: 'web',
+  currency: 'USD',
+  customer: {
+    id: 'cust_demo_001',
+    country: 'US',
+    profile: {
+      age: 34,
+      segment: 'established',
+    },
+    account: {
+      age_days: 180,
+      email_age_days: 365,
+      prior_chargebacks_180d: 0,
+    },
+    behavior: {
+      avg_amount_30d: 140,
+      std_amount_30d: 30,
+    },
+  },
+  customer_avg_amount_30d: 140,
+  customer_country: 'US',
+  customer_id: 'cust_demo_001',
+  customer_std_amount_30d: 30,
+  decline_count_24h: 7,
+  device_age_days: 1,
+  device_trust_score: 18,
+  distance_from_home_km: 4200,
+  email_age_days: 4,
+  email_domain: 'mailinator.com',
+  has_3ds: 0,
+  ip_country: 'BR',
+  ip_proxy_score: 92,
+  is_guest_checkout: 1,
+  is_verified: false,
+  local_hour: 2,
+  manual_review_hits_30d: 2,
+  merchant_category: 'gift_cards',
+  merchant_country: 'US',
+  merchant_id: 'mrc_cardhub',
+  password_reset_age_hours: 2,
+  prior_chargebacks_180d: 2,
+  receive_country: 'MX',
+  score: 0.92,
+  send_country: 'US',
+  sender: {
+    id: 'sender_demo_001',
+    country: 'US',
+    account: {
+      age_days: 90,
+    },
+    origin: {
+      country: 'BR',
+    },
+    device: {
+      age_days: 1,
+      trust_score: 18,
+    },
+  },
+  shipping_country: 'MX',
+  txn_type: 'wallet_cashout',
+  txn_velocity_10m: 10,
+  txn_velocity_1h: 6,
+  unique_cards_24h: 5,
+};
+
+@Component({
+  selector: 'app-event-tester',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule, SidebarComponent],
+  templateUrl: './event-tester.component.html'
+})
+export class EventTesterComponent implements OnInit {
+  eventId = '';
+  eventTimestamp = 0;
+  eventJson = '';
+  testing = false;
+  error: string | null = null;
+  result: EventTestResponse | null = null;
+
+  constructor(private eventTestService: EventTestService) {}
+
+  ngOnInit(): void {
+    this.resetExample();
+  }
+
+  resetExample(): void {
+    this.eventId = `test_evt_${Date.now()}`;
+    this.eventTimestamp = Math.floor(Date.now() / 1000);
+    this.eventJson = JSON.stringify(
+      DEFAULT_EVENT_PAYLOAD,
+      null,
+      2
+    );
+    this.error = null;
+    this.result = null;
+  }
+
+  runTest(): void {
+    this.error = null;
+    this.result = null;
+
+    let eventData: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(this.eventJson);
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+        this.error = 'Event payload must be a JSON object.';
+        return;
+      }
+      eventData = parsed as Record<string, unknown>;
+    } catch {
+      this.error = 'Event payload is malformed JSON.';
+      return;
+    }
+
+    this.testing = true;
+    this.eventTestService.runTest({
+      event_id: this.eventId.trim() || `test_evt_${Date.now()}`,
+      event_timestamp: Number(this.eventTimestamp),
+      event_data: eventData,
+    }).subscribe({
+      next: (response) => {
+        this.testing = false;
+        this.result = response;
+      },
+      error: (error) => {
+        this.testing = false;
+        this.error = error.error?.detail || 'Event test failed.';
+      }
+    });
+  }
+
+  handleTextareaTab(event: KeyboardEvent): void {
+    if (event.key !== 'Tab') {
+      return;
+    }
+    event.preventDefault();
+    const textarea = event.target as HTMLTextAreaElement;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    const nextValue = `${value.substring(0, start)}  ${value.substring(end)}`;
+    textarea.value = nextValue;
+    textarea.selectionStart = textarea.selectionEnd = start + 2;
+    this.eventJson = nextValue;
+  }
+
+  matchedRules(): EventTestRuleResult[] {
+    return this.result?.evaluated_rules.filter((rule) => rule.matched) ?? [];
+  }
+
+  nonMatchedRules(): EventTestRuleResult[] {
+    return this.result?.evaluated_rules.filter((rule) => !rule.matched) ?? [];
+  }
+
+  outcomeEntries(): [string, number][] {
+    return Object.entries(this.result?.outcome_counters ?? {});
+  }
+
+  outcomeBadgeClass(outcome: string | null): string {
+    if (outcome === 'CANCEL') {
+      return 'bg-red-100 text-red-800';
+    }
+    if (outcome === 'HOLD') {
+      return 'bg-amber-100 text-amber-800';
+    }
+    if (outcome === 'RELEASE') {
+      return 'bg-green-100 text-green-800';
+    }
+    if (outcome) {
+      return 'bg-blue-100 text-blue-800';
+    }
+    return 'bg-gray-200 text-gray-700';
+  }
+
+  formatTimestamp(timestamp: number): string {
+    if (!Number.isFinite(timestamp)) {
+      return '';
+    }
+    return new Date(timestamp * 1000).toLocaleString();
+  }
+}

--- a/ezrules/frontend/src/app/services/event-test.service.ts
+++ b/ezrules/frontend/src/app/services/event-test.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface EventTestRequest {
+  event_id: string;
+  event_timestamp: number;
+  event_data: Record<string, unknown>;
+}
+
+export interface EventTestRuleResult {
+  r_id: number;
+  rid: string;
+  description: string;
+  evaluation_lane: string;
+  outcome: string | null;
+  matched: boolean;
+}
+
+export interface EventTestResponse {
+  dry_run: boolean;
+  skipped_main_rules: boolean;
+  outcome_counters: Record<string, number>;
+  outcome_set: string[];
+  resolved_outcome: string | null;
+  rule_results: Record<string, string>;
+  event_version: number | null;
+  evaluation_decision_id: number | null;
+  all_rule_results: Record<string, string | null>;
+  evaluated_rules: EventTestRuleResult[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EventTestService {
+  private apiUrl = `${environment.apiUrl}/api/v2/event-tests`;
+
+  constructor(private http: HttpClient) {}
+
+  runTest(request: EventTestRequest): Observable<EventTestResponse> {
+    return this.http.post<EventTestResponse>(this.apiUrl, request);
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.18.0"
+version = "1.19.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_api_v2_event_tests.py
+++ b/tests/test_api_v2_event_tests.py
@@ -1,0 +1,129 @@
+import bcrypt
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.api_v2.routes import evaluator as evaluator_router
+from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager
+from ezrules.models.backend_core import EvaluationDecision, EventVersion, Organisation, Role, User
+from ezrules.models.backend_core import Rule as RuleModel
+
+
+def _event_test_token(session, *, permissions: list[PermissionAction], email: str) -> str:
+    org = session.query(Organisation).one()
+    role = Role(name=f"event_test_role_{email}", description="Event test role", o_id=int(org.o_id))
+    session.add(role)
+    session.commit()
+
+    user = User(
+        email=email,
+        password=bcrypt.hashpw("eventtestpass".encode("utf-8"), bcrypt.gensalt()).decode("utf-8"),
+        active=True,
+        fs_uniquifier=email,
+        o_id=int(org.o_id),
+    )
+    user.roles.append(role)
+    session.add(user)
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    for permission in permissions:
+        PermissionManager.grant_permission(int(role.id), permission)
+
+    return create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[str(role.name)],
+        org_id=int(user.o_id),
+    )
+
+
+def _save_rule_config(session) -> RuleModel:
+    org = session.query(Organisation).one()
+    rule = RuleModel(
+        logic="if $amount > 100:\n\treturn !HOLD",
+        description="Hold high amount events",
+        rid="EVENT_TEST_HIGH_AMOUNT",
+        o_id=int(org.o_id),
+        r_id=9101,
+    )
+    session.add(rule)
+    session.commit()
+
+    rule_manager = RDBRuleManager(db=session, o_id=int(org.o_id))
+    config_producer = RDBRuleEngineConfigProducer(db=session, o_id=int(org.o_id))
+    config_producer.save_config(rule_manager)
+    return rule
+
+
+def test_event_test_dry_run_returns_rule_set_result_without_persisting(session):
+    token = _event_test_token(
+        session,
+        permissions=[PermissionAction.VIEW_RULES, PermissionAction.SUBMIT_TEST_EVENTS],
+        email="event-tester@example.com",
+    )
+    rule = _save_rule_config(session)
+    org = session.query(Organisation).one()
+    evaluator_router._lre = LocalRuleExecutorSQL(db=session, o_id=int(org.o_id))
+    evaluator_router._allowlist_lre = LocalRuleExecutorSQL(db=session, o_id=int(org.o_id), label="allowlist")
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/v2/event-tests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={
+                    "event_id": "dry_run_event_1",
+                    "event_timestamp": 1234567890,
+                    "event_data": {"amount": 250},
+                },
+            )
+    finally:
+        evaluator_router._lre = None
+        evaluator_router._allowlist_lre = None
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["dry_run"] is True
+    assert payload["event_version"] is None
+    assert payload["evaluation_decision_id"] is None
+    assert payload["resolved_outcome"] == "HOLD"
+    assert payload["rule_results"] == {str(rule.r_id): "HOLD"}
+    assert payload["evaluated_rules"] == [
+        {
+            "r_id": int(rule.r_id),
+            "rid": "EVENT_TEST_HIGH_AMOUNT",
+            "description": "Hold high amount events",
+            "evaluation_lane": "main",
+            "outcome": "HOLD",
+            "matched": True,
+        }
+    ]
+    assert session.query(EvaluationDecision).filter(EvaluationDecision.event_id == "dry_run_event_1").count() == 0
+    assert session.query(EventVersion).filter(EventVersion.event_id == "dry_run_event_1").count() == 0
+
+
+def test_event_test_requires_submit_test_events_permission(session):
+    token = _event_test_token(
+        session,
+        permissions=[PermissionAction.VIEW_RULES],
+        email="event-test-denied@example.com",
+    )
+    _save_rule_config(session)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/event-tests",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "event_id": "dry_run_denied",
+                "event_timestamp": 1234567890,
+                "event_data": {"amount": 250},
+            },
+        )
+
+    assert response.status_code == 403

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.18.0"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Adds a permission-gated Event Tester workflow for running full-rule-set dry runs from the UI without storing submitted events. The new `POST /api/v2/event-tests` endpoint mirrors live evaluator normalization, allowlist short-circuiting, main-rule execution mode, rollout selection, and outcome resolution while returning no event version or decision ledger record.

Also adds the `submit_test_events` permission, an Alembic migration for existing databases, Angular navigation/sidebar wiring, focused backend and Playwright coverage, docs updates, and a `v1.19.0` version bump.

## Impact

Operators can test realistic JSON events against the active rule set from inside the app instead of using Postman or raw API calls. Dry-run submissions do not write Tested Events, field observations, rollout/shadow logs, shadow jobs, or evaluation-decision ledgers.

## Validation

- `uv run poe check`
- Full backend pytest suite: `642 passed`
- Full Playwright Chromium suite: `315 passed, 1 skipped`
- Event Tester targeted Playwright `--repeat-each=10` twice after final UI tweaks: `41 passed` each run
- `npm run build`
- `uv run mkdocs build --strict`
- Demo Docker path: `docker compose -p ezrules_demo_e485 -f docker-compose.demo.yml up --build -d`, frontend and API `/ping` verified, stack torn down

## Notes

Draft PR because the final two Event Tester UI polish tweaks were verified with targeted E2E/build checks, but I did not rerun a full code-review pass after those tweaks.
