### PR TITLE
Add recent rule trigger history

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Switch the dashboard to the 30-day window to review sustained traffic and outcom
 
 ### Inspect Rule Logic And Performance
 
-Each rule has its own detail view with source logic, test payloads, historical revisions, backtesting, and hit/outcome performance.
+Each rule has its own detail view with source logic, test payloads, historical revisions, backtesting, hit/outcome performance, and recent transactions that triggered the rule.
 
 ![30-day rule performance chart](docs/assets/readme/rule-detail-performance-30d.png)
 

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -160,6 +160,7 @@ Rule lifecycle fields on rule responses:
 | Method | Path | Auth | Notes |
 |---|---|---|---|
 | `GET` | `/api/v2/tested-events` | Bearer + `VIEW_RULES` | Recent stored event evaluations with uploaded `label_name`, transaction lifecycle timestamps (`first_effective_at`, `first_observed_at`), raw payload, and triggered rules (`?limit=50`). Add `include_referenced_fields=true` to include each rule's referenced top-level fields. |
+| `GET` | `/api/v2/rules/{rule_id}/triggered-events` | Bearer + `VIEW_RULES` | Recent stored served decisions where the selected rule produced a non-null outcome. Supports `limit` and `offset` pagination for rule-detail load-more flows. |
 | `GET` | `/api/v2/tested-events/{evaluation_decision_id}/graph` | Bearer + `VIEW_RULES` | Bounded event/entity graph for a stored served decision. Use `max_events` to cap returned event nodes and `max_hops` to configure event-to-event traversal depth (default 3). Pass `expand_entity_type` plus `expand_entity_value_hash` to expand traffic connected through a specific entity node. |
 
 ### Outcomes

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -20,7 +20,7 @@ Open **Dashboard** in the sidebar and verify:
 - Transaction volume chart has data in the selected window
 - Most-firing and least-firing rule cards look plausible for the selected window
 - Outcome charts move as you submit test or live events
-- Opening a ranked rule lets you inspect that rule's own **Performance** card and confirm which outcomes are firing over time
+- Opening a ranked rule lets you inspect that rule's own **Performance** card and review recent triggered transactions behind the trend
 
 Use aggregation windows: `1h`, `6h`, `12h`, `24h`, `30d`. For the first operational review, start with `30d` so volume and outcome lines show trend shape rather than just recent activity.
 
@@ -30,6 +30,7 @@ Healthy signal:
 - least-firing rules include active zero-hit rules instead of dropping them from the ranking
 - outcome lines change after rule updates or test submissions
 - the rule-detail performance chart shows the same rule generating plausible outcome counts in the time window you selected
+- the rule-detail recent trigger list shows the concrete served transactions that produced stored outcomes for that rule
 
 Dashboard charts use the canonical served-decision ledger filtered to current transaction projections. Transaction volume counts current served `evaluation_decisions` per `transaction_id`; outcome and rule-activity charts count per-rule `evaluation_rule_results` for those current decisions. Time buckets are based on `evaluation_decisions.evaluated_at`, which shows when ezrules served the decision.
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.25.0
+
+* **Recent rule triggers**: Rule detail pages now show recent served transactions where the rule produced an outcome, with a fixed-size **Load more** flow for reviewing additional trigger history without leaving the page.
+* **Rule trigger API**: Added `GET /api/v2/rules/{rule_id}/triggered-events` with `limit` and `offset` pagination so clients can inspect concrete transactions behind a rule's stored hit trend.
+
 ## v1.24.2
 
 * **Backtest stat resolution**: Rule backtests now resolve `stat[...]` computed features as of each historical event's `effective_at`, matching live evaluation semantics and excluding future data from feature windows.

--- a/ezrules/backend/api_v2/routes/rules.py
+++ b/ezrules/backend/api_v2/routes/rules.py
@@ -24,6 +24,7 @@ from ezrules.backend.api_v2.auth.dependencies import (
     get_db,
     require_permission,
 )
+from ezrules.backend.api_v2.routes.tested_events import build_tested_event_items
 from ezrules.backend.api_v2.schemas.rollouts import RolloutDeployRequest, RolloutDeployResponse
 from ezrules.backend.api_v2.schemas.rules import (
     MainRuleOrderUpdateRequest,
@@ -43,6 +44,7 @@ from ezrules.backend.api_v2.schemas.rules import (
     RulesListResponse,
     RuleTestRequest,
     RuleTestResponse,
+    RuleTriggeredEventsResponse,
     RuleUpdate,
     RuleVerifyRequest,
     RuleVerifyResponse,
@@ -80,12 +82,17 @@ from ezrules.core.type_casting import CastError, RequiredFieldError, normalize_e
 from ezrules.models.backend_core import (
     Action,
     AIRuleAuthoringHistory,
+    EvaluationDecision,
     EvaluationRuleResult,
+    EventVersion,
+    EventVersionLabel,
+    Label,
     RoleActions,
     RuleDeploymentResultsLog,
     RuleHistory,
     RuleStatus,
     ShadowResultsLog,
+    TransactionCurrentVersion,
     User,
 )
 from ezrules.models.backend_core import Rule as RuleModel
@@ -397,6 +404,68 @@ def get_rule(
     ]
 
     return rule_to_response(rule, revisions)
+
+
+@router.get(
+    "/{rule_id}/triggered-events",
+    response_model=RuleTriggeredEventsResponse,
+    response_model_exclude_unset=True,
+)
+def get_rule_triggered_events(
+    rule_id: int,
+    limit: int = Query(default=10, ge=1, le=100, description="Page size for triggered transactions"),
+    offset: int = Query(default=0, ge=0, description="Triggered transaction offset"),
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_RULES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> RuleTriggeredEventsResponse:
+    """Return recent served transactions where the selected rule produced an outcome."""
+    rule = db.query(RuleModel.r_id).filter(RuleModel.r_id == rule_id, RuleModel.o_id == current_org_id).first()
+    if rule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+
+    filters = (
+        EvaluationDecision.o_id == current_org_id,
+        EvaluationDecision.served.is_(True),
+        EvaluationDecision.decision_type == "served",
+        EvaluationRuleResult.r_id == rule_id,
+        EvaluationRuleResult.rule_result.isnot(None),
+    )
+
+    records = (
+        db.query(EvaluationDecision, EventVersion, TransactionCurrentVersion, Label.label)
+        .join(EvaluationRuleResult, EvaluationRuleResult.ed_id == EvaluationDecision.ed_id)
+        .join(EventVersion, EventVersion.ev_id == EvaluationDecision.ev_id)
+        .join(
+            TransactionCurrentVersion,
+            (TransactionCurrentVersion.o_id == EvaluationDecision.o_id)
+            & (TransactionCurrentVersion.transaction_id == EvaluationDecision.transaction_id),
+        )
+        .outerjoin(
+            EventVersionLabel,
+            (EventVersionLabel.ev_id == EvaluationDecision.ev_id) & (EventVersionLabel.o_id == EvaluationDecision.o_id),
+        )
+        .outerjoin(Label, (Label.el_id == EventVersionLabel.el_id) & (Label.o_id == EvaluationDecision.o_id))
+        .filter(*filters)
+        .order_by(EvaluationDecision.ed_id.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    total = (
+        db.query(EvaluationRuleResult.err_id)
+        .join(EvaluationDecision, EvaluationDecision.ed_id == EvaluationRuleResult.ed_id)
+        .filter(*filters)
+        .count()
+    )
+
+    return RuleTriggeredEventsResponse(
+        events=build_tested_event_items(db, records, include_referenced_fields=False),
+        total=int(total),
+        limit=limit,
+        offset=offset,
+    )
 
 
 # =============================================================================

--- a/ezrules/backend/api_v2/routes/tested_events.py
+++ b/ezrules/backend/api_v2/routes/tested_events.py
@@ -267,6 +267,69 @@ def _linked_event_versions_for_links(
     return discovered, truncated
 
 
+def build_tested_event_items(
+    db: Any,
+    records: list[tuple[EvaluationDecision, EventVersion, TransactionCurrentVersion, str | None]],
+    *,
+    include_referenced_fields: bool,
+) -> list[TestedEventItem]:
+    """Build tested-event response items for pre-filtered decision records."""
+    triggered_rules_by_decision: dict[int, list[TriggeredRuleItem]] = defaultdict(list)
+    referenced_fields_by_rule_id: dict[int, list[str]] = {}
+    decision_ids = [int(decision.ed_id) for decision, _event_version, _current_version, _label_name in records]
+
+    if decision_ids:
+        rule_rows = (
+            db.query(
+                EvaluationDecision.ed_id,
+                Rule.r_id,
+                Rule.rid,
+                Rule.description,
+                Rule.logic,
+                EvaluationRuleResult.rule_result,
+            )
+            .join(EvaluationRuleResult, EvaluationRuleResult.ed_id == EvaluationDecision.ed_id)
+            .join(Rule, Rule.r_id == EvaluationRuleResult.r_id)
+            .filter(EvaluationDecision.ed_id.in_(decision_ids))
+            .order_by(EvaluationDecision.ed_id.desc(), Rule.rid.asc())
+            .all()
+        )
+
+        for ed_id, r_id, rid, description, rule_logic, rule_result in rule_rows:
+            rule_id = int(r_id)
+            if include_referenced_fields and rule_id not in referenced_fields_by_rule_id:
+                referenced_fields_by_rule_id[rule_id] = _extract_referenced_fields(str(rule_logic))
+
+            triggered_rule = TriggeredRuleItem(
+                r_id=rule_id,
+                rid=str(rid),
+                description=str(description),
+                outcome=str(rule_result),
+            )
+            if include_referenced_fields:
+                triggered_rule.referenced_fields = referenced_fields_by_rule_id[rule_id]
+            triggered_rules_by_decision[int(ed_id)].append(triggered_rule)
+
+    return [
+        TestedEventItem(
+            evaluation_decision_id=int(decision.ed_id),
+            transaction_id=str(decision.transaction_id),
+            effective_at=_utc_isoformat(cast(datetime, decision.effective_at)),
+            observed_at=_utc_isoformat(cast(datetime, decision.observed_at)),
+            first_effective_at=_utc_isoformat(cast(datetime, current_version.first_effective_at)),
+            first_observed_at=_utc_isoformat(cast(datetime, current_version.first_observed_at)),
+            event_version=int(decision.event_version),
+            is_current=bool(decision.is_current),
+            resolved_outcome=str(decision.resolved_outcome) if decision.resolved_outcome is not None else None,
+            label_name=str(label_name) if label_name is not None else None,
+            outcome_counters=dict(cast(dict[str, int], decision.outcome_counters or {})),
+            event_data=dict(cast(dict[str, Any], event_version.event_data or {})),
+            triggered_rules=triggered_rules_by_decision.get(int(decision.ed_id), []),
+        )
+        for decision, event_version, current_version, label_name in records
+    ]
+
+
 @router.get("", response_model=TestedEventsResponse, response_model_exclude_unset=True)
 def list_tested_events(
     limit: int = Query(default=50, ge=1, le=200, description="Max events to return"),
@@ -312,60 +375,7 @@ def list_tested_events(
         .count()
     )
 
-    triggered_rules_by_decision: dict[int, list[TriggeredRuleItem]] = defaultdict(list)
-    referenced_fields_by_rule_id: dict[int, list[str]] = {}
-    decision_ids = [int(decision.ed_id) for decision, _event_version, _current_version, _label_name in records]
-
-    if decision_ids:
-        rule_rows = (
-            db.query(
-                EvaluationDecision.ed_id,
-                Rule.r_id,
-                Rule.rid,
-                Rule.description,
-                Rule.logic,
-                EvaluationRuleResult.rule_result,
-            )
-            .join(EvaluationRuleResult, EvaluationRuleResult.ed_id == EvaluationDecision.ed_id)
-            .join(Rule, Rule.r_id == EvaluationRuleResult.r_id)
-            .filter(EvaluationDecision.ed_id.in_(decision_ids))
-            .order_by(EvaluationDecision.ed_id.desc(), Rule.rid.asc())
-            .all()
-        )
-
-        for ed_id, r_id, rid, description, rule_logic, rule_result in rule_rows:
-            rule_id = int(r_id)
-            if include_referenced_fields and rule_id not in referenced_fields_by_rule_id:
-                referenced_fields_by_rule_id[rule_id] = _extract_referenced_fields(str(rule_logic))
-
-            triggered_rule = TriggeredRuleItem(
-                r_id=rule_id,
-                rid=str(rid),
-                description=str(description),
-                outcome=str(rule_result),
-            )
-            if include_referenced_fields:
-                triggered_rule.referenced_fields = referenced_fields_by_rule_id[rule_id]
-            triggered_rules_by_decision[int(ed_id)].append(triggered_rule)
-
-    events = [
-        TestedEventItem(
-            evaluation_decision_id=int(decision.ed_id),
-            transaction_id=str(decision.transaction_id),
-            effective_at=_utc_isoformat(decision.effective_at),
-            observed_at=_utc_isoformat(decision.observed_at),
-            first_effective_at=_utc_isoformat(current_version.first_effective_at),
-            first_observed_at=_utc_isoformat(current_version.first_observed_at),
-            event_version=int(decision.event_version),
-            is_current=bool(decision.is_current),
-            resolved_outcome=str(decision.resolved_outcome) if decision.resolved_outcome is not None else None,
-            label_name=str(label_name) if label_name is not None else None,
-            outcome_counters=dict(decision.outcome_counters or {}),
-            event_data=dict(event_version.event_data or {}),
-            triggered_rules=triggered_rules_by_decision.get(int(decision.ed_id), []),
-        )
-        for decision, event_version, current_version, label_name in records
-    ]
+    events = build_tested_event_items(db, records, include_referenced_fields=include_referenced_fields)
 
     return TestedEventsResponse(events=events, total=int(total), limit=limit)
 

--- a/ezrules/backend/api_v2/schemas/rules.py
+++ b/ezrules/backend/api_v2/schemas/rules.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from ezrules.backend.api_v2.schemas.tested_events import TestedEventItem
 from ezrules.models.backend_core import RuleStatus
 
 # =============================================================================
@@ -212,6 +213,15 @@ class RuleHistoryResponse(BaseModel):
     r_id: int
     rid: str
     history: list[RuleHistoryEntry]
+
+
+class RuleTriggeredEventsResponse(BaseModel):
+    """Recent stored events where a rule produced an outcome."""
+
+    events: list[TestedEventItem]
+    total: int
+    limit: int
+    offset: int
 
 
 class RuleVerifyError(BaseModel):

--- a/ezrules/frontend/e2e/pages/rule-detail.page.ts
+++ b/ezrules/frontend/e2e/pages/rule-detail.page.ts
@@ -26,6 +26,11 @@ export class RuleDetailPage {
   readonly performanceEmptyState: Locator;
   readonly performanceTotalHits: Locator;
   readonly performanceOutcomeCount: Locator;
+  readonly triggeredEventsCard: Locator;
+  readonly triggeredEventsRows: Locator;
+  readonly triggeredEventsEmptyState: Locator;
+  readonly triggeredEventsStatus: Locator;
+  readonly triggeredEventsLoadMoreButton: Locator;
 
   // Revision view locators
   readonly revisionBanner: Locator;
@@ -64,6 +69,11 @@ export class RuleDetailPage {
     this.performanceEmptyState = page.getByTestId('rule-performance-empty');
     this.performanceTotalHits = page.getByTestId('rule-performance-total-hits');
     this.performanceOutcomeCount = page.getByTestId('rule-performance-outcome-count');
+    this.triggeredEventsCard = page.getByTestId('rule-triggered-events-card');
+    this.triggeredEventsRows = page.getByTestId('rule-triggered-events-row');
+    this.triggeredEventsEmptyState = page.getByTestId('rule-triggered-events-empty');
+    this.triggeredEventsStatus = page.getByTestId('rule-triggered-events-status');
+    this.triggeredEventsLoadMoreButton = page.getByTestId('rule-triggered-events-load-more');
 
     // Revision view locators
     this.revisionBanner = page.locator('.bg-yellow-50');
@@ -252,5 +262,9 @@ export class RuleDetailPage {
 
   async selectPerformanceTimeRange(range: string) {
     await this.performanceTimeRangeSelect.selectOption(range);
+  }
+
+  async clickTriggeredEventsLoadMore() {
+    await this.triggeredEventsLoadMoreButton.click();
   }
 }

--- a/ezrules/frontend/e2e/tests/rule-triggered-events.spec.ts
+++ b/ezrules/frontend/e2e/tests/rule-triggered-events.spec.ts
@@ -1,0 +1,196 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { RuleDetailPage } from '../pages/rule-detail.page';
+import { getApiBaseUrl, getAuthToken } from '../support/config';
+
+const API_BASE = getApiBaseUrl();
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getAuthToken()}` };
+}
+
+function buildEvaluatedEventData(eventId: string, amount: number) {
+  return {
+    amount,
+    currency: 'USD',
+    txn_type: 'card_purchase',
+    channel: 'web',
+    customer_id: `cust-${eventId}`,
+    customer_country: 'US',
+    billing_country: 'US',
+    shipping_country: 'US',
+    ip_country: 'US',
+    merchant_id: `merchant-${eventId}`,
+    merchant_category: 'electronics',
+    merchant_country: 'US',
+    email_domain: 'example.com',
+    account_age_days: 400,
+    email_age_days: 400,
+    customer_avg_amount_30d: 110,
+    customer_std_amount_30d: 25,
+    prior_chargebacks_180d: 0,
+    manual_review_hits_30d: 0,
+    decline_count_24h: 0,
+    txn_velocity_10m: 1,
+    txn_velocity_1h: 1,
+    unique_cards_24h: 1,
+    device_age_days: 100,
+    device_trust_score: 90,
+    has_3ds: 1,
+    card_present: 0,
+    is_guest_checkout: 0,
+    password_reset_age_hours: 720,
+    distance_from_home_km: 5,
+    ip_proxy_score: 0,
+    beneficiary_country: 'US',
+    beneficiary_age_days: 400,
+    local_hour: 12,
+  };
+}
+
+async function createEvaluatedEvent(
+  request: APIRequestContext,
+  {
+    eventId,
+    amount,
+    eventTimestamp,
+  }: {
+    eventId: string;
+    amount: number;
+    eventTimestamp: number;
+  },
+) {
+  const response = await request.post(`${API_BASE}/api/v2/evaluate`, {
+    headers: authHeaders(),
+    data: {
+      transaction_id: eventId,
+      effective_at: eventTimestamp,
+      event_data: buildEvaluatedEventData(eventId, amount),
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to create evaluated event ${eventId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+test.describe('Rule Detail Triggered Transactions', () => {
+  let ruleDetailPage: RuleDetailPage;
+  let testRuleId: number;
+  let originalMainRuleExecutionMode: string | null = null;
+
+  test.beforeEach(async ({ page, request }) => {
+    ruleDetailPage = new RuleDetailPage(page);
+    originalMainRuleExecutionMode = null;
+
+    const settingsResponse = await request.get(`${API_BASE}/api/v2/settings/runtime`, {
+      headers: authHeaders(),
+    });
+    expect(settingsResponse.ok()).toBeTruthy();
+    const settingsPayload = await settingsResponse.json();
+    originalMainRuleExecutionMode = settingsPayload.main_rule_execution_mode as string;
+    if (originalMainRuleExecutionMode !== 'all_matches') {
+      const updateResponse = await request.put(`${API_BASE}/api/v2/settings/runtime`, {
+        headers: authHeaders(),
+        data: { main_rule_execution_mode: 'all_matches' },
+      });
+      expect(updateResponse.ok()).toBeTruthy();
+    }
+
+    const response = await request.post(`${API_BASE}/api/v2/rules`, {
+      headers: authHeaders(),
+      data: {
+        rid: `E2E_TRIGGERS_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        description: 'E2E rule for recent triggered transactions',
+        logic: "if $amount >= 150:\n\treturn !HOLD",
+      },
+    });
+    const payload = await response.json();
+    if (!payload.success || !payload.rule?.r_id) {
+      throw new Error(`Failed to create trigger rule: ${JSON.stringify(payload)}`);
+    }
+    testRuleId = payload.rule.r_id;
+
+    const promoteResponse = await request.post(`${API_BASE}/api/v2/rules/${testRuleId}/promote`, {
+      headers: authHeaders(),
+    });
+    const promotePayload = await promoteResponse.json();
+    if (!promoteResponse.ok() || !promotePayload.success) {
+      throw new Error(`Failed to promote trigger rule: ${JSON.stringify(promotePayload)}`);
+    }
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (testRuleId) {
+      await request.delete(`${API_BASE}/api/v2/rules/${testRuleId}`, {
+        headers: authHeaders(),
+      });
+      testRuleId = 0;
+    }
+
+    if (originalMainRuleExecutionMode && originalMainRuleExecutionMode !== 'all_matches') {
+      await request.put(`${API_BASE}/api/v2/settings/runtime`, {
+        headers: authHeaders(),
+        data: { main_rule_execution_mode: originalMainRuleExecutionMode },
+      });
+    }
+  });
+
+  test('loads recent triggered transactions in batches', async ({ page, request }) => {
+    const now = Math.floor(Date.now() / 1000);
+    for (let index = 0; index < 12; index += 1) {
+      await createEvaluatedEvent(request, {
+        eventId: `rule-triggered-${testRuleId}-${index}`,
+        amount: 200 + index,
+        eventTimestamp: now + index,
+      });
+    }
+
+    const firstPageResponsePromise = page.waitForResponse((response) =>
+      response.url().includes(`/api/v2/rules/${testRuleId}/triggered-events`) &&
+      response.url().includes('limit=10') &&
+      response.url().includes('offset=0'),
+    );
+
+    await ruleDetailPage.goto(testRuleId);
+    await ruleDetailPage.waitForRuleToLoad();
+    const firstPageResponse = await firstPageResponsePromise;
+    expect(firstPageResponse.ok()).toBeTruthy();
+
+    await expect(ruleDetailPage.triggeredEventsCard).toBeVisible();
+    await expect(ruleDetailPage.triggeredEventsRows).toHaveCount(10);
+    await expect(ruleDetailPage.triggeredEventsStatus).toContainText('Showing 10 of 12');
+    await expect(ruleDetailPage.triggeredEventsRows.first()).toContainText(`rule-triggered-${testRuleId}-11`);
+    await expect(ruleDetailPage.triggeredEventsLoadMoreButton).toBeVisible();
+
+    const secondPageResponsePromise = page.waitForResponse((response) =>
+      response.url().includes(`/api/v2/rules/${testRuleId}/triggered-events`) &&
+      response.url().includes('limit=10') &&
+      response.url().includes('offset=10'),
+    );
+    await ruleDetailPage.clickTriggeredEventsLoadMore();
+    const secondPageResponse = await secondPageResponsePromise;
+    expect(secondPageResponse.ok()).toBeTruthy();
+
+    await expect(ruleDetailPage.triggeredEventsRows).toHaveCount(12);
+    await expect(ruleDetailPage.triggeredEventsStatus).toContainText('Showing 12 of 12');
+    await expect(ruleDetailPage.triggeredEventsRows.last()).toContainText(`rule-triggered-${testRuleId}-0`);
+    await expect(ruleDetailPage.triggeredEventsLoadMoreButton).toHaveCount(0);
+  });
+
+  test('shows an empty state when the rule has no triggered transactions', async ({ page }) => {
+    const responsePromise = page.waitForResponse((response) =>
+      response.url().includes(`/api/v2/rules/${testRuleId}/triggered-events`) &&
+      response.url().includes('offset=0'),
+    );
+
+    await ruleDetailPage.goto(testRuleId);
+    await ruleDetailPage.waitForRuleToLoad();
+    const response = await responsePromise;
+    expect(response.ok()).toBeTruthy();
+
+    await expect(ruleDetailPage.triggeredEventsCard).toBeVisible();
+    await expect(ruleDetailPage.triggeredEventsEmptyState).toBeVisible();
+    await expect(ruleDetailPage.triggeredEventsRows).toHaveCount(0);
+    await expect(ruleDetailPage.triggeredEventsLoadMoreButton).toHaveCount(0);
+  });
+});

--- a/ezrules/frontend/src/app/rule-detail/rule-detail.component.html
+++ b/ezrules/frontend/src/app/rule-detail/rule-detail.component.html
@@ -455,6 +455,123 @@
             </div>
           </div>
 
+          <!-- Recent Triggered Transactions Card -->
+          <div *ngIf="!isRevisionView" class="bg-white border border-gray-200 rounded-lg p-6" data-testid="rule-triggered-events-card">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 class="text-xl font-semibold text-gray-900">Recent Triggered Transactions</h2>
+                <p class="text-sm text-gray-500 mt-1">Latest stored served transactions where this rule produced an outcome.</p>
+              </div>
+
+              <button
+                type="button"
+                (click)="refreshTriggeredEvents()"
+                [disabled]="triggeredEventsLoading || triggeredEventsRefreshing || triggeredEventsLoadingMore"
+                class="inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                data-testid="rule-triggered-events-refresh"
+              >
+                {{ triggeredEventsRefreshing ? 'Refreshing...' : 'Refresh' }}
+              </button>
+            </div>
+
+            <div *ngIf="triggeredEventsError" class="mt-4 bg-red-50 border border-red-200 rounded-lg p-4">
+              <p class="text-sm font-medium text-red-800">{{ triggeredEventsError }}</p>
+            </div>
+
+            <div *ngIf="triggeredEventsLoading" class="flex justify-center py-10">
+              <div class="animate-pulse rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            </div>
+
+            <div
+              *ngIf="!triggeredEventsLoading && !triggeredEventsError && triggeredEvents.length === 0"
+              class="mt-4 text-center py-10 text-gray-500"
+              data-testid="rule-triggered-events-empty"
+            >
+              No triggered transactions have been stored for this rule yet.
+            </div>
+
+            <div *ngIf="!triggeredEventsLoading && triggeredEvents.length > 0" class="mt-5">
+              <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+                <p class="text-sm text-gray-600" data-testid="rule-triggered-events-status">
+                  Showing <span class="font-semibold text-gray-900">{{ triggeredEvents.length }}</span> of
+                  <span class="font-semibold text-gray-900">{{ triggeredEventsTotal }}</span> triggered transactions
+                </p>
+                <p *ngIf="triggeredEventsRefreshing" class="text-xs text-blue-600">Updating results...</p>
+              </div>
+
+              <div class="divide-y divide-gray-200 rounded-lg border border-gray-200 overflow-hidden">
+                <div *ngFor="let event of triggeredEvents" class="bg-white" data-testid="rule-triggered-events-row">
+                  <div class="p-4">
+                    <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                      <div class="min-w-0">
+                        <div class="flex flex-wrap items-center gap-2">
+                          <p class="text-sm font-semibold text-gray-900 break-all">{{ event.transaction_id }}</p>
+                          <span
+                            class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                            [ngClass]="outcomeBadgeClass(event.resolved_outcome)"
+                          >
+                            {{ event.resolved_outcome ?? 'NO OUTCOME' }}
+                          </span>
+                          <span *ngIf="event.label_name" class="inline-flex items-center rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-800">
+                            {{ event.label_name }}
+                          </span>
+                        </div>
+                        <p class="mt-1 text-xs text-gray-500">
+                          Version {{ event.event_version }}{{ event.is_current ? ' - Current' : '' }} | Effective {{ formatDate(event.effective_at) }}
+                        </p>
+                        <p class="mt-1 text-xs text-gray-500 break-all">{{ eventSummary(event.event_data) }}</p>
+                      </div>
+
+                      <button
+                        type="button"
+                        (click)="toggleTriggeredEventDetails(event.evaluation_decision_id)"
+                        class="shrink-0 rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                        data-testid="rule-triggered-events-details"
+                      >
+                        {{ isTriggeredEventExpanded(event.evaluation_decision_id) ? 'Hide details' : 'View details' }}
+                      </button>
+                    </div>
+
+                    <div *ngIf="isTriggeredEventExpanded(event.evaluation_decision_id)" class="mt-4 grid gap-4 lg:grid-cols-2" data-testid="rule-triggered-events-expanded">
+                      <div>
+                        <h3 class="mb-2 text-sm font-semibold text-gray-900">Triggered rules</h3>
+                        <div class="space-y-2">
+                          <div *ngFor="let triggeredRule of event.triggered_rules" class="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                            <div class="flex items-center justify-between gap-3">
+                              <a [routerLink]="['/rules', triggeredRule.r_id]" class="text-sm font-medium text-blue-700 hover:underline">
+                                {{ triggeredRule.rid }}
+                              </a>
+                              <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800">
+                                {{ triggeredRule.outcome }}
+                              </span>
+                            </div>
+                            <p class="mt-1 text-xs text-gray-500">{{ triggeredRule.description }}</p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div>
+                        <h3 class="mb-2 text-sm font-semibold text-gray-900">Event payload</h3>
+                        <pre class="max-h-72 overflow-auto rounded-lg bg-gray-900 p-4 text-xs text-gray-100">{{ event.event_data | json }}</pre>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <button
+                *ngIf="hasMoreTriggeredEvents()"
+                type="button"
+                (click)="loadMoreTriggeredEvents()"
+                [disabled]="triggeredEventsLoadingMore"
+                class="mt-4 w-full rounded-lg border border-blue-300 bg-white px-4 py-2 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60"
+                data-testid="rule-triggered-events-load-more"
+              >
+                {{ triggeredEventsLoadingMore ? 'Loading...' : 'Load more' }}
+              </button>
+            </div>
+          </div>
+
           <!-- Test Rule Card -->
           <div class="bg-white border border-gray-200 rounded-lg p-6">
             <h2 class="text-xl font-semibold text-gray-900 mb-4">Test Rule</h2>

--- a/ezrules/frontend/src/app/rule-detail/rule-detail.component.ts
+++ b/ezrules/frontend/src/app/rule-detail/rule-detail.component.ts
@@ -17,6 +17,7 @@ import {
   ShadowRuleItem,
   UpdateRuleRequest
 } from '../services/rule.service';
+import type { TestedEvent } from '../services/tested-event.service';
 import { ChartDataset, DashboardService } from '../services/dashboard.service';
 import {
   BacktestingService,
@@ -44,6 +45,7 @@ Chart.register(...registerables);
 
 const BACKTEST_RENDER_ROW_LIMIT = 100;
 const BACKTEST_DIFF_CHAR_LIMIT = 50000;
+const RULE_TRIGGER_BATCH_SIZE = 10;
 
 interface BacktestOutcomeRow {
   outcome: string;
@@ -119,6 +121,13 @@ export class RuleDetailComponent implements OnInit, AfterViewInit, OnDestroy {
   selectedPerformanceAggregation: string = '6h';
   performanceOutcomeDatasets: ChartDataset[] = [];
   performanceTimeLabels: string[] = [];
+  triggeredEvents: TestedEvent[] = [];
+  triggeredEventsTotal: number = 0;
+  triggeredEventsLoading: boolean = false;
+  triggeredEventsLoadingMore: boolean = false;
+  triggeredEventsRefreshing: boolean = false;
+  triggeredEventsError: string | null = null;
+  expandedTriggeredEventIds: Set<number> = new Set();
 
   // Revision view properties
   isRevisionView: boolean = false;
@@ -264,6 +273,7 @@ export class RuleDetailComponent implements OnInit, AfterViewInit, OnDestroy {
     this.loading = true;
     this.error = null;
     this.resetRulePerformance();
+    this.resetTriggeredEvents();
 
     this.ruleService.getRule(ruleId).subscribe({
       next: (rule) => {
@@ -275,6 +285,7 @@ export class RuleDetailComponent implements OnInit, AfterViewInit, OnDestroy {
         this.loadRolloutEntry(rule.r_id);
         this.loadBacktestResults(rule.r_id);
         this.loadRulePerformance(rule.r_id);
+        this.loadTriggeredEvents(rule.r_id, true);
       },
       error: (error) => {
         this.rule = null;
@@ -290,6 +301,7 @@ export class RuleDetailComponent implements OnInit, AfterViewInit, OnDestroy {
     this.loading = true;
     this.error = null;
     this.resetRulePerformance();
+    this.resetTriggeredEvents();
 
     this.ruleService.getRuleRevision(ruleId, revisionNumber).subscribe({
       next: (revision: RuleRevisionDetail) => {
@@ -412,6 +424,126 @@ export class RuleDetailComponent implements OnInit, AfterViewInit, OnDestroy {
     this.performanceOutcomeDatasets = [];
     this.performanceTimeLabels = [];
     this.destroyPerformanceChart();
+  }
+
+  loadTriggeredEvents(ruleId: number, reset: boolean = false): void {
+    if (this.isRevisionView) {
+      return;
+    }
+
+    const offset = reset ? 0 : this.triggeredEvents.length;
+    if (reset) {
+      this.triggeredEventsLoading = this.triggeredEvents.length === 0;
+      this.triggeredEventsRefreshing = this.triggeredEvents.length > 0;
+      this.expandedTriggeredEventIds.clear();
+    } else {
+      this.triggeredEventsLoadingMore = true;
+    }
+    this.triggeredEventsError = null;
+
+    this.ruleService.getRuleTriggeredEvents(ruleId, RULE_TRIGGER_BATCH_SIZE, offset).subscribe({
+      next: (response) => {
+        this.triggeredEvents = reset ? response.events : [...this.triggeredEvents, ...response.events];
+        this.triggeredEventsTotal = response.total;
+        this.triggeredEventsLoading = false;
+        this.triggeredEventsRefreshing = false;
+        this.triggeredEventsLoadingMore = false;
+      },
+      error: (error) => {
+        this.triggeredEventsError = 'Failed to load recent triggered transactions.';
+        this.triggeredEventsLoading = false;
+        this.triggeredEventsRefreshing = false;
+        this.triggeredEventsLoadingMore = false;
+        console.error('Error loading rule triggered transactions:', error);
+      }
+    });
+  }
+
+  refreshTriggeredEvents(): void {
+    if (!this.rule || this.triggeredEventsLoading || this.triggeredEventsRefreshing || this.triggeredEventsLoadingMore) {
+      return;
+    }
+    this.loadTriggeredEvents(this.rule.r_id, true);
+  }
+
+  loadMoreTriggeredEvents(): void {
+    if (
+      !this.rule ||
+      this.triggeredEventsLoading ||
+      this.triggeredEventsRefreshing ||
+      this.triggeredEventsLoadingMore ||
+      !this.hasMoreTriggeredEvents()
+    ) {
+      return;
+    }
+    this.loadTriggeredEvents(this.rule.r_id, false);
+  }
+
+  hasMoreTriggeredEvents(): boolean {
+    return this.triggeredEvents.length < this.triggeredEventsTotal;
+  }
+
+  toggleTriggeredEventDetails(eventId: number): void {
+    if (this.expandedTriggeredEventIds.has(eventId)) {
+      this.expandedTriggeredEventIds.delete(eventId);
+      return;
+    }
+    this.expandedTriggeredEventIds.add(eventId);
+  }
+
+  isTriggeredEventExpanded(eventId: number): boolean {
+    return this.expandedTriggeredEventIds.has(eventId);
+  }
+
+  outcomeBadgeClass(outcome: string | null): string {
+    if (outcome === 'CANCEL') {
+      return 'bg-red-100 text-red-800';
+    }
+    if (outcome === 'HOLD') {
+      return 'bg-amber-100 text-amber-800';
+    }
+    if (outcome === 'RELEASE') {
+      return 'bg-green-100 text-green-800';
+    }
+    return 'bg-gray-200 text-gray-700';
+  }
+
+  eventSummary(eventData: Record<string, unknown>): string {
+    const entries = Object.entries(eventData).slice(0, 3);
+    if (entries.length === 0) {
+      return 'No event fields recorded';
+    }
+    return entries
+      .map(([key, value]) => `${key}: ${this.stringifyValue(value)}`)
+      .join(' | ');
+  }
+
+  private resetTriggeredEvents(): void {
+    this.triggeredEvents = [];
+    this.triggeredEventsTotal = 0;
+    this.triggeredEventsLoading = false;
+    this.triggeredEventsLoadingMore = false;
+    this.triggeredEventsRefreshing = false;
+    this.triggeredEventsError = null;
+    this.expandedTriggeredEventIds.clear();
+  }
+
+  private stringifyValue(value: unknown): string {
+    if (value === null) {
+      return 'null';
+    }
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return '[unserializable]';
+    }
   }
 
   fillInExampleParams(ruleSource?: string): void {

--- a/ezrules/frontend/src/app/services/rule.service.ts
+++ b/ezrules/frontend/src/app/services/rule.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import type { TestedEvent } from './tested-event.service';
 
 export type RuleStatus = 'draft' | 'active' | 'paused' | 'archived';
 export type RuleEvaluationLane = 'main' | 'allowlist';
@@ -113,6 +114,13 @@ export interface RuleHistoryResponse {
   r_id: number;
   rid: string;
   history: RuleHistoryEntry[];
+}
+
+export interface RuleTriggeredEventsResponse {
+  events: TestedEvent[];
+  total: number;
+  limit: number;
+  offset: number;
 }
 
 export interface UpdateRuleRequest {
@@ -306,6 +314,13 @@ export class RuleService {
 
   getRuleHistory(ruleId: number, limit: number = 10): Observable<RuleHistoryResponse> {
     return this.http.get<RuleHistoryResponse>(`${this.apiUrl}/${ruleId}/history`, { params: { limit: limit.toString() } });
+  }
+
+  getRuleTriggeredEvents(ruleId: number, limit: number = 10, offset: number = 0): Observable<RuleTriggeredEventsResponse> {
+    const params = new HttpParams()
+      .set('limit', limit.toString())
+      .set('offset', offset.toString());
+    return this.http.get<RuleTriggeredEventsResponse>(`${this.apiUrl}/${ruleId}/triggered-events`, { params });
   }
 
   rollbackRule(ruleId: number, revisionNumber: number): Observable<UpdateRuleResponse> {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.24.2"
+version = "1.25.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_api_v2_rule_triggered_events.py
+++ b/tests/test_api_v2_rule_triggered_events.py
@@ -1,0 +1,186 @@
+import datetime
+import uuid
+
+import bcrypt
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import Organisation, Role, RuleStatus, User
+from ezrules.models.backend_core import Rule as RuleModel
+from tests.canonical_helpers import add_served_decision
+
+
+def _make_client(session, *, grant_view_rules: bool = True) -> tuple[TestClient, str]:
+    org = session.query(Organisation).filter(Organisation.o_id == 1).first()
+    if org is None:
+        org = Organisation(o_id=1, name="Test Org")
+        session.add(org)
+        session.commit()
+
+    hashed_password = bcrypt.hashpw("rule-trigger-pass".encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    role = Role(
+        name=f"rule_trigger_viewer_{uuid.uuid4().hex[:8]}",
+        description="Rule trigger test role",
+        o_id=int(org.o_id),
+    )
+    user = User(
+        email=f"rule-trigger-{uuid.uuid4().hex[:8]}@example.com",
+        password=hashed_password,
+        active=True,
+        fs_uniquifier=str(uuid.uuid4()),
+        o_id=int(org.o_id),
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    if grant_view_rules:
+        PermissionManager.grant_permission(role.id, PermissionAction.VIEW_RULES)
+
+    token = create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[role.name for role in user.roles],
+        org_id=int(user.o_id),
+    )
+
+    return TestClient(app), token
+
+
+def _add_rule(session, *, org_id: int, rid: str) -> RuleModel:
+    rule = RuleModel(
+        rid=rid,
+        logic="return !HOLD",
+        description=f"{rid} rule",
+        o_id=org_id,
+        status=RuleStatus.ACTIVE,
+    )
+    session.add(rule)
+    session.commit()
+    return rule
+
+
+def _ensure_other_org(session) -> Organisation:
+    org = session.query(Organisation).filter(Organisation.o_id == 2).first()
+    if org is not None:
+        return org
+
+    org = Organisation(o_id=2, name=f"Other Org {uuid.uuid4().hex[:8]}")
+    session.add(org)
+    session.commit()
+    return org
+
+
+def test_rule_triggered_events_pages_and_filters_results(session):
+    client, token = _make_client(session)
+    target_rule = _add_rule(session, org_id=1, rid=f"TRIGGER_TARGET_{uuid.uuid4().hex[:8]}")
+    other_rule = _add_rule(session, org_id=1, rid=f"TRIGGER_OTHER_{uuid.uuid4().hex[:8]}")
+    _ensure_other_org(session)
+    other_org_rule = _add_rule(session, org_id=2, rid=f"TRIGGER_ORG2_{uuid.uuid4().hex[:8]}")
+
+    base_time = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    for index in range(12):
+        add_served_decision(
+            session,
+            org_id=1,
+            transaction_id=f"target-trigger-{index:02d}",
+            event_data={"amount": 100 + index, "kind": "target"},
+            effective_at=int((base_time + datetime.timedelta(minutes=index)).timestamp()),
+            evaluated_at=base_time + datetime.timedelta(minutes=index),
+            outcome_counters={"HOLD": 1},
+            resolved_outcome="HOLD",
+            rule_results={int(target_rule.r_id): "HOLD"},
+        )
+
+    add_served_decision(
+        session,
+        org_id=1,
+        transaction_id="other-rule-trigger",
+        event_data={"amount": 999, "kind": "same-org-other-rule"},
+        rule_results={int(other_rule.r_id): "HOLD"},
+        resolved_outcome="HOLD",
+    )
+    add_served_decision(
+        session,
+        org_id=1,
+        transaction_id="no-rule-trigger",
+        event_data={"amount": 1, "kind": "no-hit"},
+        rule_results={},
+        resolved_outcome=None,
+    )
+    add_served_decision(
+        session,
+        org_id=2,
+        transaction_id="other-org-trigger",
+        event_data={"amount": 1000, "kind": "other-org"},
+        rule_results={int(other_org_rule.r_id): "HOLD"},
+        resolved_outcome="HOLD",
+    )
+    session.commit()
+
+    first_page = client.get(
+        f"/api/v2/rules/{target_rule.r_id}/triggered-events",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"limit": 10, "offset": 0},
+    )
+    assert first_page.status_code == 200
+    first_payload = first_page.json()
+    assert first_payload["total"] == 12
+    assert first_payload["limit"] == 10
+    assert first_payload["offset"] == 0
+    assert [event["transaction_id"] for event in first_payload["events"]] == [
+        f"target-trigger-{index:02d}" for index in range(11, 1, -1)
+    ]
+    assert first_payload["events"][0]["triggered_rules"] == [
+        {
+            "r_id": int(target_rule.r_id),
+            "rid": target_rule.rid,
+            "description": target_rule.description,
+            "outcome": "HOLD",
+        }
+    ]
+
+    second_page = client.get(
+        f"/api/v2/rules/{target_rule.r_id}/triggered-events",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"limit": 10, "offset": 10},
+    )
+    assert second_page.status_code == 200
+    second_payload = second_page.json()
+    assert second_payload["total"] == 12
+    assert second_payload["limit"] == 10
+    assert second_payload["offset"] == 10
+    assert [event["transaction_id"] for event in second_payload["events"]] == [
+        "target-trigger-01",
+        "target-trigger-00",
+    ]
+
+
+def test_rule_triggered_events_returns_not_found_for_other_org_rule(session):
+    client, token = _make_client(session)
+    _ensure_other_org(session)
+    other_org_rule = _add_rule(session, org_id=2, rid=f"TRIGGER_NOT_FOUND_{uuid.uuid4().hex[:8]}")
+
+    response = client.get(
+        f"/api/v2/rules/{other_org_rule.r_id}/triggered-events",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_rule_triggered_events_requires_view_rules_permission(session):
+    client, token = _make_client(session, grant_view_rules=False)
+    rule = _add_rule(session, org_id=1, rid=f"TRIGGER_FORBIDDEN_{uuid.uuid4().hex[:8]}")
+
+    response = client.get(
+        f"/api/v2/rules/{rule.r_id}/triggered-events",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.24.2"
+version = "1.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Adds a rule-detail section for recent served transactions that triggered the selected rule, with a fixed 10-row Load more flow. The backend exposes a paginated `GET /api/v2/rules/{rule_id}/triggered-events` endpoint that reuses Tested Events response semantics.

## Impact

Analysts can move from aggregate rule performance to concrete transaction examples without leaving the rule detail page. The feature reuses existing `VIEW_RULES` access and does not add persistent user settings or read audit events.

## Validation

- `uv run poe check`
- `EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_599d_rule_triggers EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 uv run pytest -q tests/test_api_v2_rule_triggered_events.py`
- `npx playwright test e2e/tests/rule-triggered-events.spec.ts --project=chromium --workers=1 --repeat-each=5` run twice against the same private DB
- `uv run mkdocs build --strict`
