### PR TITLE
Publish immutable containers from main merges

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract project version
+        id: project_version
+        run: |
+          version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -38,6 +44,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
           tags: |
             type=sha,prefix=sha-
+            type=raw,value=${{ steps.project_version.outputs.version }}
+            type=raw,value=v${{ steps.project_version.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Extract frontend image metadata
@@ -47,6 +55,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
           tags: |
             type=sha,prefix=sha-
+            type=raw,value=${{ steps.project_version.outputs.version }}
+            type=raw,value=v${{ steps.project_version.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push API image

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -45,7 +45,6 @@ jobs:
           tags: |
             type=sha,prefix=sha-
             type=raw,value=${{ steps.project_version.outputs.version }}
-            type=raw,value=v${{ steps.project_version.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Extract frontend image metadata
@@ -56,7 +55,6 @@ jobs:
           tags: |
             type=sha,prefix=sha-
             type=raw,value=${{ steps.project_version.outputs.version }}
-            type=raw,value=v${{ steps.project_version.outputs.version }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push API image

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -1,0 +1,74 @@
+name: Publish Container Images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE_NAME: ${{ github.repository_owner }}/ezrules-api
+  FRONTEND_IMAGE_NAME: ${{ github.repository_owner }}/ezrules-frontend
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract API image metadata
+        id: api_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Extract frontend image metadata
+        id: frontend_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.api_meta.outputs.tags }}
+          labels: ${{ steps.api_meta.outputs.labels }}
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.frontend
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.frontend_meta.outputs.tags }}
+          labels: ${{ steps.frontend_meta.outputs.labels }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.23.0"
+version = "1.23.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.23.0"
+version = "1.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Main branch deployment needs registry artifacts that can be consumed by private infrastructure without copying source onto hosts. This workflow builds the API and frontend Dockerfiles in GitHub Actions and publishes linux/amd64 images to GHCR using the built-in GITHUB_TOKEN.

Constraint: Public app repository should not contain deployment secrets or DigitalOcean access.

Rejected: Deploy directly from this workflow | production credentials belong in the private ezrules-saas repo.

Rejected: Build images on the Droplet | mutable host builds make rollback and audit weaker.

Confidence: high

Scope-risk: narrow

Directive: Keep runtime deployment and secret injection outside this public workflow.

Tested: uv run poe check; YAML parsed with PyYAML

Not-tested: GitHub Actions push to GHCR before merge