### PR TITLE
Add user-list versioning

### DIFF
--- a/alembic/versions/20260522_0030_user_list_versions.py
+++ b/alembic/versions/20260522_0030_user_list_versions.py
@@ -1,0 +1,32 @@
+"""Add user-list version records.
+
+Revision ID: 20260522_0030
+Revises: 20260506_0029
+Create Date: 2026-05-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260522_0030"
+down_revision: str | None = "20260506_0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_list_versions",
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("o_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_list_versions")

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,9 @@
 # What's New
 
+## v1.22.1
+
+* **User-list version records**: Added an org-scoped user-list version table that advances in the same transaction as successful list and entry mutations, giving the user-list domain a deterministic runtime version signal separate from audit history.
+
 ## v1.22.0
 
 * **Computed feature registry**: Added org-scoped feature definitions for history-aware rule inputs such as velocity counts, distinct counts, sums, averages, min/max, standard deviation, and days since first seen.

--- a/ezrules/backend/api_v2/routes/user_lists.py
+++ b/ezrules/backend/api_v2/routes/user_lists.py
@@ -31,6 +31,7 @@ from ezrules.backend.api_v2.schemas.user_lists import (
 )
 from ezrules.core.audit_helpers import save_user_list_history
 from ezrules.core.permissions_constants import PermissionAction
+from ezrules.core.user_lists import bump_user_list_version
 from ezrules.models.backend_core import User, UserList, UserListEntry
 
 router = APIRouter(prefix="/api/v2/user-lists", tags=["User Lists"])
@@ -189,8 +190,7 @@ def create_user_list(
     )
 
     db.add(new_list)
-    db.commit()
-    db.refresh(new_list)
+    db.flush()
 
     save_user_list_history(
         db,
@@ -200,7 +200,9 @@ def create_user_list(
         o_id=current_org_id,
         changed_by=str(user.email) if user.email else None,
     )
+    bump_user_list_version(db, current_org_id)
     db.commit()
+    db.refresh(new_list)
 
     return UserListMutationResponse(
         success=True,
@@ -244,7 +246,7 @@ def update_user_list(
         )
 
     # Check if new name already exists
-    if list_data.name is not None:
+    if list_data.name is not None and list_data.name != user_list.list_name:
         existing = (
             db.query(UserList)
             .filter(
@@ -274,6 +276,8 @@ def update_user_list(
             changed_by=str(user.email) if user.email else None,
             details=f"Renamed from '{old_name}' to '{list_data.name}'",
         )
+
+        bump_user_list_version(db, current_org_id)
 
     db.commit()
     db.refresh(user_list)
@@ -333,6 +337,7 @@ def delete_user_list(
 
     # Entries will be cascade deleted due to relationship configuration
     db.delete(user_list)
+    bump_user_list_version(db, current_org_id)
     db.commit()
 
     return UserListMutationResponse(
@@ -447,6 +452,7 @@ def add_entry(
         details=f"Added entry '{entry_data.value}'",
     )
 
+    bump_user_list_version(db, current_org_id)
     db.commit()
     db.refresh(new_entry)
 
@@ -526,6 +532,7 @@ def bulk_add_entries(
             changed_by=str(user.email) if user.email else None,
             details=f"Added {len(added)} entries, skipped {len(skipped)}",
         )
+        bump_user_list_version(db, current_org_id)
 
     db.commit()
 
@@ -601,6 +608,7 @@ def delete_entry(
     )
 
     db.delete(entry)
+    bump_user_list_version(db, current_org_id)
     db.commit()
 
     return UserListEntryMutationResponse(

--- a/ezrules/cli.py
+++ b/ezrules/cli.py
@@ -25,7 +25,7 @@ from ezrules.core.rule_updater import (
     RuleManager,
     RuleManagerFactory,
 )
-from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.core.user_lists import PersistentUserListManager, ensure_user_list_version
 from ezrules.demo_data import build_demo_events, build_demo_rules, determine_demo_label, seed_demo_user_lists
 from ezrules.models.backend_core import (
     AllowedOutcome,
@@ -189,6 +189,8 @@ def _bootstrap_organisation(session, *, org_name: str) -> tuple[Organisation, bo
 
     user_list_manager = PersistentUserListManager(db_session=session, o_id=organization_id)
     user_list_manager._ensure_default_lists()
+    ensure_user_list_version(session, organization_id)
+    session.commit()
     return organization, created
 
 

--- a/ezrules/core/user_lists.py
+++ b/ezrules/core/user_lists.py
@@ -1,4 +1,38 @@
 import abc
+import datetime
+
+from sqlalchemy import update
+from sqlalchemy.dialects.postgresql import insert
+
+
+def ensure_user_list_version(db_session, o_id: int):
+    """Ensure the org has a user-list version row without changing its version."""
+    from ezrules.models.backend_core import UserListVersion
+
+    now = datetime.datetime.now(datetime.UTC)
+    stmt = (
+        insert(UserListVersion)
+        .values(o_id=o_id, version=0, updated_at=now)
+        .on_conflict_do_nothing(index_elements=["o_id"])
+    )
+    db_session.execute(stmt)
+    db_session.flush()
+    return db_session.query(UserListVersion).filter(UserListVersion.o_id == o_id).one()
+
+
+def bump_user_list_version(db_session, o_id: int) -> int:
+    """Increment the org user-list version in the caller's current transaction."""
+    from ezrules.models.backend_core import UserListVersion
+
+    ensure_user_list_version(db_session, o_id)
+    now = datetime.datetime.now(datetime.UTC)
+    stmt = (
+        update(UserListVersion)
+        .where(UserListVersion.o_id == o_id)
+        .values(version=UserListVersion.version + 1, updated_at=now)
+        .returning(UserListVersion.version)
+    )
+    return int(db_session.execute(stmt).scalar_one())
 
 
 class AbstractUserListManager(abc.ABC):
@@ -127,7 +161,10 @@ class PersistentUserListManager(AbstractUserListManager):
                     entry = UserListEntry(entry_value=entry_value, ul_id=user_list.ul_id)
                     self.db_session.add(entry)
 
+            bump_user_list_version(self.db_session, self.o_id)
             self.db_session.commit()
+        else:
+            ensure_user_list_version(self.db_session, self.o_id)
 
     def _ensure_initialized(self):
         """Ensure the database has been initialized with default lists"""
@@ -172,11 +209,13 @@ class PersistentUserListManager(AbstractUserListManager):
         # Find the list
         user_list = self.db_session.query(UserList).filter_by(list_name=list_name, o_id=self.o_id).first()
 
+        list_created = False
         if not user_list:
             # Create new list if it doesn't exist
             user_list = UserList(list_name=list_name, o_id=self.o_id)
             self.db_session.add(user_list)
             self.db_session.flush()  # Ensure we have the ID
+            list_created = True
 
         # Check if entry already exists
         existing_entry = (
@@ -186,8 +225,13 @@ class PersistentUserListManager(AbstractUserListManager):
         if not existing_entry:
             entry = UserListEntry(entry_value=new_entry, ul_id=user_list.ul_id)
             self.db_session.add(entry)
+            bump_user_list_version(self.db_session, self.o_id)
             self.db_session.commit()
             # Invalidate cache to force reload
+            self._cached_lists = None
+        elif list_created:
+            bump_user_list_version(self.db_session, self.o_id)
+            self.db_session.commit()
             self._cached_lists = None
 
     def remove_entry(self, list_name, entry_value):
@@ -206,6 +250,7 @@ class PersistentUserListManager(AbstractUserListManager):
 
         if entry:
             self.db_session.delete(entry)
+            bump_user_list_version(self.db_session, self.o_id)
             self.db_session.commit()
             # Invalidate cache to force reload
             self._cached_lists = None
@@ -223,6 +268,7 @@ class PersistentUserListManager(AbstractUserListManager):
 
         user_list = UserList(list_name=list_name, o_id=self.o_id)
         self.db_session.add(user_list)
+        bump_user_list_version(self.db_session, self.o_id)
         self.db_session.commit()
         # Invalidate cache to force reload
         self._cached_lists = None
@@ -239,6 +285,7 @@ class PersistentUserListManager(AbstractUserListManager):
 
         # Due to cascade delete, entries will be automatically deleted
         self.db_session.delete(user_list)
+        bump_user_list_version(self.db_session, self.o_id)
         self.db_session.commit()
         # Invalidate cache to force reload
         self._cached_lists = None

--- a/ezrules/demo_data.py
+++ b/ezrules/demo_data.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from ezrules.core.field_paths import get_field_value
-from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.core.user_lists import PersistentUserListManager, bump_user_list_version
 from ezrules.models.backend_core import UserList, UserListEntry
 
 type DemoScalar = str | int | float
@@ -171,6 +171,7 @@ def seed_demo_user_lists(list_manager: PersistentUserListManager) -> None:
                 current_entries.add(entry)
                 changed = True
     if changed:
+        bump_user_list_version(db_session, list_manager.o_id)
         db_session.commit()
         list_manager._cached_lists = None
 

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -711,6 +711,19 @@ class UserList(Base):
         return f"{self.ul_id=},{self.list_name=},{self.o_id=}"
 
 
+class UserListVersion(Base):
+    __tablename__ = "user_list_versions"
+
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id", ondelete="CASCADE"), primary_key=True)
+    version = Column(Integer, nullable=False, default=0)
+    updated_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+
+    org: Mapped["Organisation"] = relationship()
+
+    def __repr__(self) -> str:
+        return f"{self.o_id=},{self.version=},{self.updated_at=}"
+
+
 class UserListEntry(Base):
     __tablename__ = "user_list_entries"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.22.0"
+version = "1.22.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_user_list_versions.py
+++ b/tests/test_user_list_versions.py
@@ -1,0 +1,244 @@
+"""Tests for org-scoped user-list version records."""
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from ezrules import cli as cli_module
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.demo_data import seed_demo_user_lists
+from ezrules.models.backend_core import Role, User, UserList, UserListEntry, UserListHistory, UserListVersion
+
+
+@pytest.fixture(scope="function")
+def user_list_version_client(session):
+    """Create a FastAPI test client with list-management permissions."""
+    hashed_password = bcrypt.hashpw("versionadmin".encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    admin_role = Role(name="version_list_admin", description="Can manage versioned lists", o_id=1)
+    session.add(admin_role)
+    session.commit()
+
+    admin_user = User(
+        email="version-list-admin@example.com",
+        password=hashed_password,
+        active=True,
+        fs_uniquifier="version-list-admin@example.com",
+        o_id=1,
+    )
+    admin_user.roles.append(admin_role)
+    session.add(admin_user)
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    PermissionManager.grant_permission(admin_role.id, PermissionAction.VIEW_LISTS)
+    PermissionManager.grant_permission(admin_role.id, PermissionAction.CREATE_LIST)
+    PermissionManager.grant_permission(admin_role.id, PermissionAction.MODIFY_LIST)
+    PermissionManager.grant_permission(admin_role.id, PermissionAction.DELETE_LIST)
+
+    token = create_access_token(
+        user_id=int(admin_user.id),
+        email=str(admin_user.email),
+        roles=[str(admin_role.name)],
+        org_id=int(admin_user.o_id),
+    )
+
+    with TestClient(app) as client:
+        client.test_data = {"token": token}  # type: ignore[attr-defined]
+        yield client
+
+
+def _auth_headers(client) -> dict[str, str]:
+    return {"Authorization": f"Bearer {client.test_data['token']}"}
+
+
+def _version(session, org_id: int = 1) -> int | None:
+    session.expire_all()
+    version = session.get(UserListVersion, org_id)
+    return None if version is None else int(version.version)
+
+
+def _create_user_list(session, *, name: str = "VersionedCountries", org_id: int = 1) -> UserList:
+    user_list = UserList(list_name=name, o_id=org_id)
+    session.add(user_list)
+    session.commit()
+    return user_list
+
+
+def _create_entry(session, user_list: UserList, value: str) -> UserListEntry:
+    entry = UserListEntry(entry_value=value, ul_id=int(user_list.ul_id))
+    session.add(entry)
+    session.commit()
+    return entry
+
+
+def test_bootstrap_organisation_creates_user_list_version_row(session):
+    organisation, created = cli_module._bootstrap_organisation(session, org_name="versioned-org")
+
+    assert created is True
+    version = session.get(UserListVersion, int(organisation.o_id))
+    assert version is not None
+    assert int(version.version) == 1
+
+
+def test_api_list_create_rename_delete_increment_version(user_list_version_client, session):
+    headers = _auth_headers(user_list_version_client)
+
+    create_response = user_list_version_client.post(
+        "/api/v2/user-lists",
+        headers=headers,
+        json={"name": "LifecycleCountries"},
+    )
+    assert create_response.status_code == 201
+    assert create_response.json()["success"] is True
+    assert _version(session) == 1
+
+    list_id = create_response.json()["list"]["id"]
+    rename_response = user_list_version_client.put(
+        f"/api/v2/user-lists/{list_id}",
+        headers=headers,
+        json={"name": "RenamedLifecycleCountries"},
+    )
+    assert rename_response.status_code == 200
+    assert rename_response.json()["success"] is True
+    assert _version(session) == 2
+
+    delete_response = user_list_version_client.delete(f"/api/v2/user-lists/{list_id}", headers=headers)
+    assert delete_response.status_code == 200
+    assert delete_response.json()["success"] is True
+    assert _version(session) == 3
+    assert session.query(UserListHistory).filter(UserListHistory.o_id == 1).count() == 3
+
+
+def test_api_entry_mutations_increment_only_when_entries_change(user_list_version_client, session):
+    headers = _auth_headers(user_list_version_client)
+    create_response = user_list_version_client.post(
+        "/api/v2/user-lists",
+        headers=headers,
+        json={"name": "EntryCountries"},
+    )
+    list_id = create_response.json()["list"]["id"]
+    assert _version(session) == 1
+
+    add_response = user_list_version_client.post(
+        f"/api/v2/user-lists/{list_id}/entries",
+        headers=headers,
+        json={"value": "US"},
+    )
+    assert add_response.status_code == 201
+    assert add_response.json()["success"] is True
+    assert _version(session) == 2
+
+    duplicate_response = user_list_version_client.post(
+        f"/api/v2/user-lists/{list_id}/entries",
+        headers=headers,
+        json={"value": "US"},
+    )
+    assert duplicate_response.status_code == 201
+    assert duplicate_response.json()["success"] is False
+    assert _version(session) == 2
+
+    bulk_response = user_list_version_client.post(
+        f"/api/v2/user-lists/{list_id}/entries/bulk",
+        headers=headers,
+        json={"values": ["US", "CA", "MX"]},
+    )
+    assert bulk_response.status_code == 201
+    assert bulk_response.json()["added"] == ["CA", "MX"]
+    assert bulk_response.json()["skipped"] == ["US"]
+    assert _version(session) == 3
+
+    duplicate_bulk_response = user_list_version_client.post(
+        f"/api/v2/user-lists/{list_id}/entries/bulk",
+        headers=headers,
+        json={"values": ["US", "CA"]},
+    )
+    assert duplicate_bulk_response.status_code == 201
+    assert duplicate_bulk_response.json()["added"] == []
+    assert _version(session) == 3
+
+    entry = session.query(UserListEntry).filter(UserListEntry.ul_id == list_id, UserListEntry.entry_value == "CA").one()
+    delete_response = user_list_version_client.delete(
+        f"/api/v2/user-lists/{list_id}/entries/{entry.ule_id}",
+        headers=headers,
+    )
+    assert delete_response.status_code == 200
+    assert delete_response.json()["success"] is True
+    assert _version(session) == 4
+
+
+def test_api_failed_and_no_op_list_mutations_do_not_increment(user_list_version_client, session):
+    headers = _auth_headers(user_list_version_client)
+    user_list = _create_user_list(session, name="ExistingCountries")
+
+    duplicate_response = user_list_version_client.post(
+        "/api/v2/user-lists",
+        headers=headers,
+        json={"name": "ExistingCountries"},
+    )
+    assert duplicate_response.status_code == 201
+    assert duplicate_response.json()["success"] is False
+    assert _version(session) is None
+
+    validation_response = user_list_version_client.post(
+        "/api/v2/user-lists",
+        headers=headers,
+        json={"name": ""},
+    )
+    assert validation_response.status_code == 422
+    assert _version(session) is None
+
+    same_name_response = user_list_version_client.put(
+        f"/api/v2/user-lists/{user_list.ul_id}",
+        headers=headers,
+        json={"name": "ExistingCountries"},
+    )
+    assert same_name_response.status_code == 200
+    assert same_name_response.json()["success"] is True
+    assert _version(session) is None
+
+    missing_delete_response = user_list_version_client.delete("/api/v2/user-lists/99999", headers=headers)
+    assert missing_delete_response.status_code == 404
+    assert _version(session) is None
+
+
+def test_persistent_manager_mutations_increment_version(session):
+    manager = PersistentUserListManager(db_session=session, o_id=1)
+    manager._ensure_initialized()
+    base_version = _version(session)
+    assert base_version == 1
+
+    manager.create_list("ManagerCountries")
+    assert _version(session) == base_version + 1
+
+    manager.add_entry("ManagerCountries", "GB")
+    assert _version(session) == base_version + 2
+
+    manager.add_entry("ManagerCountries", "GB")
+    assert _version(session) == base_version + 2
+
+    manager.remove_entry("ManagerCountries", "GB")
+    assert _version(session) == base_version + 3
+
+    manager.remove_entry("ManagerCountries", "GB")
+    assert _version(session) == base_version + 3
+
+    manager.delete_list("ManagerCountries")
+    assert _version(session) == base_version + 4
+
+
+def test_demo_user_list_seeding_increments_only_when_seed_data_changes(session):
+    manager = PersistentUserListManager(db_session=session, o_id=1)
+    manager._ensure_initialized()
+    base_version = _version(session)
+    assert base_version == 1
+
+    seed_demo_user_lists(manager)
+    assert _version(session) == base_version + 1
+
+    seed_demo_user_lists(manager)
+    assert _version(session) == base_version + 1

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.22.0"
+version = "1.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Adds explicit org-scoped user-list version records as the durable runtime/domain version signal for user-list state.

## Changes

- Add `user_list_versions` with `o_id`, `version`, and `updated_at`.
- Add shared helpers to ensure and bump the version row in the caller's active transaction.
- Increment versions for successful list and entry mutations through API routes, `PersistentUserListManager`, org bootstrap/default list setup, and demo user-list seeding.
- Keep audit history separate from versioning; `user_list_history` remains audit history only.
- Add live-DB regression coverage for successful mutations and no-op/failure cases.
- Bump package version to `1.22.1` and update `docs/whatsnew.md`.

## Validation

- `uv run pytest -q tests/test_user_list_versions.py`
- `uv run pytest -q tests/test_user_list_versions.py tests/test_api_v2_user_lists.py tests/test_cli_organisation_bootstrap.py tests/test_user_lists.py`
- `uv run poe check`
- `uv run mkdocs build --strict`
- `uv run alembic heads`