### PR TITLE
Add canonical business journey contract

### DIFF
--- a/.github/workflows/business-journeys.yml
+++ b/.github/workflows/business-journeys.yml
@@ -1,0 +1,57 @@
+name: Business Journey Contract
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  business-journeys:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: root
+          POSTGRES_DB: tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      EZRULES_DB_ENDPOINT: postgresql://postgres:root@localhost:5432/tests
+      EZRULES_TESTING: "true"
+      EZRULES_APP_SECRET: test-secret
+      EZRULES_ORG_ID: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Apply database migrations
+        run: uv run alembic upgrade head
+
+      - name: Run canonical business journeys
+        run: uv run pytest -q tests/business_scenarios

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,17 @@ uv run pytest -q --cov=ezrules.backend --cov=ezrules.core --cov-report=xml tests
 - Prefer quiet test output by default: use backend pytest in quiet mode (`-q`) and keep coverage output in XML unless a failing run specifically needs the more verbose terminal report.
 - Prefer the default quiet Playwright run (`npm run test:e2e`) instead of the verbose reporter variant. Use the verbose mode only when debugging failures interactively.
 
+# Agentic Exploratory Testing
+Agentic product exploration charters live under `tests/agentic_exploration/`. Treat them as free-testing prompts for finding unknown product issues, not deterministic CI gates.
+
+When asked to run agentic exploration:
+- Use `tests/agentic_exploration/RUN_CONTRACT.md` plus exactly one charter from `tests/agentic_exploration/charters/` per agent.
+- Run against a private local/dev database and disposable test data only. Never use shared `tests` or `ezrules` databases.
+- Ask agents to report findings using `tests/agentic_exploration/REPORT_TEMPLATE.md`.
+- Do not let exploration agents modify source code or fix bugs during the exploration run; they should report evidence and deterministic-test recommendations.
+- Convert credible repeatable findings into backend business tests or Playwright E2E tests before relying on them as release gates.
+- Generated exploration reports belong under `tests/agentic_exploration/reports/` or `artifacts/` and should not be committed unless explicitly requested.
+
 # Common Development Commands
 - **Install dependencies**: `uv sync`
 - **Initialize database**: `uv run ezrules init-db`

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -4,6 +4,7 @@
 
 * **Canonical business journey contract**: Added a deterministic evaluation universe with fixed outcomes, rules, user lists, and transaction scenarios that prove core `/api/v2/evaluate` behavior through the real PostgreSQL-backed API path.
 * **Product journey regression coverage**: Added deterministic journeys for rule authoring through served decisions, dry-run isolation, Tested Events explainability, pause/resume serving changes, and no-side-effect negative paths.
+* **Extended product workflow proof**: Added deterministic coverage for permission grant/revoke behavior, rule edit promotion semantics, user-list driven serving changes, label-backed rule-quality analytics, audit trail reads, and rollout candidate provenance.
 * **Business gate in CI**: Added a dedicated GitHub Actions workflow that runs the canonical business journey suite on pull requests and main-branch pushes.
 
 ## v1.21.0

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.21.1
+
+* **Canonical business journey contract**: Added a deterministic evaluation universe with fixed outcomes, rules, user lists, and transaction scenarios that prove core `/api/v2/evaluate` behavior through the real PostgreSQL-backed API path.
+* **Business gate in CI**: Added a dedicated GitHub Actions workflow that runs the canonical business journey suite on pull requests and main-branch pushes.
+
 ## v1.21.0
 
 * **Transaction lifecycle contract**: Live evaluation now uses `transaction_id`, `effective_at`, and `observed_at` to separate stable transaction identity from append-only event versions.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -3,6 +3,7 @@
 ## v1.21.1
 
 * **Canonical business journey contract**: Added a deterministic evaluation universe with fixed outcomes, rules, user lists, and transaction scenarios that prove core `/api/v2/evaluate` behavior through the real PostgreSQL-backed API path.
+* **Product journey regression coverage**: Added deterministic journeys for rule authoring through served decisions, dry-run isolation, Tested Events explainability, pause/resume serving changes, and no-side-effect negative paths.
 * **Business gate in CI**: Added a dedicated GitHub Actions workflow that runs the canonical business journey suite on pull requests and main-branch pushes.
 
 ## v1.21.0

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -5,6 +5,7 @@
 * **Canonical business journey contract**: Added a deterministic evaluation universe with fixed outcomes, rules, user lists, and transaction scenarios that prove core `/api/v2/evaluate` behavior through the real PostgreSQL-backed API path.
 * **Product journey regression coverage**: Added deterministic journeys for rule authoring through served decisions, dry-run isolation, Tested Events explainability, pause/resume serving changes, and no-side-effect negative paths.
 * **Extended product workflow proof**: Added deterministic coverage for permission grant/revoke behavior, rule edit promotion semantics, user-list driven serving changes, label-backed rule-quality analytics, audit trail reads, and rollout candidate provenance.
+* **Agentic exploration charters**: Added a free-testing prompt library with shared run and report contracts so browser agents can explore product areas on demand and produce triage-ready findings.
 * **Business gate in CI**: Added a dedicated GitHub Actions workflow that runs the canonical business journey suite on pull requests and main-branch pushes.
 
 ## v1.21.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.21.0"
+version = "1.21.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/agentic_exploration/README.md
+++ b/tests/agentic_exploration/README.md
@@ -1,0 +1,64 @@
+# Agentic Product Exploration
+
+This folder contains browser-agent exploratory testing charters. These are not deterministic CI tests. They are prompts for agents to explore the product like real users, look for unknown breakage, and return evidence that humans can triage.
+
+Use this layer for free testing, not release gating. When a finding is real and repeatable, convert it into a deterministic backend or Playwright test.
+
+## How To Run A Charter
+
+Start a private local stack first. Do not run agentic exploration against a shared database or production-like environment.
+
+Recommended operator prompt:
+
+```text
+Use tests/agentic_exploration/RUN_CONTRACT.md and the charter at
+tests/agentic_exploration/charters/<charter>.md.
+
+Explore FRONTEND_URL=<url> and API_URL=<url>.
+Login with <credentials>.
+Write the final report using tests/agentic_exploration/REPORT_TEMPLATE.md.
+Save any screenshots/videos under artifacts/ and reference their absolute paths.
+Do not modify source code. Do not fix issues. Report findings only.
+```
+
+Run one charter per agent. If running many agents in parallel, give each agent a unique private database, user/account set, and report filename.
+
+## What Agents Should Optimize For
+
+- Find product behavior that feels wrong, unsafe, confusing, stale, inconsistent, or hard to recover from.
+- Compare what the UI says with what actually happens after refresh, navigation, API calls, and later workflow steps.
+- Stress role boundaries, lifecycle transitions, auditability, labels, analytics, and rule/evaluation explainability.
+- Capture exact repro steps, data used, expected behavior, actual behavior, and evidence.
+- Avoid declaring a product area correct just because one happy path worked.
+
+## Report Outcomes
+
+Use these verdicts:
+
+- `PASS`: No credible issues found in the charter scope.
+- `CONCERN`: Something suspicious, confusing, flaky, or under-evidenced needs human review.
+- `FAIL`: A reproducible product bug, data inconsistency, permission failure, or broken journey was found.
+- `BLOCKED`: The agent could not explore the charter because of setup, auth, seed data, or tool failure.
+
+## Charter Index
+
+- `api_key_and_evaluate_integration.md`
+- `audit_trail_compliance_reviewer.md`
+- `backtesting_and_async_operations.md`
+- `dashboard_analytics_consistency.md`
+- `duplicate_and_supersession_ledger.md`
+- `event_tester_dry_run.md`
+- `field_typing_and_nested_payloads.md`
+- `fraud_analyst_rule_authoring.md`
+- `labels_and_rule_quality.md`
+- `navigation_and_session_resilience.md`
+- `negative_inputs_and_validation.md`
+- `notifications_and_alerts.md`
+- `outcome_configuration.md`
+- `permissions_role_boundary.md`
+- `rule_edit_lifecycle.md`
+- `rule_ordering_first_match.md`
+- `settings_runtime_modes.md`
+- `shadow_and_rollout.md`
+- `tested_events_explainability.md`
+- `user_list_operations.md`

--- a/tests/agentic_exploration/REPORT_TEMPLATE.md
+++ b/tests/agentic_exploration/REPORT_TEMPLATE.md
@@ -1,0 +1,57 @@
+# Agentic Exploration Report
+
+## Metadata
+
+- Charter:
+- Agent/persona:
+- Date/time:
+- Frontend URL:
+- API URL:
+- Commit SHA:
+- Database:
+- Login/role:
+- Timebox:
+- Verdict: PASS | CONCERN | FAIL | BLOCKED
+
+## Executive Summary
+
+One short paragraph describing what was explored and whether the product looked trustworthy in this area.
+
+## Coverage Notes
+
+- Happy paths exercised:
+- State transitions exercised:
+- Negative/error paths exercised:
+- Cross-check surfaces used:
+- Areas not covered:
+
+## Findings
+
+### Finding 1: <title>
+
+- Verdict: CONCERN | FAIL
+- Severity: P0 | P1 | P2 | P3
+- Confidence: Low | Medium | High
+- Product area:
+- Reproduced: Yes | No | Partially
+- Expected:
+- Actual:
+- Steps:
+  1. 
+  2. 
+  3. 
+- Test data:
+- Evidence:
+- Suggested deterministic regression test:
+
+## Suspicious But Unproven Notes
+
+- 
+
+## Product Friction
+
+Usability, copy, navigation, loading-state, recoverability, or mental-model issues that are not necessarily bugs.
+
+## Follow-Up Charters
+
+Other charters or product areas that should be explored next based on this run.

--- a/tests/agentic_exploration/RUN_CONTRACT.md
+++ b/tests/agentic_exploration/RUN_CONTRACT.md
@@ -1,0 +1,64 @@
+# Agentic Exploration Run Contract
+
+## Role
+
+You are a product explorer using the app through a browser and, when helpful, through documented API calls. You are not a code fixer. You are looking for unknown product failures.
+
+## Required Inputs
+
+- Charter path
+- Frontend URL
+- API URL
+- Login credentials and role/persona
+- Whether the database is freshly seeded or intentionally dirty
+- Report output path
+
+## Guardrails
+
+- Do not modify source code.
+- Do not change Git state.
+- Do not run destructive database commands.
+- Do not use shared `tests` or `ezrules` databases.
+- Do not test production, external customer systems, or real secrets.
+- Do not perform load/performance testing from these charters.
+- If you need a destructive action to explore a path, use only disposable data you created during the run.
+
+## Exploration Style
+
+- Use the product as the persona would, not as a test script.
+- Follow the charter, but branch when the product exposes suspicious behavior.
+- After important actions, verify through a second surface: refresh the UI, inspect a list/detail page, call an API endpoint, or check a downstream workflow.
+- Prefer small, named data values that make repro steps obvious, such as `AGENT_RULE_<timestamp>`.
+- Keep notes while exploring so the final report includes exact steps.
+
+## Evidence Rules
+
+Every `FAIL` or `CONCERN` must include:
+
+- Exact repro steps
+- Input data used
+- Expected behavior
+- Actual behavior
+- Evidence path or API response excerpt
+- Whether it reproduced after refresh or retry
+- Severity and confidence
+
+If a finding cannot be reproduced, report it as `CONCERN`, not `FAIL`.
+
+## Stop Conditions
+
+Stop when one of these is true:
+
+- The charter mission has been explored across happy path, state transition, and negative path.
+- A severe blocking bug prevents meaningful continuation.
+- The assigned timebox expires.
+- Auth, seed data, or local services are broken enough that exploration would be misleading.
+
+## Conversion Rule
+
+For every reproducible finding, recommend the deterministic test that should be added:
+
+- Backend API/business test
+- Playwright E2E test
+- Unit/component test
+- Documentation/spec clarification

--- a/tests/agentic_exploration/charters/api_key_and_evaluate_integration.md
+++ b/tests/agentic_exploration/charters/api_key_and_evaluate_integration.md
@@ -1,0 +1,29 @@
+# Charter: API Key And Evaluate Integration
+
+## Persona
+
+Integration developer wiring transaction evaluation into another system.
+
+## Mission
+
+Explore API key lifecycle and `/api/v2/evaluate` behavior from a client perspective.
+
+## Goals
+
+- Create or locate an API key.
+- Submit valid, invalid, duplicate, and changed-version evaluation requests.
+- Inspect response fields and error messages.
+- Revoke or rotate the key if supported, then retry.
+- Compare API responses with Tested Events or dashboard visibility.
+
+## Hunt For
+
+- Invalid keys producing side effects.
+- Duplicate requests creating duplicate events.
+- Response fields missing identifiers needed for tracing.
+- Revoked keys still working.
+- API docs, UI, and runtime behavior disagreeing.
+
+## Suggested Deterministic Follow-Up
+
+Backend evaluator contract test or API-key lifecycle test.

--- a/tests/agentic_exploration/charters/audit_trail_compliance_reviewer.md
+++ b/tests/agentic_exploration/charters/audit_trail_compliance_reviewer.md
@@ -1,0 +1,28 @@
+# Charter: Audit Trail Compliance Reviewer
+
+## Persona
+
+Compliance reviewer reconstructing what changed in the system.
+
+## Mission
+
+Explore whether audit/history surfaces provide enough evidence to explain rule, label, list, settings, and permission changes.
+
+## Goals
+
+- Perform several changes as one user.
+- Inspect audit trail filters and detail views.
+- Confirm actor, timestamp, action, object, and before/after context are understandable.
+- Check whether deleted or paused objects remain investigable.
+
+## Hunt For
+
+- Missing actions for important state changes.
+- Audit entries with ambiguous actor or object identity.
+- Filters that omit expected records.
+- History that differs from current object state without explanation.
+- Inability to trace a served decision back to rule/list/label state.
+
+## Suggested Deterministic Follow-Up
+
+Backend audit API regression test.

--- a/tests/agentic_exploration/charters/backtesting_and_async_operations.md
+++ b/tests/agentic_exploration/charters/backtesting_and_async_operations.md
@@ -1,0 +1,29 @@
+# Charter: Backtesting And Async Operations
+
+## Persona
+
+Analyst validating a rule against historical traffic.
+
+## Mission
+
+Explore backtesting and async job behavior, including progress, completion, errors, and result interpretation.
+
+## Goals
+
+- Start a backtest for a rule or draft if available.
+- Observe progress/polling and final results.
+- Compare result counts with known seeded/evaluated traffic.
+- Try navigation away and back during an active job.
+- Trigger a known invalid backtest if possible.
+
+## Hunt For
+
+- Job appears stuck while backend completed or failed.
+- Result counts disagree with visible data.
+- Errors hidden behind generic failure text.
+- Duplicate jobs created by repeated clicks.
+- Results attached to the wrong rule or draft.
+
+## Suggested Deterministic Follow-Up
+
+Backend task/state test or Playwright async polling E2E.

--- a/tests/agentic_exploration/charters/dashboard_analytics_consistency.md
+++ b/tests/agentic_exploration/charters/dashboard_analytics_consistency.md
@@ -1,0 +1,29 @@
+# Charter: Dashboard Analytics Consistency
+
+## Persona
+
+Risk operations lead using dashboards to understand live rule activity.
+
+## Mission
+
+Explore whether dashboard and analytics numbers match generated traffic and rule outcomes.
+
+## Goals
+
+- Generate known evaluation traffic.
+- Compare transaction count, outcome distribution, rule activity, and trend widgets.
+- Change date filters or refresh the page.
+- Open rule-level analytics if available.
+- Compare dashboard numbers with Tested Events.
+
+## Hunt For
+
+- Counts that disagree between dashboard and Tested Events.
+- Date filters off by timezone or boundary.
+- Paused/deleted rules counted incorrectly.
+- Duplicate events counted as new served traffic.
+- Empty states shown when data exists.
+
+## Suggested Deterministic Follow-Up
+
+Backend analytics aggregation test or dashboard Playwright E2E.

--- a/tests/agentic_exploration/charters/duplicate_and_supersession_ledger.md
+++ b/tests/agentic_exploration/charters/duplicate_and_supersession_ledger.md
@@ -1,0 +1,28 @@
+# Charter: Duplicate And Supersession Ledger
+
+## Persona
+
+Integration developer investigating transaction lifecycle behavior.
+
+## Mission
+
+Explore duplicate evaluation and changed-version behavior from product and API surfaces.
+
+## Goals
+
+- Submit the same transaction payload twice.
+- Submit the same transaction ID with changed event data or effective time.
+- Inspect response status, event version identifiers, and Tested Events.
+- Check dashboard counts and current/latest transaction display.
+
+## Hunt For
+
+- Exact duplicate counted as new served traffic.
+- Changed version not visible or not marked current.
+- Historical versions overwritten instead of preserved.
+- UI cannot explain which version produced a decision.
+- API response lacks identifiers needed for reconciliation.
+
+## Suggested Deterministic Follow-Up
+
+Backend event-ledger contract test.

--- a/tests/agentic_exploration/charters/event_tester_dry_run.md
+++ b/tests/agentic_exploration/charters/event_tester_dry_run.md
@@ -1,0 +1,29 @@
+# Charter: Event Tester Dry Run
+
+## Persona
+
+Analyst testing a proposed event before sending real traffic.
+
+## Mission
+
+Explore whether Event Tester behaves like evaluation without persistence side effects.
+
+## Goals
+
+- Run dry-run events that match and miss rules.
+- Compare dry-run result with live evaluation for equivalent payloads.
+- Verify dry runs do not appear as served Tested Events unless explicitly expected.
+- Try malformed JSON and missing fields.
+- Try rollout/allowlist interactions if available.
+
+## Hunt For
+
+- Dry run creating persistent served events.
+- Dry-run result disagreeing with live evaluation for same active config.
+- Error state that loses user input.
+- Invalid payload accepted silently.
+- Missing explanation of why no rule matched.
+
+## Suggested Deterministic Follow-Up
+
+Backend event-test isolation journey or Playwright Event Tester E2E.

--- a/tests/agentic_exploration/charters/field_typing_and_nested_payloads.md
+++ b/tests/agentic_exploration/charters/field_typing_and_nested_payloads.md
@@ -1,0 +1,28 @@
+# Charter: Field Typing And Nested Payloads
+
+## Persona
+
+Integration developer sending realistic nested transaction payloads.
+
+## Mission
+
+Explore nested field references, type coercion, missing fields, and payload display.
+
+## Goals
+
+- Create rules using nested fields such as `$customer.profile.age` or `$device.trust_score`.
+- Submit numeric strings, missing fields, nulls, and nested objects.
+- Inspect validation, evaluation, Tested Events, and referenced-field display.
+- Try payloads with unexpected extra fields.
+
+## Hunt For
+
+- Nested rule compiles but fails at runtime.
+- Type coercion differs between dry run, live evaluation, and backtesting.
+- Missing fields produce unclear errors or wrong outcomes.
+- Referenced-field highlighting breaks nested paths.
+- Payload viewer corrupts nested data.
+
+## Suggested Deterministic Follow-Up
+
+Backend nested-field evaluator test or Playwright payload explainability E2E.

--- a/tests/agentic_exploration/charters/fraud_analyst_rule_authoring.md
+++ b/tests/agentic_exploration/charters/fraud_analyst_rule_authoring.md
@@ -1,0 +1,29 @@
+# Charter: Fraud Analyst Rule Authoring
+
+## Persona
+
+Fraud analyst creating production rules from observed transaction patterns.
+
+## Mission
+
+Explore whether a user can create, validate, promote, and understand a basic fraud rule without hidden surprises.
+
+## Goals
+
+- Create valid and invalid rules.
+- Confirm validation messages are useful.
+- Promote a rule and verify a matching live transaction receives the expected outcome.
+- Verify non-matching traffic stays neutral.
+- Inspect rule detail, history, and tested-event explanation.
+
+## Hunt For
+
+- UI says a rule is active but live evaluation disagrees.
+- Rule syntax accepted in one surface but rejected elsewhere.
+- Missing or misleading validation errors.
+- Stale rule lists or detail pages after create/promote.
+- Outcome names shown differently across editor, result, and history.
+
+## Suggested Deterministic Follow-Up
+
+Backend product journey or Playwright rule-authoring E2E.

--- a/tests/agentic_exploration/charters/labels_and_rule_quality.md
+++ b/tests/agentic_exploration/charters/labels_and_rule_quality.md
@@ -1,0 +1,29 @@
+# Charter: Labels And Rule Quality
+
+## Persona
+
+Risk operations lead reviewing whether rules are producing useful alerts.
+
+## Mission
+
+Explore label creation, event labeling, and rule-quality analytics.
+
+## Goals
+
+- Create labels for fraud, legitimate, and false-positive outcomes.
+- Label evaluated events.
+- Inspect rule-quality analytics and confirm counts match the labeled events.
+- Refresh and revisit analytics after adding more labels.
+- Check label audit entries.
+
+## Hunt For
+
+- Analytics counts that do not match visible labeled events.
+- Labels attached to the wrong transaction version.
+- Label names changing case unexpectedly.
+- Rule-quality metrics stale after new labels.
+- Audit trail missing assignment details.
+
+## Suggested Deterministic Follow-Up
+
+Backend label/rule-quality journey or analytics Playwright E2E.

--- a/tests/agentic_exploration/charters/navigation_and_session_resilience.md
+++ b/tests/agentic_exploration/charters/navigation_and_session_resilience.md
@@ -1,0 +1,28 @@
+# Charter: Navigation And Session Resilience
+
+## Persona
+
+Busy analyst moving quickly across the app.
+
+## Mission
+
+Explore whether navigation, refresh, back/forward, and session behavior preserve a coherent product state.
+
+## Goals
+
+- Navigate between list, detail, create, settings, audit, dashboard, and Tested Events.
+- Use browser refresh and back/forward after mutations.
+- Let forms partially fill, navigate away, and return.
+- Test logout/login and forbidden route behavior.
+
+## Hunt For
+
+- Stale state after refresh or back navigation.
+- Broken deep links.
+- Session expiry causing data loss without warning.
+- Sidebar or breadcrumbs pointing to wrong state.
+- Unauthorized routes briefly exposing data.
+
+## Suggested Deterministic Follow-Up
+
+Playwright app-shell/session E2E.

--- a/tests/agentic_exploration/charters/negative_inputs_and_validation.md
+++ b/tests/agentic_exploration/charters/negative_inputs_and_validation.md
@@ -1,0 +1,28 @@
+# Charter: Negative Inputs And Validation
+
+## Persona
+
+Adversarial product explorer trying odd but realistic user input.
+
+## Mission
+
+Explore validation, error recovery, and side-effect safety for malformed input.
+
+## Goals
+
+- Try invalid rule syntax, unknown outcomes, duplicate names, empty fields, huge values, nulls, and odd whitespace.
+- Try invalid API payloads.
+- Verify failed operations do not create partial data.
+- Refresh after failures and inspect lists/history.
+
+## Hunt For
+
+- Error response with persisted side effects.
+- UI shows success despite backend failure.
+- Duplicate objects created after retries.
+- Validation message does not identify the field or problem.
+- User input lost unnecessarily after correctable errors.
+
+## Suggested Deterministic Follow-Up
+
+Backend negative-path business test or Playwright validation E2E.

--- a/tests/agentic_exploration/charters/notifications_and_alerts.md
+++ b/tests/agentic_exploration/charters/notifications_and_alerts.md
@@ -1,0 +1,29 @@
+# Charter: Notifications And Alerts
+
+## Persona
+
+Risk operations lead monitoring spikes and incidents.
+
+## Mission
+
+Explore alert creation, trigger behavior, in-app notifications, and read/unread state.
+
+## Goals
+
+- Configure or inspect alert rules if available.
+- Generate traffic that should and should not trigger alerts.
+- Check notification bell/list behavior.
+- Mark notifications read/unread if supported.
+- Inspect whether incidents link to relevant traffic or outcomes.
+
+## Hunt For
+
+- Alerts not firing for obvious threshold breaches.
+- Duplicate alerts for the same incident.
+- Notification unread state stale after refresh.
+- Alerts based on duplicate or dry-run traffic.
+- Missing context to investigate the incident.
+
+## Suggested Deterministic Follow-Up
+
+Backend alert detection test or Playwright notification E2E.

--- a/tests/agentic_exploration/charters/outcome_configuration.md
+++ b/tests/agentic_exploration/charters/outcome_configuration.md
@@ -1,0 +1,29 @@
+# Charter: Outcome Configuration
+
+## Persona
+
+Operations admin configuring business outcomes.
+
+## Mission
+
+Explore configured outcomes and how they affect rule authoring, validation, severity, and result display.
+
+## Goals
+
+- Inspect configured outcomes.
+- Create rules using valid and invalid outcomes.
+- Change severity/rank if supported.
+- Evaluate events returning multiple outcomes.
+- Confirm UI displays configured outcomes consistently.
+
+## Hunt For
+
+- Unknown outcomes accepted.
+- Valid outcomes rejected because of case or formatting confusion.
+- Severity ordering inconsistent between response, dashboard, and UI.
+- Outcome changes not reflected in editor autocomplete or validation.
+- Old outcomes remain usable unexpectedly.
+
+## Suggested Deterministic Follow-Up
+
+Backend outcome validation/resolution test.

--- a/tests/agentic_exploration/charters/permissions_role_boundary.md
+++ b/tests/agentic_exploration/charters/permissions_role_boundary.md
@@ -1,0 +1,29 @@
+# Charter: Permissions And Role Boundaries
+
+## Persona
+
+Operations admin managing least-privilege access.
+
+## Mission
+
+Explore whether users can only see and do what their roles allow.
+
+## Goals
+
+- Try rule create/edit/promote with insufficient permissions.
+- Grant and revoke permissions, then retry without changing the user identity.
+- Check direct navigation to forbidden pages.
+- Check API behavior for forbidden actions if API access is available.
+- Confirm UI hides or disables actions consistently.
+
+## Hunt For
+
+- Forbidden buttons visible and executable.
+- UI denies but API allows.
+- Permission changes not taking effect until logout without explanation.
+- Read-only users mutating state through secondary workflows.
+- Missing 403 messaging or confusing redirects.
+
+## Suggested Deterministic Follow-Up
+
+Backend permission journey plus Playwright role-boundary E2E.

--- a/tests/agentic_exploration/charters/rule_edit_lifecycle.md
+++ b/tests/agentic_exploration/charters/rule_edit_lifecycle.md
@@ -1,0 +1,28 @@
+# Charter: Rule Edit Lifecycle
+
+## Persona
+
+Senior analyst maintaining active rules.
+
+## Mission
+
+Explore edit, draft, promote, pause, resume, and archive behavior around an existing active rule.
+
+## Goals
+
+- Edit an active rule and determine whether new logic serves immediately or waits for promotion.
+- Pause and resume a rule, then verify live traffic behavior after each state change.
+- Refresh and revisit detail/list pages after each transition.
+- Inspect history entries and status labels.
+
+## Hunt For
+
+- Active and draft states that contradict served behavior.
+- Old logic still serving after promotion.
+- New logic serving before expected.
+- Missing actor/timestamp/status transitions in history.
+- Buttons enabled in invalid lifecycle states.
+
+## Suggested Deterministic Follow-Up
+
+Backend lifecycle journey plus Playwright state-transition E2E.

--- a/tests/agentic_exploration/charters/rule_ordering_first_match.md
+++ b/tests/agentic_exploration/charters/rule_ordering_first_match.md
@@ -1,0 +1,28 @@
+# Charter: Rule Ordering And First Match
+
+## Persona
+
+Risk operations lead configuring rule priority.
+
+## Mission
+
+Explore ordered main-rule execution and whether first-match behavior is understandable and correct.
+
+## Goals
+
+- Create overlapping rules with different outcomes.
+- Enable first-match mode if available.
+- Reorder rules and evaluate the same transaction after each order change.
+- Confirm rule list order, served outcome, and tested-event explanation agree.
+
+## Hunt For
+
+- Reordering appears successful but evaluation still uses old order.
+- UI hides ordering while first-match mode is enabled.
+- Multiple matches persist when first-match should stop.
+- Audit/history does not record order changes.
+- Confusing behavior when rules have equal or missing order.
+
+## Suggested Deterministic Follow-Up
+
+Backend ordered-execution universe scenario or Playwright ordering E2E.

--- a/tests/agentic_exploration/charters/settings_runtime_modes.md
+++ b/tests/agentic_exploration/charters/settings_runtime_modes.md
@@ -1,0 +1,29 @@
+# Charter: Settings And Runtime Modes
+
+## Persona
+
+Operations admin changing organization-wide runtime behavior.
+
+## Mission
+
+Explore settings that affect evaluation behavior and whether changes are clear, reversible, and audited.
+
+## Goals
+
+- Change main-rule execution mode if available.
+- Change rule-quality or analytics settings if available.
+- Toggle AI or strict/runtime settings if available.
+- Verify downstream behavior changes after settings updates.
+- Inspect audit/history for setting changes.
+
+## Hunt For
+
+- Setting appears saved but runtime behavior does not change.
+- Dangerous setting changes without confirmation.
+- Unsaved changes lost silently.
+- Audit trail missing settings changes.
+- Settings page shows stale values after refresh.
+
+## Suggested Deterministic Follow-Up
+
+Backend runtime settings test or Playwright settings E2E.

--- a/tests/agentic_exploration/charters/shadow_and_rollout.md
+++ b/tests/agentic_exploration/charters/shadow_and_rollout.md
@@ -1,0 +1,29 @@
+# Charter: Shadow And Rollout
+
+## Persona
+
+Risk lead trialing a candidate rule change before full promotion.
+
+## Mission
+
+Explore shadow and rollout behavior, especially whether users can understand which logic served the customer-facing outcome.
+
+## Goals
+
+- Start a shadow comparison or rollout candidate if available.
+- Send events that make control and candidate differ.
+- Inspect rollout/shadow result surfaces.
+- Confirm traffic percent behavior is understandable.
+- Stop or change the deployment and verify behavior.
+
+## Hunt For
+
+- Candidate result returned when control should serve, or vice versa.
+- Provenance missing from result/history.
+- Rollout percent saved but not applied.
+- UI reports no data while logs exist.
+- Stopping rollout leaves stale candidate behavior.
+
+## Suggested Deterministic Follow-Up
+
+Backend rollout provenance journey or Playwright rollout management E2E.

--- a/tests/agentic_exploration/charters/tested_events_explainability.md
+++ b/tests/agentic_exploration/charters/tested_events_explainability.md
@@ -1,0 +1,29 @@
+# Charter: Tested Events Explainability
+
+## Persona
+
+Fraud analyst investigating why a transaction received a decision.
+
+## Mission
+
+Explore whether Tested Events explains served decisions clearly and accurately.
+
+## Goals
+
+- Generate events that hit one rule, multiple rules, allowlist rules, and no rules.
+- Open Tested Events and inspect detail/explanation views.
+- Confirm referenced fields and triggered rules match rule logic.
+- Label or filter events if supported.
+- Revisit after rule edits to see whether historical explanation remains understandable.
+
+## Hunt For
+
+- Missing triggered rules.
+- Referenced fields absent or wrong.
+- Historical events appearing to use current rule logic incorrectly.
+- Filtering/search hiding events unexpectedly.
+- Event payload display losing nested fields or data types.
+
+## Suggested Deterministic Follow-Up
+
+Backend Tested Events API test or Playwright investigation flow.

--- a/tests/agentic_exploration/charters/user_list_operations.md
+++ b/tests/agentic_exploration/charters/user_list_operations.md
@@ -1,0 +1,29 @@
+# Charter: User List Operations
+
+## Persona
+
+Operations analyst maintaining trusted and risky customer lists.
+
+## Mission
+
+Explore list creation, entry mutation, rule usage, and downstream evaluation behavior.
+
+## Goals
+
+- Create a user list and add entries.
+- Reference the list from a rule.
+- Verify matching and non-matching evaluations.
+- Remove entries and verify behavior updates.
+- Inspect audit/history for list changes.
+
+## Hunt For
+
+- Rules using stale list values after entry changes.
+- Duplicate entries or case/whitespace behavior that surprises users.
+- List deletion or rename breaking rules without clear warnings.
+- Audit trail missing entry-level actions.
+- UI/API disagreement on list contents.
+
+## Suggested Deterministic Follow-Up
+
+Backend user-list mutation journey or Playwright list-management E2E.

--- a/tests/agentic_exploration/fixtures/personas.md
+++ b/tests/agentic_exploration/fixtures/personas.md
@@ -1,0 +1,25 @@
+# Exploration Personas
+
+## Fraud Analyst
+
+Owns rule authoring, event testing, investigation, and outcome correctness. Cares about whether a transaction receives the expected decision and whether the app explains why.
+
+## Compliance Reviewer
+
+Owns auditability, history, labels, approvals, and evidence trails. Cares about who changed what, when, and whether the product can support an investigation.
+
+## Operations Admin
+
+Owns user roles, permissions, runtime settings, API keys, data lists, and safe operational changes. Cares about reversibility and least privilege.
+
+## Integration Developer
+
+Owns API usage, schema expectations, error behavior, idempotency, and integration examples. Cares about predictable responses and stable contracts.
+
+## Risk Operations Lead
+
+Owns dashboards, analytics, rule quality, alerting, and trend inspection. Cares about whether aggregated numbers match operational reality.
+
+## Adversarial Product Explorer
+
+Uses odd inputs, state changes, refreshes, back/forward navigation, and partial workflows to find stale UI, broken validation, and hidden data corruption.

--- a/tests/agentic_exploration/fixtures/seed_payloads.json
+++ b/tests/agentic_exploration/fixtures/seed_payloads.json
@@ -1,0 +1,58 @@
+{
+  "events": {
+    "high_amount_review": {
+      "transaction_id": "agent_high_amount_review",
+      "effective_at": 1710000000,
+      "event_data": {
+        "amount": 1500,
+        "currency": "GBP",
+        "country": "GB",
+        "customer_id": "agent_customer_001",
+        "risk_score": 82
+      }
+    },
+    "trusted_customer_release": {
+      "transaction_id": "agent_trusted_customer_release",
+      "effective_at": 1710000000,
+      "event_data": {
+        "amount": 250,
+        "currency": "GBP",
+        "country": "GB",
+        "customer_id": "agent_trusted_001",
+        "risk_score": 12
+      }
+    },
+    "nested_profile_risk": {
+      "transaction_id": "agent_nested_profile_risk",
+      "effective_at": 1710000000,
+      "event_data": {
+        "amount": "1250.00",
+        "customer": {
+          "id": "agent_nested_001",
+          "profile": {
+            "age": 19,
+            "country": "NG"
+          }
+        },
+        "device": {
+          "trust_score": 9
+        }
+      }
+    }
+  },
+  "rule_logic": {
+    "amount_review": "if $amount >= 1000:\n\treturn !REVIEW",
+    "risk_hold": "if $risk_score >= 80:\n\treturn !HOLD",
+    "trusted_allowlist": "if $customer_id in @AgentTrustedCustomers:\n\treturn !RELEASE",
+    "nested_device_hold": "if $device.trust_score <= 10:\n\treturn !HOLD"
+  },
+  "lists": {
+    "trusted_customers": "AgentTrustedCustomers",
+    "watchlist_customers": "AgentWatchlistCustomers"
+  },
+  "labels": [
+    "AGENT_FRAUD",
+    "AGENT_FALSE_POSITIVE",
+    "AGENT_LEGIT"
+  ]
+}

--- a/tests/agentic_exploration/reports/.gitignore
+++ b/tests/agentic_exploration/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/business_scenarios/canonical_evaluation_universe.yaml
+++ b/tests/business_scenarios/canonical_evaluation_universe.yaml
@@ -1,0 +1,306 @@
+version: 1
+name: canonical_evaluation_universe
+
+outcomes:
+  - name: CANCEL
+    severity_rank: 1
+    meaning: Hard stop; highest severity outcome.
+  - name: HOLD
+    severity_rank: 2
+    meaning: Manual intervention required.
+  - name: REVIEW
+    severity_rank: 3
+    meaning: Analyst review required before release.
+  - name: RELEASE
+    severity_rank: 4
+    meaning: Neutral outcome; transaction may proceed.
+
+settings:
+  main_rule_execution_mode: all_matches
+  neutral_outcome: RELEASE
+
+user_lists:
+  TrustedCustomers:
+    - cust_trusted_001
+    - cust_trusted_002
+  HighRiskCountries:
+    - NG
+    - RU
+    - IR
+
+rules:
+  - id: R_AMOUNT_REVIEW
+    numeric_id: 10101
+    lane: main
+    order: 10
+    description: High amount requires review.
+    logic: "if $amount >= 1000:\n\treturn !REVIEW"
+
+  - id: R_COUNTRY_HOLD
+    numeric_id: 10102
+    lane: main
+    order: 20
+    description: High-risk country requires hold.
+    logic: "if $country in @HighRiskCountries:\n\treturn !HOLD"
+
+  - id: R_VELOCITY_CANCEL
+    numeric_id: 10103
+    lane: main
+    order: 30
+    description: High-value velocity requires cancel.
+    logic: "if $transaction_count_1h >= 5 and $amount >= 5000:\n\treturn !CANCEL"
+
+  - id: R_DEVICE_HOLD
+    numeric_id: 10104
+    lane: main
+    order: 40
+    description: Low device trust requires hold.
+    logic: "if $device_trust_score <= 20:\n\treturn !HOLD"
+
+  - id: A_TRUSTED_CUSTOMER_RELEASE
+    numeric_id: 10201
+    lane: allowlist
+    order: 1
+    description: Trusted customers bypass main rules.
+    logic: "if $customer_id in @TrustedCustomers:\n\treturn !RELEASE"
+
+scenarios:
+  - id: amount_only_reviews_transaction
+    purpose: A single main-rule hit persists a predictable REVIEW decision.
+    submissions:
+      - transaction_id: canonical_amount_only
+        effective_at: 1710000000
+        event_data:
+          amount: 1500
+          country: GB
+          customer_id: cust_normal_001
+          transaction_count_1h: 1
+          device_trust_score: 90
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: REVIEW
+          outcome_counters:
+            REVIEW: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+    final:
+      event_versions: 1
+      decisions: 1
+      current_event_version: 1
+      current_resolved_outcome: REVIEW
+
+  - id: amount_and_country_resolves_highest_severity
+    purpose: Multiple main-rule hits preserve all rule results and resolve to the highest-severity outcome.
+    submissions:
+      - transaction_id: canonical_amount_country
+        effective_at: 1710000000
+        event_data:
+          amount: 2500
+          country: NG
+          customer_id: cust_normal_002
+          transaction_count_1h: 1
+          device_trust_score: 90
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: HOLD
+          outcome_counters:
+            REVIEW: 1
+            HOLD: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+            R_COUNTRY_HOLD: HOLD
+    final:
+      event_versions: 1
+      decisions: 1
+      current_event_version: 1
+      current_resolved_outcome: HOLD
+
+  - id: velocity_cancel_wins_over_hold_and_review
+    purpose: CANCEL outranks lower-severity outcomes when several rules match together.
+    submissions:
+      - transaction_id: canonical_velocity_cancel
+        effective_at: 1710000000
+        event_data:
+          amount: 9000
+          country: NG
+          customer_id: cust_normal_003
+          transaction_count_1h: 7
+          device_trust_score: 90
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: CANCEL
+          outcome_counters:
+            REVIEW: 1
+            HOLD: 1
+            CANCEL: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+            R_COUNTRY_HOLD: HOLD
+            R_VELOCITY_CANCEL: CANCEL
+    final:
+      event_versions: 1
+      decisions: 1
+      current_event_version: 1
+      current_resolved_outcome: CANCEL
+
+  - id: first_match_stops_after_first_hit
+    purpose: Ordered execution stops after the first matching main rule.
+    settings:
+      main_rule_execution_mode: first_match
+    submissions:
+      - transaction_id: canonical_first_match
+        effective_at: 1710000000
+        event_data:
+          amount: 9000
+          country: NG
+          customer_id: cust_normal_004
+          transaction_count_1h: 7
+          device_trust_score: 5
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: REVIEW
+          outcome_counters:
+            REVIEW: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+          absent_rule_results:
+            - R_COUNTRY_HOLD
+            - R_VELOCITY_CANCEL
+            - R_DEVICE_HOLD
+    final:
+      event_versions: 1
+      decisions: 1
+      current_event_version: 1
+      current_resolved_outcome: REVIEW
+
+  - id: trusted_customer_short_circuits_main_rules
+    purpose: A matching allowlist rule returns the neutral outcome and prevents main-rule execution.
+    submissions:
+      - transaction_id: canonical_allowlist
+        effective_at: 1710000000
+        event_data:
+          amount: 9000
+          country: NG
+          customer_id: cust_trusted_001
+          transaction_count_1h: 7
+          device_trust_score: 5
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: RELEASE
+          outcome_counters:
+            RELEASE: 1
+          rule_results:
+            A_TRUSTED_CUSTOMER_RELEASE: RELEASE
+          absent_rule_results:
+            - R_AMOUNT_REVIEW
+            - R_COUNTRY_HOLD
+            - R_VELOCITY_CANCEL
+            - R_DEVICE_HOLD
+    final:
+      event_versions: 1
+      decisions: 1
+      current_event_version: 1
+      current_resolved_outcome: RELEASE
+
+  - id: exact_duplicate_reuses_served_decision
+    purpose: An exact replay returns the original served decision instead of creating a second event version.
+    submissions:
+      - transaction_id: canonical_duplicate
+        effective_at: 1710000000
+        event_data:
+          amount: 1500
+          country: GB
+          customer_id: cust_normal_005
+          transaction_count_1h: 1
+          device_trust_score: 90
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: REVIEW
+          outcome_counters:
+            REVIEW: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+      - transaction_id: canonical_duplicate
+        effective_at: 1710000000
+        event_data:
+          amount: 1500
+          country: GB
+          customer_id: cust_normal_005
+          transaction_count_1h: 1
+          device_trust_score: 90
+        expected:
+          evaluation_status: duplicate
+          event_version: 1
+          same_evaluation_as_submission: 0
+          is_current: true
+          resolved_outcome: REVIEW
+          outcome_counters:
+            REVIEW: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+    final:
+      event_versions: 1
+      decisions: 1
+      current_event_version: 1
+      current_resolved_outcome: REVIEW
+
+  - id: changed_payload_supersedes_current_transaction
+    purpose: A changed payload for the same transaction creates the next event version and updates current projection.
+    submissions:
+      - transaction_id: canonical_superseding
+        effective_at: 1710000000
+        event_data:
+          amount: 1500
+          country: GB
+          customer_id: cust_normal_006
+          transaction_count_1h: 1
+          device_trust_score: 90
+        expected:
+          evaluation_status: new
+          event_version: 1
+          is_current: true
+          resolved_outcome: REVIEW
+          outcome_counters:
+            REVIEW: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+      - transaction_id: canonical_superseding
+        effective_at: 1710000300
+        event_data:
+          amount: 9000
+          country: NG
+          customer_id: cust_normal_006
+          transaction_count_1h: 7
+          device_trust_score: 90
+        expected:
+          evaluation_status: superseding
+          event_version: 2
+          is_current: true
+          resolved_outcome: CANCEL
+          outcome_counters:
+            REVIEW: 1
+            HOLD: 1
+            CANCEL: 1
+          rule_results:
+            R_AMOUNT_REVIEW: REVIEW
+            R_COUNTRY_HOLD: HOLD
+            R_VELOCITY_CANCEL: CANCEL
+    final:
+      event_versions: 2
+      decisions: 2
+      current_event_version: 2
+      current_resolved_outcome: CANCEL
+      superseded_decision_versions:
+        - 1

--- a/tests/business_scenarios/test_canonical_evaluation_universe.py
+++ b/tests/business_scenarios/test_canonical_evaluation_universe.py
@@ -1,0 +1,241 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.api_v2.routes import evaluator as evaluator_router
+from ezrules.backend.runtime_settings import set_runtime_setting
+from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager
+from ezrules.models.backend_core import (
+    AllowedOutcome,
+    EvaluationDecision,
+    EvaluationRuleResult,
+    EventVersion,
+    Organisation,
+    RuleStatus,
+    TransactionCurrentVersion,
+    UserList,
+    UserListEntry,
+)
+from ezrules.models.backend_core import Rule as RuleModel
+
+
+UNIVERSE_PATH = Path(__file__).with_name("canonical_evaluation_universe.yaml")
+
+
+def _load_universe() -> dict[str, Any]:
+    with UNIVERSE_PATH.open() as file:
+        return yaml.safe_load(file)
+
+
+UNIVERSE = _load_universe()
+RULE_ID_BY_RID = {rule["id"]: int(rule["numeric_id"]) for rule in UNIVERSE["rules"]}
+
+
+def _scenario_ids() -> list[str]:
+    return [scenario["id"] for scenario in UNIVERSE["scenarios"]]
+
+
+def _seed_outcomes(session, *, org_id: int) -> None:
+    session.query(AllowedOutcome).filter(AllowedOutcome.o_id == org_id).delete(synchronize_session=False)
+    for outcome in UNIVERSE["outcomes"]:
+        session.add(
+            AllowedOutcome(
+                outcome_name=str(outcome["name"]),
+                severity_rank=int(outcome["severity_rank"]),
+                o_id=org_id,
+            )
+        )
+
+
+def _seed_user_lists(session, *, org_id: int) -> None:
+    for list_name, entries in UNIVERSE["user_lists"].items():
+        user_list = UserList(list_name=str(list_name), o_id=org_id)
+        session.add(user_list)
+        session.flush()
+        for entry in entries:
+            session.add(UserListEntry(entry_value=str(entry), ul_id=int(user_list.ul_id)))
+
+
+def _seed_rules(session, *, org_id: int) -> None:
+    for rule in UNIVERSE["rules"]:
+        session.add(
+            RuleModel(
+                r_id=int(rule["numeric_id"]),
+                rid=str(rule["id"]),
+                logic=str(rule["logic"]),
+                description=str(rule["description"]),
+                execution_order=int(rule["order"]),
+                evaluation_lane=str(rule["lane"]),
+                status=RuleStatus.ACTIVE,
+                o_id=org_id,
+            )
+        )
+
+
+def _apply_settings(session, *, org_id: int, scenario: dict[str, Any]) -> None:
+    settings = dict(UNIVERSE.get("settings") or {})
+    settings.update(scenario.get("settings") or {})
+    for key, value in settings.items():
+        set_runtime_setting(session, str(key), value, org_id)
+
+
+def _seed_universe(session, scenario: dict[str, Any]) -> int:
+    org = session.query(Organisation).one()
+    org_id = int(org.o_id)
+    _seed_outcomes(session, org_id=org_id)
+    _seed_user_lists(session, org_id=org_id)
+    _seed_rules(session, org_id=org_id)
+    _apply_settings(session, org_id=org_id, scenario=scenario)
+    session.commit()
+
+    RDBRuleEngineConfigProducer(db=session, o_id=org_id).save_config(RDBRuleManager(db=session, o_id=org_id))
+    return org_id
+
+
+def _reset_evaluator_state() -> None:
+    evaluator_router._lre = None
+    evaluator_router._shadow_lre = None
+    evaluator_router._allowlist_lre = None
+
+
+def _expected_rule_results_by_numeric_id(expected: dict[str, str]) -> dict[str, str]:
+    return {str(RULE_ID_BY_RID[rid]): outcome for rid, outcome in expected.items()}
+
+
+def _assert_response_matches(
+    response: dict[str, Any], expected: dict[str, Any], prior_responses: list[dict[str, Any]]
+) -> None:
+    assert response["evaluation_status"] == expected["evaluation_status"]
+    assert response["event_version"] == expected["event_version"]
+    assert response["is_current"] is expected.get("is_current")
+    assert response["resolved_outcome"] == expected["resolved_outcome"]
+    assert response["outcome_counters"] == expected["outcome_counters"]
+    assert response["rule_results"] == _expected_rule_results_by_numeric_id(expected["rule_results"])
+
+    if "same_evaluation_as_submission" in expected:
+        previous = prior_responses[int(expected["same_evaluation_as_submission"])]
+        assert response["evaluation_id"] == previous["evaluation_id"]
+
+    for rid in expected.get("absent_rule_results") or []:
+        assert str(RULE_ID_BY_RID[rid]) not in response["rule_results"]
+
+
+def _assert_persisted_rule_results(session, decision: EvaluationDecision, expected: dict[str, Any]) -> None:
+    stored_results = (
+        session.query(EvaluationRuleResult)
+        .filter(EvaluationRuleResult.ed_id == int(decision.ed_id))
+        .order_by(EvaluationRuleResult.r_id.asc())
+        .all()
+    )
+    assert {
+        str(result.r_id): str(result.rule_result) for result in stored_results
+    } == _expected_rule_results_by_numeric_id(expected["rule_results"])
+
+    all_rule_results = {str(key): value for key, value in (decision.all_rule_results or {}).items()}
+    for rid in expected.get("absent_rule_results") or []:
+        assert str(RULE_ID_BY_RID[rid]) not in all_rule_results
+
+
+def _assert_submission_persisted(session, submission: dict[str, Any], response: dict[str, Any]) -> None:
+    if submission["expected"]["evaluation_status"] == "duplicate":
+        return
+
+    decision = (
+        session.query(EvaluationDecision).filter(EvaluationDecision.ed_id == int(response["evaluation_id"])).one()
+    )
+    assert decision.transaction_id == submission["transaction_id"]
+    assert int(decision.event_version) == submission["expected"]["event_version"]
+    assert decision.outcome_counters == submission["expected"]["outcome_counters"]
+    assert decision.resolved_outcome == submission["expected"]["resolved_outcome"]
+    assert bool(decision.is_current) is submission["expected"]["is_current"]
+    assert decision.rule_config_label == "production"
+    _assert_persisted_rule_results(session, decision, submission["expected"])
+
+
+def _assert_final_projection(session, *, org_id: int, scenario: dict[str, Any]) -> None:
+    final = scenario["final"]
+    transaction_id = scenario["submissions"][-1]["transaction_id"]
+    assert (
+        session.query(EventVersion)
+        .filter(EventVersion.o_id == org_id, EventVersion.transaction_id == transaction_id)
+        .count()
+        == final["event_versions"]
+    )
+    assert (
+        session.query(EvaluationDecision)
+        .filter(EvaluationDecision.o_id == org_id, EvaluationDecision.transaction_id == transaction_id)
+        .count()
+        == final["decisions"]
+    )
+
+    current = (
+        session.query(TransactionCurrentVersion)
+        .filter(TransactionCurrentVersion.o_id == org_id, TransactionCurrentVersion.transaction_id == transaction_id)
+        .one()
+    )
+    assert current.current_effective_at is not None
+
+    current_decision = (
+        session.query(EvaluationDecision)
+        .filter(EvaluationDecision.o_id == org_id, EvaluationDecision.ed_id == int(current.current_ed_id))
+        .one()
+    )
+    assert int(current_decision.event_version) == final["current_event_version"]
+    assert current_decision.resolved_outcome == final["current_resolved_outcome"]
+
+    superseded_versions = set(final.get("superseded_decision_versions") or [])
+    if superseded_versions:
+        superseded = (
+            session.query(EvaluationDecision)
+            .filter(
+                EvaluationDecision.o_id == org_id,
+                EvaluationDecision.transaction_id == transaction_id,
+                EvaluationDecision.is_current.is_(False),
+            )
+            .all()
+        )
+        assert {int(decision.event_version) for decision in superseded} == superseded_versions
+
+
+def test_canonical_evaluation_universe_is_internally_consistent():
+    assert UNIVERSE["version"] == 1
+    assert len(RULE_ID_BY_RID) == len(UNIVERSE["rules"])
+    assert len(set(RULE_ID_BY_RID.values())) == len(UNIVERSE["rules"])
+    assert len(_scenario_ids()) == len(set(_scenario_ids()))
+    assert [outcome["severity_rank"] for outcome in UNIVERSE["outcomes"]] == sorted(
+        outcome["severity_rank"] for outcome in UNIVERSE["outcomes"]
+    )
+
+
+@pytest.mark.parametrize("scenario", UNIVERSE["scenarios"], ids=_scenario_ids())
+def test_canonical_evaluation_business_journey(session, live_api_key, scenario):
+    org_id = _seed_universe(session, scenario)
+    _reset_evaluator_state()
+    prior_responses: list[dict[str, Any]] = []
+
+    try:
+        with TestClient(app) as client:
+            for submission in scenario["submissions"]:
+                result = client.post(
+                    "/api/v2/evaluate",
+                    json={
+                        "transaction_id": submission["transaction_id"],
+                        "effective_at": submission["effective_at"],
+                        "event_data": submission["event_data"],
+                    },
+                    headers={"X-API-Key": live_api_key},
+                )
+
+                assert result.status_code == 200
+                payload = result.json()
+                _assert_response_matches(payload, submission["expected"], prior_responses)
+                _assert_submission_persisted(session, submission, payload)
+                prior_responses.append(payload)
+    finally:
+        _reset_evaluator_state()
+
+    _assert_final_projection(session, org_id=org_id, scenario=scenario)

--- a/tests/business_scenarios/test_product_journeys.py
+++ b/tests/business_scenarios/test_product_journeys.py
@@ -12,10 +12,16 @@ from ezrules.models.backend_core import (
     EvaluationDecision,
     EvaluationRuleResult,
     EventVersion,
+    EventVersionLabel,
+    Label,
     Organisation,
     Role,
+    RuleDeploymentResultsLog,
     RuleHistory,
+    RuleQualityPair,
     User,
+    UserListEntry,
+    UserListHistory,
 )
 from ezrules.models.backend_core import Rule as RuleModel
 
@@ -80,6 +86,13 @@ def _manager_token(session, *, email: str = "journey-manager@example.com") -> st
             PermissionAction.PAUSE_RULES,
             PermissionAction.DELETE_RULE,
             PermissionAction.SUBMIT_TEST_EVENTS,
+            PermissionAction.VIEW_LISTS,
+            PermissionAction.CREATE_LIST,
+            PermissionAction.MODIFY_LIST,
+            PermissionAction.DELETE_LIST,
+            PermissionAction.VIEW_LABELS,
+            PermissionAction.CREATE_LABEL,
+            PermissionAction.ACCESS_AUDIT_TRAIL,
         ],
     )
 
@@ -108,6 +121,12 @@ def _promote_rule(client: TestClient, token: str, rule_id: int) -> None:
     payload = response.json()
     assert payload["success"] is True
     assert payload["rule"]["status"] == "active"
+
+
+def _get_rule(client: TestClient, token: str, rule_id: int) -> dict:
+    response = client.get(f"/api/v2/rules/{rule_id}", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    return response.json()
 
 
 def _evaluate(client: TestClient, api_key: str, *, transaction_id: str, event_data: dict) -> dict:
@@ -326,3 +345,353 @@ def test_negative_product_journeys_leave_no_side_effects(session):
             .count()
             == 0
         )
+
+
+def test_permission_grant_and_revoke_controls_rule_authoring(session):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    email = "journey-permissions@example.com"
+    token = _token_with_permissions(
+        session,
+        email=email,
+        permissions=[PermissionAction.VIEW_RULES],
+    )
+    role = session.query(Role).filter(Role.name == f"journey_role_{email}", Role.o_id == int(org.o_id)).one()
+
+    with TestClient(app) as client:
+        forbidden_before_grant = client.post(
+            "/api/v2/rules",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "rid": "JOURNEY_PERMISSION_BEFORE_GRANT",
+                "description": "Role without create permission must not create",
+                "logic": "return !REVIEW",
+                "evaluation_lane": "main",
+            },
+        )
+        assert forbidden_before_grant.status_code == 403
+        assert (
+            session.query(RuleModel)
+            .filter(RuleModel.o_id == int(org.o_id), RuleModel.rid == "JOURNEY_PERMISSION_BEFORE_GRANT")
+            .count()
+            == 0
+        )
+
+        PermissionManager.db_session = session
+        PermissionManager.grant_permission(int(role.id), PermissionAction.CREATE_RULE)
+
+        created_rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_PERMISSION_AFTER_GRANT",
+            description="Role can create after create permission grant",
+            logic="return !REVIEW",
+        )
+        assert (
+            session.query(RuleModel).filter(RuleModel.o_id == int(org.o_id), RuleModel.r_id == created_rule_id).count()
+            == 1
+        )
+
+        PermissionManager.revoke_permission(int(role.id), PermissionAction.CREATE_RULE)
+
+        forbidden_after_revoke = client.post(
+            "/api/v2/rules",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "rid": "JOURNEY_PERMISSION_AFTER_REVOKE",
+                "description": "Role must lose create ability after revoke",
+                "logic": "return !REVIEW",
+                "evaluation_lane": "main",
+            },
+        )
+        assert forbidden_after_revoke.status_code == 403
+        assert (
+            session.query(RuleModel)
+            .filter(RuleModel.o_id == int(org.o_id), RuleModel.rid == "JOURNEY_PERMISSION_AFTER_REVOKE")
+            .count()
+            == 0
+        )
+
+
+def test_rule_edit_requires_promotion_before_serving_new_logic(session, live_api_key):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    token = _manager_token(session, email="journey-edit@example.com")
+
+    with TestClient(app) as client:
+        rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_EDIT_RULE",
+            description="Review high amount before edit",
+            logic="if $amount >= 1000:\n\treturn !REVIEW",
+        )
+        _promote_rule(client, token, rule_id)
+
+        before_edit = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-edit-before",
+            event_data={"amount": 1500},
+        )
+        assert before_edit["resolved_outcome"] == "REVIEW"
+        assert before_edit["rule_results"] == {str(rule_id): "REVIEW"}
+
+        update = client.put(
+            f"/api/v2/rules/{rule_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "description": "Hold high amount after edit",
+                "logic": "if $amount >= 1000:\n\treturn !HOLD",
+            },
+        )
+        assert update.status_code == 200
+        assert update.json()["rule"]["status"] == "draft"
+
+        while_draft = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-edit-draft",
+            event_data={"amount": 1500},
+        )
+        assert while_draft["resolved_outcome"] is None
+        assert while_draft["rule_results"] == {}
+
+        _promote_rule(client, token, rule_id)
+
+        after_promote = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-edit-after",
+            event_data={"amount": 1500},
+        )
+        assert after_promote["resolved_outcome"] == "HOLD"
+        assert after_promote["rule_results"] == {str(rule_id): "HOLD"}
+
+        history = client.get(f"/api/v2/rules/{rule_id}/history", headers={"Authorization": f"Bearer {token}"})
+        assert history.status_code == 200
+        assert [entry["status"] for entry in history.json()["history"]] == ["draft", "active", "draft", "active"]
+
+    actions = [
+        action
+        for (action,) in session.query(RuleHistory.action)
+        .filter(RuleHistory.r_id == rule_id)
+        .order_by(RuleHistory.changed.asc())
+        .all()
+    ]
+    assert actions == ["promoted", "updated", "promoted"]
+
+
+def test_user_list_mutation_changes_rule_serving_and_audit(session, live_api_key):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    token = _manager_token(session, email="journey-lists@example.com")
+
+    with TestClient(app) as client:
+        list_response = client.post(
+            "/api/v2/user-lists",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "JourneyWatchlistCustomers"},
+        )
+        assert list_response.status_code == 201
+        list_id = int(list_response.json()["list"]["id"])
+
+        rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_WATCHLIST_RULE",
+            description="Hold watchlisted customers",
+            logic="if $customer_id in @JourneyWatchlistCustomers:\n\treturn !HOLD",
+        )
+        _promote_rule(client, token, rule_id)
+
+        missing_result = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-list-before-add",
+            event_data={"customer_id": "cust_watch_001"},
+        )
+        assert missing_result["resolved_outcome"] is None
+        assert missing_result["rule_results"] == {}
+
+        entry_response = client.post(
+            f"/api/v2/user-lists/{list_id}/entries",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"value": "cust_watch_001"},
+        )
+        assert entry_response.status_code == 201
+        entry_id = int(entry_response.json()["entry"]["id"])
+
+        listed_result = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-list-hit",
+            event_data={"customer_id": "cust_watch_001"},
+        )
+        assert listed_result["resolved_outcome"] == "HOLD"
+        assert listed_result["rule_results"] == {str(rule_id): "HOLD"}
+
+        delete_entry = client.delete(
+            f"/api/v2/user-lists/{list_id}/entries/{entry_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert delete_entry.status_code == 200
+        assert delete_entry.json()["success"] is True
+
+        removed_result = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-list-miss",
+            event_data={"customer_id": "cust_watch_001"},
+        )
+        assert removed_result["resolved_outcome"] is None
+        assert removed_result["rule_results"] == {}
+
+        audit = client.get(f"/api/v2/audit/user-lists?list_id={list_id}", headers={"Authorization": f"Bearer {token}"})
+        assert audit.status_code == 200
+        assert [item["action"] for item in audit.json()["items"]] == ["entry_removed", "entry_added", "created"]
+
+    history_actions = [
+        action
+        for (action,) in session.query(UserListHistory.action)
+        .filter(UserListHistory.ul_id == list_id)
+        .order_by(UserListHistory.changed.asc())
+        .all()
+    ]
+    assert history_actions == ["created", "entry_added", "entry_removed"]
+    remaining_entries = session.query(UserListEntry).filter(UserListEntry.ul_id == list_id).count()
+    assert remaining_entries == 0
+
+
+def test_label_rule_quality_and_audit_journey(session, live_api_key):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    token = _manager_token(session, email="journey-quality@example.com")
+
+    with TestClient(app) as client:
+        rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_QUALITY_RULE",
+            description="Hold risky quality events",
+            logic="if $risk_score >= 80:\n\treturn !HOLD",
+        )
+        _promote_rule(client, token, rule_id)
+
+        label_response = client.post(
+            "/api/v2/labels",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"label_name": "journey_fraud"},
+        )
+        assert label_response.status_code == 201
+        label_name = label_response.json()["label"]["label"]
+
+        session.add(
+            RuleQualityPair(
+                outcome="HOLD",
+                label=label_name,
+                active=True,
+                created_by="journey-quality@example.com",
+                o_id=int(org.o_id),
+            )
+        )
+        session.commit()
+
+        for index, risk_score in enumerate((95, 88)):
+            transaction_id = f"journey-quality-fraud-{index}"
+            evaluated = _evaluate(
+                client,
+                live_api_key,
+                transaction_id=transaction_id,
+                event_data={"risk_score": risk_score},
+            )
+            assert evaluated["resolved_outcome"] == "HOLD"
+            mark = client.post(
+                "/api/v2/labels/mark-event",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"transaction_id": transaction_id, "label_name": label_name},
+            )
+            assert mark.status_code == 200
+            assert mark.json()["success"] is True
+
+        quality = client.get("/api/v2/analytics/rule-quality", headers={"Authorization": f"Bearer {token}"})
+        assert quality.status_code == 200
+        quality_payload = quality.json()
+        assert quality_payload["total_labeled_events"] == 2
+        metric = next(
+            item
+            for item in quality_payload["pair_metrics"]
+            if item["r_id"] == rule_id and item["outcome"] == "HOLD" and item["label"] == label_name
+        )
+        assert metric["true_positive"] == 2
+        assert metric["false_positive"] == 0
+        assert metric["false_negative"] == 0
+        assert metric["precision"] == pytest.approx(1.0)
+        assert metric["recall"] == pytest.approx(1.0)
+        assert metric["f1"] == pytest.approx(1.0)
+
+        label_audit = client.get("/api/v2/audit/labels", headers={"Authorization": f"Bearer {token}"})
+        assert label_audit.status_code == 200
+        assert [item["action"] for item in label_audit.json()["items"][:3]] == ["assigned", "assigned", "created"]
+
+    label = session.query(Label).filter(Label.o_id == int(org.o_id), Label.label == label_name).one()
+    labeled_event_count = (
+        session.query(EventVersionLabel)
+        .filter(EventVersionLabel.o_id == int(org.o_id), EventVersionLabel.el_id == label.el_id)
+        .count()
+    )
+    assert labeled_event_count == 2
+
+
+def test_rollout_candidate_logs_provenance_without_changing_control_rule(session, live_api_key):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    token = _manager_token(session, email="journey-rollout@example.com")
+
+    with TestClient(app) as client:
+        rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_ROLLOUT_RULE",
+            description="Control review rule",
+            logic="if $amount >= 1000:\n\treturn !REVIEW",
+        )
+        _promote_rule(client, token, rule_id)
+
+        deploy = client.post(
+            f"/api/v2/rules/{rule_id}/rollout",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "logic": "if $amount >= 1000:\n\treturn !HOLD",
+                "description": "Candidate hold rule",
+                "traffic_percent": 100,
+            },
+        )
+        assert deploy.status_code == 200
+        assert deploy.json()["success"] is True
+
+        served = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-rollout-served",
+            event_data={"amount": 1500},
+        )
+        assert served["resolved_outcome"] == "HOLD"
+        assert served["rule_results"] == {str(rule_id): "HOLD"}
+
+        current_rule = _get_rule(client, token, rule_id)
+        assert current_rule["logic"] == "if $amount >= 1000:\n\treturn !REVIEW"
+
+    log = (
+        session.query(RuleDeploymentResultsLog)
+        .filter(
+            RuleDeploymentResultsLog.ed_id == int(served["evaluation_id"]), RuleDeploymentResultsLog.r_id == rule_id
+        )
+        .one()
+    )
+    assert log.mode == "split"
+    assert log.selected_variant == "candidate"
+    assert log.traffic_percent == 100
+    assert log.control_result == "REVIEW"
+    assert log.candidate_result == "HOLD"
+    assert log.returned_result == "HOLD"

--- a/tests/business_scenarios/test_product_journeys.py
+++ b/tests/business_scenarios/test_product_journeys.py
@@ -1,0 +1,328 @@
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.api_v2.routes import evaluator as evaluator_router
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import (
+    AllowedOutcome,
+    EvaluationDecision,
+    EvaluationRuleResult,
+    EventVersion,
+    Organisation,
+    Role,
+    RuleHistory,
+    User,
+)
+from ezrules.models.backend_core import Rule as RuleModel
+
+
+BUSINESS_OUTCOMES = ("CANCEL", "HOLD", "REVIEW", "RELEASE")
+
+
+@pytest.fixture(autouse=True)
+def reset_evaluator_executors():
+    evaluator_router._lre = None
+    evaluator_router._shadow_lre = None
+    evaluator_router._allowlist_lre = None
+    yield
+    evaluator_router._lre = None
+    evaluator_router._shadow_lre = None
+    evaluator_router._allowlist_lre = None
+
+
+def _seed_business_outcomes(session, *, org_id: int) -> None:
+    session.query(AllowedOutcome).filter(AllowedOutcome.o_id == org_id).delete(synchronize_session=False)
+    for severity_rank, outcome_name in enumerate(BUSINESS_OUTCOMES, start=1):
+        session.add(AllowedOutcome(outcome_name=outcome_name, severity_rank=severity_rank, o_id=org_id))
+    session.commit()
+
+
+def _token_with_permissions(session, *, email: str, permissions: list[PermissionAction]) -> str:
+    org = session.query(Organisation).one()
+    role = Role(name=f"journey_role_{email}", description="Product journey role", o_id=int(org.o_id))
+    user = User(
+        email=email,
+        password=bcrypt.hashpw("journeypass".encode("utf-8"), bcrypt.gensalt()).decode("utf-8"),
+        active=True,
+        fs_uniquifier=email,
+        o_id=int(org.o_id),
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    for permission in permissions:
+        PermissionManager.grant_permission(int(role.id), permission)
+
+    return create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[str(role.name)],
+        org_id=int(user.o_id),
+    )
+
+
+def _manager_token(session, *, email: str = "journey-manager@example.com") -> str:
+    return _token_with_permissions(
+        session,
+        email=email,
+        permissions=[
+            PermissionAction.VIEW_RULES,
+            PermissionAction.CREATE_RULE,
+            PermissionAction.MODIFY_RULE,
+            PermissionAction.PROMOTE_RULES,
+            PermissionAction.PAUSE_RULES,
+            PermissionAction.DELETE_RULE,
+            PermissionAction.SUBMIT_TEST_EVENTS,
+        ],
+    )
+
+
+def _create_rule(client: TestClient, token: str, *, rid: str, logic: str, description: str) -> int:
+    response = client.post(
+        "/api/v2/rules",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rid": rid,
+            "description": description,
+            "logic": logic,
+            "evaluation_lane": "main",
+        },
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["rule"]["status"] == "draft"
+    return int(payload["rule"]["r_id"])
+
+
+def _promote_rule(client: TestClient, token: str, rule_id: int) -> None:
+    response = client.post(f"/api/v2/rules/{rule_id}/promote", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["rule"]["status"] == "active"
+
+
+def _evaluate(client: TestClient, api_key: str, *, transaction_id: str, event_data: dict) -> dict:
+    response = client.post(
+        "/api/v2/evaluate",
+        headers={"X-API-Key": api_key},
+        json={
+            "transaction_id": transaction_id,
+            "effective_at": 1710000000,
+            "event_data": event_data,
+        },
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def test_rule_authoring_to_served_decision_product_journey(session, live_api_key):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    token = _manager_token(session)
+    transaction_id = "journey-author-promote-evaluate"
+
+    with TestClient(app) as client:
+        rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_AMOUNT_REVIEW",
+            description="Review high-value product journey events",
+            logic="if $amount >= 1000:\n\treturn !REVIEW",
+        )
+        _promote_rule(client, token, rule_id)
+
+        dry_run = client.post(
+            "/api/v2/event-tests",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "transaction_id": "journey-dry-run",
+                "effective_at": 1710000000,
+                "event_data": {"amount": 1500, "country": "GB"},
+            },
+        )
+        assert dry_run.status_code == 200
+        dry_run_payload = dry_run.json()
+        assert dry_run_payload["dry_run"] is True
+        assert dry_run_payload["resolved_outcome"] == "REVIEW"
+        assert dry_run_payload["event_version"] is None
+        assert dry_run_payload["evaluation_id"] is None
+        assert session.query(EventVersion).filter(EventVersion.transaction_id == "journey-dry-run").count() == 0
+
+        served = _evaluate(
+            client,
+            live_api_key,
+            transaction_id=transaction_id,
+            event_data={"amount": 1500, "country": "GB"},
+        )
+        assert served["resolved_outcome"] == "REVIEW"
+        assert served["rule_results"] == {str(rule_id): "REVIEW"}
+
+        tested_events = client.get(
+            "/api/v2/tested-events?limit=200&include_referenced_fields=true",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert tested_events.status_code == 200
+        served_event = next(
+            event for event in tested_events.json()["events"] if event["transaction_id"] == transaction_id
+        )
+        assert served_event["resolved_outcome"] == "REVIEW"
+        assert served_event["event_data"] == {"amount": 1500, "country": "GB"}
+        assert served_event["triggered_rules"] == [
+            {
+                "r_id": rule_id,
+                "rid": "JOURNEY_AMOUNT_REVIEW",
+                "description": "Review high-value product journey events",
+                "outcome": "REVIEW",
+                "referenced_fields": ["amount"],
+            }
+        ]
+
+        history = client.get(f"/api/v2/rules/{rule_id}/history", headers={"Authorization": f"Bearer {token}"})
+        assert history.status_code == 200
+        assert history.json()["history"][-1]["status"] == "active"
+
+    decision = session.query(EvaluationDecision).filter(EvaluationDecision.transaction_id == transaction_id).one()
+    assert decision.resolved_outcome == "REVIEW"
+    assert decision.outcome_counters == {"REVIEW": 1}
+    stored_results = session.query(EvaluationRuleResult).filter(EvaluationRuleResult.ed_id == decision.ed_id).all()
+    assert [(int(result.r_id), str(result.rule_result)) for result in stored_results] == [(rule_id, "REVIEW")]
+    rule_history = session.query(RuleHistory).filter(RuleHistory.r_id == rule_id).one()
+    assert rule_history.action == "promoted"
+    assert rule_history.changed_by == "journey-manager@example.com"
+
+
+def test_pause_resume_rule_lifecycle_changes_live_serving(session, live_api_key):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    token = _manager_token(session, email="journey-lifecycle@example.com")
+
+    with TestClient(app) as client:
+        rule_id = _create_rule(
+            client,
+            token,
+            rid="JOURNEY_DEVICE_HOLD",
+            description="Hold low-trust device journey events",
+            logic="if $device_trust_score <= 20:\n\treturn !HOLD",
+        )
+        _promote_rule(client, token, rule_id)
+
+        active_result = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-lifecycle-active",
+            event_data={"device_trust_score": 5},
+        )
+        assert active_result["resolved_outcome"] == "HOLD"
+        assert active_result["rule_results"] == {str(rule_id): "HOLD"}
+
+        pause = client.post(f"/api/v2/rules/{rule_id}/pause", headers={"Authorization": f"Bearer {token}"})
+        assert pause.status_code == 200
+        assert pause.json()["rule"]["status"] == "paused"
+
+        paused_result = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-lifecycle-paused",
+            event_data={"device_trust_score": 5},
+        )
+        assert paused_result["resolved_outcome"] is None
+        assert paused_result["outcome_counters"] == {}
+        assert paused_result["rule_results"] == {}
+
+        resume = client.post(f"/api/v2/rules/{rule_id}/resume", headers={"Authorization": f"Bearer {token}"})
+        assert resume.status_code == 200
+        assert resume.json()["rule"]["status"] == "active"
+
+        resumed_result = _evaluate(
+            client,
+            live_api_key,
+            transaction_id="journey-lifecycle-resumed",
+            event_data={"device_trust_score": 5},
+        )
+        assert resumed_result["resolved_outcome"] == "HOLD"
+        assert resumed_result["rule_results"] == {str(rule_id): "HOLD"}
+
+    actions = [
+        action
+        for (action,) in session.query(RuleHistory.action)
+        .filter(RuleHistory.r_id == rule_id)
+        .order_by(RuleHistory.changed.asc())
+        .all()
+    ]
+    assert actions == ["promoted", "paused", "resumed"]
+
+
+def test_negative_product_journeys_leave_no_side_effects(session):
+    org = session.query(Organisation).one()
+    _seed_business_outcomes(session, org_id=int(org.o_id))
+    manager_token = _manager_token(session, email="journey-negative-manager@example.com")
+    viewer_token = _token_with_permissions(
+        session,
+        email="journey-negative-viewer@example.com",
+        permissions=[PermissionAction.VIEW_RULES],
+    )
+
+    with TestClient(app) as client:
+        invalid_allowlist = client.post(
+            "/api/v2/rules",
+            headers={"Authorization": f"Bearer {manager_token}"},
+            json={
+                "rid": "JOURNEY_BAD_ALLOWLIST",
+                "description": "Invalid allowlist should not persist",
+                "logic": "if $customer_id == 'trusted':\n\treturn !HOLD",
+                "evaluation_lane": "allowlist",
+            },
+        )
+        assert invalid_allowlist.status_code == 201
+        assert invalid_allowlist.json()["success"] is False
+        assert (
+            session.query(RuleModel)
+            .filter(RuleModel.o_id == int(org.o_id), RuleModel.rid == "JOURNEY_BAD_ALLOWLIST")
+            .count()
+            == 0
+        )
+
+        forbidden_create = client.post(
+            "/api/v2/rules",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+            json={
+                "rid": "JOURNEY_FORBIDDEN_CREATE",
+                "description": "Viewer must not create rules",
+                "logic": "return !REVIEW",
+                "evaluation_lane": "main",
+            },
+        )
+        assert forbidden_create.status_code == 403
+        assert (
+            session.query(RuleModel)
+            .filter(RuleModel.o_id == int(org.o_id), RuleModel.rid == "JOURNEY_FORBIDDEN_CREATE")
+            .count()
+            == 0
+        )
+
+        invalid_key_eval = client.post(
+            "/api/v2/evaluate",
+            headers={"X-API-Key": "ezrk_invalid"},
+            json={
+                "transaction_id": "journey-invalid-api-key",
+                "effective_at": 1710000000,
+                "event_data": {"amount": 1500},
+            },
+        )
+        assert invalid_key_eval.status_code == 401
+        assert session.query(EventVersion).filter(EventVersion.transaction_id == "journey-invalid-api-key").count() == 0
+        assert (
+            session.query(EvaluationDecision)
+            .filter(EvaluationDecision.transaction_id == "journey-invalid-api-key")
+            .count()
+            == 0
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.21.0"
+version = "1.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Add a versioned YAML canonical evaluation universe with deterministic outcomes, user lists, rules, and business scenarios.
- Add a pytest harness that exercises /api/v2/evaluate through the real FastAPI + PostgreSQL path and asserts API responses, persisted rule results, duplicate handling, supersession, first-match behavior, and allowlist short-circuiting.
- Add deterministic product journeys for rule authoring through served decisions, dry-run isolation, Tested Events explainability, pause/resume serving changes, and no-side-effect negative paths.
- Extend product journey coverage for permission grant/revoke behavior, rule edit re-promotion semantics, user-list membership mutation, label-backed rule-quality analytics, audit trail reads, and rollout candidate provenance.
- Add an agentic exploration prompt library with 20 product charters, shared run/report contracts, personas, and seed payloads for on-demand browser-agent free testing.
- Add a dedicated Business Journey Contract GitHub Actions workflow for PR/main checks.
- Bump the package to v1.21.1 and add the matching what's-new entry so the existing PyPI version guard can pass.

## Verification
- uv run poe check
- uv run mkdocs build --strict
- EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_more_journeys_retry_<timestamp> EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 uv run pytest -q tests/business_scenarios
- EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_more_journeys_full_<timestamp> EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 uv run pytest -q --cov=ezrules.backend --cov=ezrules.core --cov-report=xml tests

Do not merge until required status checks are green.