### PR TITLE
Resolve computed stats during rule backtests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ output/playwright
 CLAUDE.md
 
 .omx
+.omc
 artifacts
 
 package/

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,9 @@
 # What's New
 
+## v1.24.2
+
+* **Backtest stat resolution**: Rule backtests now resolve `stat[...]` computed features as of each historical event's `effective_at`, matching live evaluation semantics and excluding future data from feature windows.
+
 ## v1.24.1
 
 * **Agent local stack scripts**: Added `scripts/start-agent-stack.sh`, `scripts/verify-stack.sh`, and `scripts/stop-agent-stack.sh` to pick correlated API/frontend ports, write `.env.agent-stack`, reset a private database, and verify browser login topology plus a form-encoded login smoke test.

--- a/ezrules/backend/backtesting.py
+++ b/ezrules/backend/backtesting.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
-from ezrules.core.rule import MissingFieldLookupError
+from ezrules.backend.features import FeatureResolutionError, FeatureResolver
+from ezrules.core.rule import MissingFieldLookupError, MissingStatLookupError
 from ezrules.core.type_casting import (
     CastError,
     FieldCastConfig,
@@ -56,6 +58,7 @@ def _count_rates(counts: Counter[str], total_records: int) -> dict[str, float]:
 class BacktestRecord:
     event_data: dict[str, Any]
     label_name: str | None = None
+    as_of: datetime | None = None
 
 
 @dataclass
@@ -168,10 +171,15 @@ def compute_backtest_metrics(
     proposed_rule: Any,
     test_records: Iterable[BacktestRecord],
     configs: list[FieldCastConfig],
+    feature_resolver: FeatureResolver | None = None,
 ) -> dict[str, Any]:
     stored_rule_fields = set(stored_rule.get_rule_params())
     proposed_rule_fields = set(proposed_rule.get_rule_params())
     referenced_fields = sorted(stored_rule_fields | proposed_rule_fields)
+    stat_paths = stored_rule.get_rule_stats() | proposed_rule.get_rule_stats()
+    if stat_paths and feature_resolver is None:
+        raise ValueError("Backtest rules reference computed stats but feature resolution was not configured.")
+
     total_records = 0
     skipped_records = 0
     labeled_records = 0
@@ -179,6 +187,7 @@ def compute_backtest_metrics(
     quality_outcomes: set[str] = set()
     missing_field_counts: Counter[str] = Counter()
     normalization_failures: Counter[str] = Counter()
+    stat_resolution_failures: Counter[str] = Counter()
 
     stored_metrics = _RuleMetricsAccumulator()
     proposed_metrics = _RuleMetricsAccumulator()
@@ -200,12 +209,30 @@ def compute_backtest_metrics(
             normalization_failures[str(exc)] += 1
             continue
 
+        stats: dict[str, Any] | None = None
+        if stat_paths:
+            if record.as_of is None:
+                skipped_records += 1
+                stat_resolution_failures["missing_as_of"] += 1
+                continue
+            try:
+                assert feature_resolver is not None
+                stats = feature_resolver.resolve(normalized_event, record.as_of, stat_paths)
+            except FeatureResolutionError as exc:
+                skipped_records += 1
+                stat_resolution_failures[str(exc)] += 1
+                continue
+
         try:
-            stored_outcome = stored_rule(normalized_event)
-            proposed_outcome = proposed_rule(normalized_event)
+            stored_outcome = stored_rule(normalized_event, stats)
+            proposed_outcome = proposed_rule(normalized_event, stats)
         except MissingFieldLookupError as exc:
             skipped_records += 1
             missing_field_counts[exc.field_name] += 1
+            continue
+        except MissingStatLookupError as exc:
+            skipped_records += 1
+            stat_resolution_failures[exc.stat_path] += 1
             continue
         except KeyError as exc:
             missing_field = _extract_runtime_missing_field(exc, normalized_event)
@@ -266,6 +293,11 @@ def compute_backtest_metrics(
             f"Records excluded by live normalization rules: {message} ({count})."
             for message, count in normalization_failures.items()
         )
+    if stat_resolution_failures:
+        impacted_stats = ", ".join(
+            f"{reason} ({stat_resolution_failures[reason]})" for reason in sorted(stat_resolution_failures)
+        )
+        warnings.append(f"Records excluded because computed stats could not be resolved: {impacted_stats}.")
 
     return {
         "stored_result": _sorted_counts(stored_metrics.outcome_counts),

--- a/ezrules/backend/tasks.py
+++ b/ezrules/backend/tasks.py
@@ -12,6 +12,7 @@ from ezrules.backend.backtesting import (
     BacktestRecord,
     compute_backtest_metrics,
 )
+from ezrules.backend.features import FeatureResolver
 from ezrules.backend.observation_queue import drain_observation_queue
 from ezrules.backend.rule_quality import (
     compute_rule_quality_metrics,
@@ -207,7 +208,7 @@ def execute_backtest_rule_change(
 
         try:
             query = (
-                db_session.query(EventVersion.event_data, Label.label)
+                db_session.query(EventVersion.event_data, EventVersion.effective_at, Label.label)
                 .join(EvaluationDecision, EvaluationDecision.ev_id == EventVersion.ev_id)
                 .outerjoin(
                     EventVersionLabel,
@@ -235,14 +236,21 @@ def execute_backtest_rule_change(
 
         configs = load_cast_configs(db_session, org_id)
 
+        feature_resolver = FeatureResolver(db_session, org_id)
+
         payload = compute_backtest_metrics(
             stored_rule=stored_rule,
             proposed_rule=proposed_rule,
             test_records=(
-                BacktestRecord(event_data=dict(row.event_data or {}), label_name=str(row.label) if row.label else None)
+                BacktestRecord(
+                    event_data=dict(row.event_data or {}),
+                    label_name=str(row.label) if row.label else None,
+                    as_of=row.effective_at,
+                )
                 for row in query.yield_per(5000)
             ),
             configs=configs,
+            feature_resolver=feature_resolver,
         )
     except Exception as e:
         db_session.rollback()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.24.1"
+version = "1.24.2"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_backtesting_features.py
+++ b/tests/test_backtesting_features.py
@@ -1,0 +1,164 @@
+"""Backtesting with point-in-time computed stat resolution."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ezrules.backend.backtesting import BacktestRecord, compute_backtest_metrics
+from ezrules.backend.features import FeatureResolver
+from ezrules.backend.tasks import app as celery_app
+from ezrules.backend.tasks import backtest_rule_change
+from ezrules.core.rule import Rule
+from ezrules.models.backend_core import EventVersion, FeatureDefinition, Organisation
+from ezrules.models.backend_core import Rule as RuleModel
+from tests.canonical_helpers import _hash_payload, add_served_decision
+
+
+def _ensure_org(session) -> Organisation:
+    org = session.query(Organisation).filter(Organisation.o_id == 1).first()
+    if org is None:
+        org = Organisation(o_id=1, name="Test Org")
+        session.add(org)
+        session.commit()
+    return org
+
+
+def _add_event_version(session, *, org_id: int, transaction_id: str, effective_at: datetime, event_data: dict):
+    session.add(
+        EventVersion(
+            o_id=org_id,
+            transaction_id=transaction_id,
+            event_version=1,
+            effective_at=effective_at,
+            observed_at=effective_at,
+            event_data=event_data,
+            payload_hash=_hash_payload(event_data),
+        )
+    )
+
+
+def _active_sum_feature(org_id: int) -> FeatureDefinition:
+    return FeatureDefinition(
+        o_id=org_id,
+        name="Sender sent amount 24h",
+        entity="sender",
+        feature_name="sent_amount_sum_24h",
+        entity_key="sender_id",
+        aggregation_type="sum",
+        source_field="amount",
+        window_seconds=86400,
+        filters=[],
+        status="active",
+    )
+
+
+def test_compute_backtest_metrics_resolves_stats_as_of_record_time(session):
+    org = _ensure_org(session)
+    session.add(_active_sum_feature(int(org.o_id)))
+    for transaction_id, effective_at, event_data in (
+        ("prior-1", datetime(2026, 5, 5, 12, 0, tzinfo=UTC), {"sender_id": "S1", "amount": 60}),
+        ("prior-2", datetime(2026, 5, 5, 13, 0, tzinfo=UTC), {"sender_id": "S1", "amount": 70}),
+        ("future", datetime(2026, 5, 6, 13, 0, tzinfo=UTC), {"sender_id": "S1", "amount": 10000}),
+    ):
+        _add_event_version(
+            session,
+            org_id=int(org.o_id),
+            transaction_id=transaction_id,
+            effective_at=effective_at,
+            event_data=event_data,
+        )
+    session.commit()
+
+    payload = compute_backtest_metrics(
+        stored_rule=Rule(rid="stored", logic="if $amount > 0:\n\treturn !PASS"),
+        proposed_rule=Rule(rid="proposed", logic="if stat[sender.sent_amount_sum_24h] > 100:\n\treturn !HOLD"),
+        test_records=[
+            BacktestRecord(
+                event_data={"sender_id": "S1", "amount": 5},
+                as_of=datetime(2026, 5, 6, 12, 0, tzinfo=UTC),
+            )
+        ],
+        configs=[],
+        feature_resolver=FeatureResolver(session, int(org.o_id)),
+    )
+
+    assert payload["total_records"] == 1
+    assert payload["stored_result"] == {"PASS": 1}
+    assert payload["proposed_result"] == {"HOLD": 1}
+
+
+def test_compute_backtest_metrics_skips_records_missing_entity_key_for_stats(session):
+    org = _ensure_org(session)
+    session.add(_active_sum_feature(int(org.o_id)))
+    session.commit()
+
+    payload = compute_backtest_metrics(
+        stored_rule=Rule(rid="stored", logic="if $amount > 0:\n\treturn !PASS"),
+        proposed_rule=Rule(rid="proposed", logic="if stat[sender.sent_amount_sum_24h] > 100:\n\treturn !HOLD"),
+        test_records=[BacktestRecord(event_data={"amount": 5}, as_of=datetime(2026, 5, 6, 12, 0, tzinfo=UTC))],
+        configs=[],
+        feature_resolver=FeatureResolver(session, int(org.o_id)),
+    )
+
+    assert payload["total_records"] == 0
+    assert payload["skipped_records"] == 1
+    assert any("computed stats could not be resolved" in warning for warning in payload["warnings"])
+
+
+def test_compute_backtest_metrics_requires_resolver_when_rules_reference_stats():
+    with pytest.raises(ValueError, match="feature resolution was not configured"):
+        compute_backtest_metrics(
+            stored_rule=Rule(rid="stored", logic="if $amount > 0:\n\treturn !PASS"),
+            proposed_rule=Rule(rid="proposed", logic="if stat[sender.sent_amount_sum_24h] > 100:\n\treturn !HOLD"),
+            test_records=[BacktestRecord(event_data={"sender_id": "S1", "amount": 5})],
+            configs=[],
+        )
+
+
+def test_backtest_task_resolves_stats_as_of_event_time(session):
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+
+    org = _ensure_org(session)
+    session.add(_active_sum_feature(int(org.o_id)))
+    rule = RuleModel(
+        rid="bt_feature_rule",
+        logic="if $amount > 0:\n\treturn !PASS",
+        description="Backtest baseline rule",
+        o_id=org.o_id,
+    )
+    session.add(rule)
+    for transaction_id, effective_at, event_data in (
+        ("prior-1", datetime(2026, 5, 5, 12, 0, tzinfo=UTC), {"sender_id": "S1", "amount": 60}),
+        ("prior-2", datetime(2026, 5, 5, 13, 0, tzinfo=UTC), {"sender_id": "S1", "amount": 70}),
+        ("future", datetime(2026, 5, 6, 13, 0, tzinfo=UTC), {"sender_id": "S1", "amount": 10000}),
+    ):
+        _add_event_version(
+            session,
+            org_id=int(org.o_id),
+            transaction_id=transaction_id,
+            effective_at=effective_at,
+            event_data=event_data,
+        )
+    add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="current",
+        effective_at=int(datetime(2026, 5, 6, 12, 0, tzinfo=UTC).timestamp()),
+        event_data={"sender_id": "S1", "amount": 5},
+    )
+    session.commit()
+
+    result = backtest_rule_change(
+        rule.r_id,
+        "if stat[sender.sent_amount_sum_24h] > 100:\n\treturn !HOLD",
+        int(org.o_id),
+    )
+
+    assert "error" not in result
+    assert result["total_records"] == 1
+    assert result["stored_result"] == {"PASS": 1}
+    assert result["proposed_result"] == {"HOLD": 1}
+
+    celery_app.conf.task_always_eager = False
+    celery_app.conf.task_eager_propagates = False

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.24.1"
+version = "1.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Backtests now resolve `stat[...]` features via `FeatureResolver` using each historical record's `effective_at`, matching live evaluation semantics.
- Skips ineligible records when stats cannot be resolved and surfaces warnings in backtest results.
- Adds regression coverage in `tests/test_backtesting_features.py`.

## Test plan
- [x] `uv run poe check`
- [x] Full backend pytest (721 passed)
- [x] Full Playwright e2e suite (321 passed, 1 skipped)


Made with [Cursor](https://cursor.com)