### PR TITLE
Make backtesting feature snapshots time-aware

### DIFF
--- a/alembic/versions/20260625_0032_feature_snapshot_resolutions.py
+++ b/alembic/versions/20260625_0032_feature_snapshot_resolutions.py
@@ -1,0 +1,68 @@
+"""Add feature snapshot resolution audit storage.
+
+Revision ID: 20260625_0032
+Revises: 20260604_0031
+Create Date: 2026-06-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260625_0032"
+down_revision: str | None = "20260604_0031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "feature_snapshot_resolutions",
+        sa.Column("fsr_id", sa.Integer(), nullable=False),
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("ed_id", sa.Integer(), nullable=True),
+        sa.Column("backtest_task_id", sa.String(), nullable=True),
+        sa.Column("backtest_record_index", sa.Integer(), nullable=True),
+        sa.Column("fd_id", sa.Integer(), nullable=True),
+        sa.Column("stat_path", sa.String(length=255), nullable=False),
+        sa.Column("feature_kind", sa.String(length=32), nullable=True),
+        sa.Column("feature_version", sa.Integer(), nullable=True),
+        sa.Column("as_of", sa.DateTime(), nullable=False),
+        sa.Column("window_start", sa.DateTime(), nullable=False),
+        sa.Column("matched_event_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("entity_value_hash", sa.String(length=64), nullable=True),
+        sa.Column("resolution_status", sa.String(length=32), nullable=False, server_default="resolved"),
+        sa.Column("warning", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["ed_id"], ["evaluation_decisions.ed_id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["fd_id"], ["feature_definitions.fd_id"]),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"]),
+        sa.PrimaryKeyConstraint("fsr_id"),
+        sa.UniqueConstraint("fsr_id"),
+    )
+    op.create_index(
+        "ix_feature_snapshot_resolutions_o_id_ed_id",
+        "feature_snapshot_resolutions",
+        ["o_id", "ed_id"],
+    )
+    op.create_index(
+        "ix_feature_snapshot_resolutions_o_id_backtest_task",
+        "feature_snapshot_resolutions",
+        ["o_id", "backtest_task_id"],
+    )
+    op.create_index(
+        "ix_feature_snapshot_resolutions_o_id_stat_as_of",
+        "feature_snapshot_resolutions",
+        ["o_id", "stat_path", "as_of"],
+    )
+    op.alter_column("feature_snapshot_resolutions", "matched_event_count", server_default=None)
+    op.alter_column("feature_snapshot_resolutions", "resolution_status", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_feature_snapshot_resolutions_o_id_stat_as_of", table_name="feature_snapshot_resolutions")
+    op.drop_index("ix_feature_snapshot_resolutions_o_id_backtest_task", table_name="feature_snapshot_resolutions")
+    op.drop_index("ix_feature_snapshot_resolutions_o_id_ed_id", table_name="feature_snapshot_resolutions")
+    op.drop_table("feature_snapshot_resolutions")

--- a/alembic/versions/20260630_0033_feature_snapshot_resolutions.py
+++ b/alembic/versions/20260630_0033_feature_snapshot_resolutions.py
@@ -1,8 +1,8 @@
 """Add feature snapshot resolution audit storage.
 
-Revision ID: 20260625_0032
-Revises: 20260604_0031
-Create Date: 2026-06-25
+Revision ID: 20260630_0033
+Revises: 20260625_0032
+Create Date: 2026-06-30
 """
 
 from collections.abc import Sequence
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "20260625_0032"
-down_revision: str | None = "20260604_0031"
+revision: str = "20260630_0033"
+down_revision: str | None = "20260625_0032"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/docs/api-reference/evaluator-api.md
+++ b/docs/api-reference/evaluator-api.md
@@ -157,7 +157,7 @@ Nested lookups return the full dotted path in the same format:
 }
 ```
 
-Rules can also reference active computed features with `stat[entity.feature_name]`. These include aggregate history features and bounded graph features over configured transaction entity fields. Graph features keep append-only event-version links for audit and backtesting, but traversal uses the transaction version that is current as of the request's `effective_at` timestamp so corrected transaction versions do not double-count relationships. If a referenced stat is missing, inactive, or exceeds feature guardrails, evaluation returns `400` and does not store the event.
+Rules can also reference active computed features with `stat[entity.feature_name]`. These include aggregate history features and bounded graph features over configured transaction entity fields. Feature resolution uses the transaction version that is current as of the request's `effective_at` timestamp, so corrected transaction versions do not double-count aggregates or graph relationships. Successful live evaluations persist feature snapshot metadata linked to the served decision; dry-run event tests do not. If a referenced stat is missing, inactive, or exceeds feature guardrails, evaluation returns `400` and does not store the event.
 
 Field observations are also recorded on each successful call, contributing to the **Observed Fields** data visible in the UI. Observations include canonical dotted nested paths as well as parent objects. Live evaluation now buffers those observation writes through Redis and a periodic Celery drain, so observation listings are eventually consistent rather than immediate.
 

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -336,7 +336,7 @@ Field type config note:
 Feature definition notes:
 - `feature_kind` defaults to `aggregate`. Aggregate features support `aggregation_type` values `count`, `count_distinct`, `sum`, `avg`, `min`, `max`, `stddev`, and `days_since_first_seen`.
 - Graph features use `feature_kind=graph`, `aggregation_type=graph_distinct_count`, and a `graph_config` containing `target_entity`, `allowed_entity_types`, `max_depth`, and `max_expanded_nodes`.
-- Graph traversal uses current-as-of transaction semantics: repeated transaction versions are stored append-only, but only the version current at the feature's as-of time contributes links.
+- Feature resolution uses current-as-of transaction semantics: repeated transaction versions are stored append-only, but only the version current at the feature's as-of time contributes to aggregate values or graph links.
 - `window_seconds` must use a preset online window: `600`, `3600`, `86400`, `604800`, `2592000`, `7776000`, or `15552000`.
 - Rule logic references active features with `stat[entity.feature_name]`; raw payload fields continue to use `$field`.
 
@@ -366,7 +366,7 @@ Feature definition notes:
 | `POST` | `/api/v2/backtesting` | Bearer + permission | Trigger async backtest for a rule in the caller's org |
 | `DELETE` | `/api/v2/backtesting/{task_id}` | Bearer + permission | Cancel a queued or running backtest task and persist it as `cancelled` |
 | `POST` | `/api/v2/backtesting/{task_id}/retry` | Bearer + permission | Retry a failed/cancelled backtest using the stored logic snapshot |
-| `GET` | `/api/v2/backtesting/task/{task_id}` | Bearer + permission | Task status/result, including outcome counts/rates, `eligible_records`, `skipped_records`, warnings, plus label counts and quality metrics for labeled history |
+| `GET` | `/api/v2/backtesting/task/{task_id}` | Bearer + permission | Task status/result, including outcome counts/rates, `eligible_records`, `skipped_records`, warnings, computed-feature snapshot summaries, plus label counts and quality metrics for labeled history |
 | `GET` | `/api/v2/backtesting/{rule_id}` | Bearer + permission | Backtest history for a rule visible to the caller's org |
 
 Backtest task result note:
@@ -374,6 +374,7 @@ Backtest task result note:
 - Backtest history rows now persist `queue_status`, `completed_at`, and the full result payload in `result_metrics`, so completed jobs remain inspectable even after Celery result-backend entries age out.
 - `GET /api/v2/backtesting/task/{task_id}` returns raw outcome counts/rates over the eligible comparison subset used by both stored and proposed logic.
 - Results now include `eligible_records`, `skipped_records`, and `warnings` when historical records were excluded because a referenced field was missing/null or live normalization rules would have rejected the event.
+- Backtests that resolve computed stats include optional `feature_snapshots` and `feature_snapshot_warnings` fields. Snapshot summaries report the stat path, feature version, as-of/window range, matched-event count range, resolution status counts, and reconstruction warnings for the run.
 - When labeled historical events exist, it also returns `labeled_records`, `label_counts`, and stored/proposed outcome→label quality summaries and pair metrics (`precision`, `recall`, `f1`, `true_positive`, `false_positive`, `false_negative`).
 - Backtest workers derive organisation context from the selected rule/request rather than a fixed app-wide org setting.
 

--- a/docs/user-guide/creating-rules.md
+++ b/docs/user-guide/creating-rules.md
@@ -135,7 +135,7 @@ if stat[sender.sent_amount_sum_24h] > 10000:
     return !HOLD
 ```
 
-Computed features are defined in **Features** and are resolved as of the event timestamp. Features use bounded preset windows such as `10m`, `1h`, `24h`, `7d`, `30d`, `90d`, and `180d`; arbitrary lifetime windows are intentionally not allowed for online rule evaluation. Graph features can also expose bounded relationship counts, for example unique cards reachable from a user through configured transaction entity fields.
+Computed features are defined in **Features** and are resolved as of the event timestamp. Features use bounded preset windows such as `10m`, `1h`, `24h`, `7d`, `30d`, `90d`, and `180d`; arbitrary lifetime windows are intentionally not allowed for online rule evaluation. Repeated transaction versions are handled as-of the event timestamp, so corrected or superseded versions do not double-count in backtests. Graph features can also expose bounded relationship counts, for example unique cards reachable from a user through configured transaction entity fields.
 
 ### Allowlist pattern
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.25.0
+
+* **Auditable feature snapshots**: Backtests and live evaluations now persist computed-feature snapshot metadata, including feature version, as-of/window assumptions, matched-event counts, and reconstruction warnings.
+* **Correction-aware aggregate stats**: Aggregate `stat[...]` features now use the transaction version current at the historical as-of timestamp, so late corrections and superseded versions do not double-count or leak future data into backtests.
+
 ## v1.24.2
 
 * **Backtest stat resolution**: Rule backtests now resolve `stat[...]` computed features as of each historical event's `effective_at`, matching live evaluation semantics and excluding future data from feature windows.

--- a/ezrules/backend/api_v2/routes/backtesting.py
+++ b/ezrules/backend/api_v2/routes/backtesting.py
@@ -77,6 +77,8 @@ def _build_task_result_response(
         proposed_quality_summary=payload.get("proposed_quality_summary"),
         stored_quality_metrics=payload.get("stored_quality_metrics"),
         proposed_quality_metrics=payload.get("proposed_quality_metrics"),
+        feature_snapshots=payload.get("feature_snapshots"),
+        feature_snapshot_warnings=payload.get("feature_snapshot_warnings"),
         warnings=payload.get("warnings"),
         error=(
             str(payload["error"])

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -24,7 +24,7 @@ from ezrules.backend.api_v2.schemas.evaluator import (
     EventTestRuleResult,
 )
 from ezrules.backend.data_utils import Event
-from ezrules.backend.features import FeatureResolutionError, FeatureResolver
+from ezrules.backend.features import FeatureResolutionError, FeatureResolutionTrace, FeatureResolver
 from ezrules.backend.observation_queue import enqueue_observations
 from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
 from ezrules.backend.runtime_settings import get_main_rule_execution_mode
@@ -183,11 +183,11 @@ def _resolve_evaluation_stats(
     lre: LocalRuleExecutorSQL,
     rollout_entries: list[dict[str, Any]],
     list_provider: PersistentUserListManager | None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[FeatureResolutionTrace]]:
     stat_paths = lre.get_rule_stats()
     if rollout_entries and list_provider is not None:
         stat_paths.update(_get_rollout_stat_paths(rollout_entries, list_provider))
-    return FeatureResolver(db, o_id).resolve(event_data, as_of, stat_paths)
+    return FeatureResolver(db, o_id).resolve_with_traces(event_data, as_of, stat_paths)
 
 
 def _evaluate_rollout_result(
@@ -328,7 +328,7 @@ def evaluate(
 
         rollout_entries = list_candidate_deployments(db, lre.o_id, ROLLOUT_CONFIG_LABEL)
         list_provider = PersistentUserListManager(db, lre.o_id) if rollout_entries else None
-        stats = _resolve_evaluation_stats(
+        stats, feature_traces = _resolve_evaluation_stats(
             db=db,
             o_id=lre.o_id,
             event_data=event.event_data,
@@ -367,6 +367,8 @@ def evaluate(
     try:
         # `result` already contains the merged served outcome; passing it avoids a second rule evaluation.
         result, evaluation_decision_id = data_utils.eval_and_store(lre, event, response=result)
+        FeatureResolver(db, lre.o_id).persist_traces(feature_traces, evaluation_decision_id=int(evaluation_decision_id))
+        db.commit()
         enqueue_alert_detection(
             o_id=int(lre.o_id),
             evaluation_decision_id=int(evaluation_decision_id),
@@ -479,7 +481,7 @@ def test_event(
         else:
             rollout_entries = list_candidate_deployments(db, lre.o_id, ROLLOUT_CONFIG_LABEL)
             list_provider = PersistentUserListManager(db, lre.o_id) if rollout_entries else None
-            stats = _resolve_evaluation_stats(
+            stats, _feature_traces = _resolve_evaluation_stats(
                 db=db,
                 o_id=lre.o_id,
                 event_data=event.event_data,

--- a/ezrules/backend/api_v2/schemas/backtesting.py
+++ b/ezrules/backend/api_v2/schemas/backtesting.py
@@ -54,6 +54,20 @@ class BacktestQualitySummary(BaseModel):
     worst_pair: str | None = None
 
 
+class FeatureSnapshotSummary(BaseModel):
+    stat_path: str
+    feature_id: int | None = None
+    feature_kind: str | None = None
+    feature_version: int | None = None
+    as_of_start: str
+    as_of_end: str
+    window_start: str
+    matched_event_count_min: int
+    matched_event_count_max: int
+    resolution_status_counts: dict[str, int]
+    warning_count: int = 0
+
+
 class BacktestTaskResult(BaseModel):
     status: str
     queue_status: str | None = None
@@ -72,5 +86,7 @@ class BacktestTaskResult(BaseModel):
     proposed_quality_summary: BacktestQualitySummary | None = None
     stored_quality_metrics: list[BacktestQualityMetric] | None = None
     proposed_quality_metrics: list[BacktestQualityMetric] | None = None
+    feature_snapshots: list[FeatureSnapshotSummary] | None = None
+    feature_snapshot_warnings: list[str] | None = None
     warnings: list[str] | None = None
     error: str | None = None

--- a/ezrules/backend/backtesting.py
+++ b/ezrules/backend/backtesting.py
@@ -172,6 +172,7 @@ def compute_backtest_metrics(
     test_records: Iterable[BacktestRecord],
     configs: list[FieldCastConfig],
     feature_resolver: FeatureResolver | None = None,
+    backtest_task_id: str | None = None,
 ) -> dict[str, Any]:
     stored_rule_fields = set(stored_rule.get_rule_params())
     proposed_rule_fields = set(proposed_rule.get_rule_params())
@@ -192,7 +193,7 @@ def compute_backtest_metrics(
     stored_metrics = _RuleMetricsAccumulator()
     proposed_metrics = _RuleMetricsAccumulator()
 
-    for record in test_records:
+    for record_index, record in enumerate(test_records):
         raw_payload = record.event_data if isinstance(record.event_data, dict) else {}
         raw_event = dict(raw_payload)
 
@@ -217,8 +218,21 @@ def compute_backtest_metrics(
                 continue
             try:
                 assert feature_resolver is not None
-                stats = feature_resolver.resolve(normalized_event, record.as_of, stat_paths)
+                stats, feature_traces = feature_resolver.resolve_with_traces(normalized_event, record.as_of, stat_paths)
+                if backtest_task_id is not None:
+                    feature_resolver.persist_traces(
+                        feature_traces,
+                        backtest_task_id=backtest_task_id,
+                        backtest_record_index=record_index,
+                    )
             except FeatureResolutionError as exc:
+                assert feature_resolver is not None
+                if backtest_task_id is not None and feature_resolver.last_resolution_traces:
+                    feature_resolver.persist_traces(
+                        feature_resolver.last_resolution_traces,
+                        backtest_task_id=backtest_task_id,
+                        backtest_record_index=record_index,
+                    )
                 skipped_records += 1
                 stat_resolution_failures[str(exc)] += 1
                 continue

--- a/ezrules/backend/features.py
+++ b/ezrules/backend/features.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -11,7 +12,13 @@ from sqlalchemy import false, func, or_, text, tuple_
 from ezrules.backend.api_v2.schemas.features import ALLOWED_WINDOW_SECONDS, FeatureAggregation
 from ezrules.core.field_paths import get_field_value, split_field_path
 from ezrules.core.rule_helpers import StatReferenceExtractor
-from ezrules.models.backend_core import EventVersion, FeatureDefinition, GraphEntityField, GraphEventEntityLink
+from ezrules.models.backend_core import (
+    EventVersion,
+    FeatureDefinition,
+    FeatureSnapshotResolution,
+    GraphEntityField,
+    GraphEventEntityLink,
+)
 from ezrules.models.backend_core import Rule as RuleModel
 
 MAX_STAT_REFERENCES_PER_RULE = 10
@@ -33,6 +40,21 @@ class FeatureComputationResult:
     matched_event_count: int
     as_of: datetime
     window_start: datetime
+    entity_value_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class FeatureResolutionTrace:
+    stat_path: str
+    feature_id: int | None
+    feature_kind: str | None
+    feature_version: int | None
+    as_of: datetime
+    window_start: datetime
+    matched_event_count: int
+    entity_value_hash: str | None
+    resolution_status: str
+    warning: str | None = None
 
 
 def normalize_as_utc(value: datetime) -> datetime:
@@ -96,6 +118,13 @@ def _jsonb_text_value(value: Any) -> str | None:
 
 def _graph_entity_value_hash(entity_value: str) -> str:
     return hashlib.sha256(entity_value.encode("utf-8")).hexdigest()
+
+
+def _entity_value_hash(entity_value: Any) -> str | None:
+    text_value = _jsonb_text_value(entity_value)
+    if not text_value:
+        return None
+    return _graph_entity_value_hash(text_value)
 
 
 def _graph_entity_values(event_data: dict[str, Any], field_path: str) -> list[str]:
@@ -265,17 +294,26 @@ def _compute_aggregate_feature(
         EventVersion.o_id == o_id,
         EventVersion.effective_at >= window_start,
         EventVersion.effective_at < as_of,
+        EventVersion.observed_at <= as_of,
         _event_data_text_expression(str(feature.entity_key)) == entity_text_value,
     )
     filters = list(cast(list[dict[str, Any]], feature.filters or []))
     for filter_config in filters:
         query = _apply_jsonb_filter(query, filter_config)
-    matched_events = query.order_by(EventVersion.effective_at.asc(), EventVersion.ev_id.asc()).all()
+    candidate_events = query.order_by(EventVersion.effective_at.asc(), EventVersion.ev_id.asc()).all()
+    current_event_ids = _current_event_version_ids_as_of(
+        db,
+        o_id,
+        {str(event.transaction_id) for event in candidate_events},
+        as_of,
+    )
+    matched_events = [event for event in candidate_events if int(event.ev_id) in current_event_ids]
     return FeatureComputationResult(
         value=_compute_aggregate(feature, matched_events, as_of=as_of),
         matched_event_count=len(matched_events),
         as_of=as_of,
         window_start=window_start,
+        entity_value_hash=_entity_value_hash(entity_value),
     )
 
 
@@ -372,7 +410,13 @@ def _compute_graph_distinct_count(
 
     seed_text_value = _jsonb_text_value(entity_value)
     if not seed_text_value:
-        return FeatureComputationResult(value=0, matched_event_count=0, as_of=as_of, window_start=window_start)
+        return FeatureComputationResult(
+            value=0,
+            matched_event_count=0,
+            as_of=as_of,
+            window_start=window_start,
+            entity_value_hash=_entity_value_hash(entity_value),
+        )
 
     seed = (str(feature.entity), _graph_entity_value_hash(seed_text_value))
     frontier = {seed}
@@ -442,6 +486,7 @@ def _compute_graph_distinct_count(
         matched_event_count=len(visited_event_ids),
         as_of=as_of,
         window_start=window_start,
+        entity_value_hash=_entity_value_hash(entity_value),
     )
 
 
@@ -463,12 +508,20 @@ class FeatureResolver:
     def __init__(self, db: Any, o_id: int):
         self.db = db
         self.o_id = o_id
-        self._cache: dict[tuple[str, str, datetime], Any] = {}
+        self._cache: dict[tuple[str, str, datetime], FeatureComputationResult] = {}
+        self.last_resolution_traces: list[FeatureResolutionTrace] = []
 
     def resolve(self, event_data: dict[str, Any], as_of: datetime, stat_paths: set[str]) -> dict[str, Any]:
+        resolved, _ = self.resolve_with_traces(event_data, as_of, stat_paths)
+        return resolved
+
+    def resolve_with_traces(
+        self, event_data: dict[str, Any], as_of: datetime, stat_paths: set[str]
+    ) -> tuple[dict[str, Any], list[FeatureResolutionTrace]]:
+        self.last_resolution_traces = []
         validate_feature_reference_budget(stat_paths)
         if not stat_paths:
-            return {}
+            return {}, []
 
         features = (
             self.db.query(FeatureDefinition)
@@ -484,17 +537,125 @@ class FeatureResolver:
             raise FeatureResolutionError(f"Unknown or inactive computed stats: {', '.join(missing)}")
 
         resolved: dict[str, Any] = {}
+        traces: list[FeatureResolutionTrace] = []
         as_of = normalize_as_utc(as_of)
         for stat_path in sorted(stat_paths):
             feature = by_path[stat_path]
             entity_value = _safe_get(event_data, str(feature.entity_key))
             if entity_value is None:
+                trace = FeatureResolutionTrace(
+                    stat_path=stat_path,
+                    feature_id=int(feature.fd_id) if feature.fd_id is not None else None,
+                    feature_kind=str(feature.feature_kind),
+                    feature_version=int(feature.version) if feature.version is not None else None,
+                    as_of=as_of,
+                    window_start=as_of,
+                    matched_event_count=0,
+                    entity_value_hash=None,
+                    resolution_status="failed",
+                    warning=f"Event is missing entity key '{feature.entity_key}' required for stat[{stat_path}]",
+                )
+                traces.append(trace)
+                self.last_resolution_traces = traces
                 raise FeatureResolutionError(
                     f"Event is missing entity key '{feature.entity_key}' required for stat[{stat_path}]"
                 )
             entity_value = str(entity_value)
             cache_key = (stat_path, entity_value, as_of)
             if cache_key not in self._cache:
-                self._cache[cache_key] = compute_feature(self.db, self.o_id, feature, event_data, as_of).value
-            resolved[stat_path] = self._cache[cache_key]
-        return resolved
+                self._cache[cache_key] = compute_feature(self.db, self.o_id, feature, event_data, as_of)
+            result = self._cache[cache_key]
+            resolved[stat_path] = result.value
+            traces.append(
+                FeatureResolutionTrace(
+                    stat_path=stat_path,
+                    feature_id=int(feature.fd_id) if feature.fd_id is not None else None,
+                    feature_kind=str(feature.feature_kind),
+                    feature_version=int(feature.version) if feature.version is not None else None,
+                    as_of=result.as_of,
+                    window_start=result.window_start,
+                    matched_event_count=result.matched_event_count,
+                    entity_value_hash=result.entity_value_hash,
+                    resolution_status="resolved",
+                )
+            )
+        self.last_resolution_traces = traces
+        return resolved, traces
+
+    def persist_traces(
+        self,
+        traces: list[FeatureResolutionTrace],
+        *,
+        evaluation_decision_id: int | None = None,
+        backtest_task_id: str | None = None,
+        backtest_record_index: int | None = None,
+    ) -> None:
+        for trace in traces:
+            self.db.add(
+                FeatureSnapshotResolution(
+                    o_id=self.o_id,
+                    ed_id=evaluation_decision_id,
+                    backtest_task_id=backtest_task_id,
+                    backtest_record_index=backtest_record_index,
+                    fd_id=trace.feature_id,
+                    stat_path=trace.stat_path,
+                    feature_kind=trace.feature_kind,
+                    feature_version=trace.feature_version,
+                    as_of=trace.as_of,
+                    window_start=trace.window_start,
+                    matched_event_count=trace.matched_event_count,
+                    entity_value_hash=trace.entity_value_hash,
+                    resolution_status=trace.resolution_status,
+                    warning=trace.warning,
+                )
+            )
+
+
+def summarize_feature_snapshot_resolutions(db: Any, o_id: int, backtest_task_id: str) -> dict[str, Any]:
+    rows = (
+        db.query(FeatureSnapshotResolution)
+        .filter(
+            FeatureSnapshotResolution.o_id == o_id,
+            FeatureSnapshotResolution.backtest_task_id == backtest_task_id,
+        )
+        .order_by(FeatureSnapshotResolution.stat_path.asc(), FeatureSnapshotResolution.as_of.asc())
+        .all()
+    )
+    if not rows:
+        return {"feature_snapshots": [], "feature_snapshot_warnings": []}
+
+    grouped: dict[str, list[FeatureSnapshotResolution]] = defaultdict(list)
+    for row in rows:
+        grouped[str(row.stat_path)].append(row)
+
+    snapshots: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for stat_path in sorted(grouped):
+        stat_rows = grouped[stat_path]
+        status_counts = Counter(str(row.resolution_status) for row in stat_rows)
+        warning_count = sum(1 for row in stat_rows if row.warning)
+        warnings.extend(str(row.warning) for row in stat_rows if row.warning)
+        matched_counts = [int(row.matched_event_count or 0) for row in stat_rows]
+        snapshots.append(
+            {
+                "stat_path": stat_path,
+                "feature_id": int(stat_rows[0].fd_id) if stat_rows[0].fd_id is not None else None,
+                "feature_kind": stat_rows[0].feature_kind,
+                "feature_version": int(stat_rows[0].feature_version)
+                if stat_rows[0].feature_version is not None
+                else None,
+                "as_of_start": min(normalize_as_utc(cast(datetime, row.as_of)) for row in stat_rows).isoformat(),
+                "as_of_end": max(normalize_as_utc(cast(datetime, row.as_of)) for row in stat_rows).isoformat(),
+                "window_start": min(
+                    normalize_as_utc(cast(datetime, row.window_start)) for row in stat_rows
+                ).isoformat(),
+                "matched_event_count_min": min(matched_counts),
+                "matched_event_count_max": max(matched_counts),
+                "resolution_status_counts": dict(sorted(status_counts.items())),
+                "warning_count": warning_count,
+            }
+        )
+    return {
+        "feature_snapshots": snapshots,
+        "feature_snapshot_warnings": sorted(set(warnings)),
+    }

--- a/ezrules/backend/tasks.py
+++ b/ezrules/backend/tasks.py
@@ -12,7 +12,7 @@ from ezrules.backend.backtesting import (
     BacktestRecord,
     compute_backtest_metrics,
 )
-from ezrules.backend.features import FeatureResolver
+from ezrules.backend.features import FeatureResolver, summarize_feature_snapshot_resolutions
 from ezrules.backend.observation_queue import drain_observation_queue
 from ezrules.backend.rule_quality import (
     compute_rule_quality_metrics,
@@ -251,7 +251,11 @@ def execute_backtest_rule_change(
             ),
             configs=configs,
             feature_resolver=feature_resolver,
+            backtest_task_id=task_id,
         )
+        if task_id is not None:
+            db_session.flush()
+            payload.update(summarize_feature_snapshot_resolutions(db_session, org_id, task_id))
     except Exception as e:
         db_session.rollback()
         payload = {"error": f"Backtest task failed: {e!s}"}

--- a/ezrules/frontend/src/app/rule-detail/rule-detail.component.html
+++ b/ezrules/frontend/src/app/rule-detail/rule-detail.component.html
@@ -712,6 +712,37 @@
                           </ul>
                         </div>
 
+                        <div *ngIf="taskResult.feature_snapshots?.length" class="mb-4 overflow-hidden rounded-lg border border-gray-200" data-testid="backtest-feature-snapshots">
+                          <div class="border-b border-gray-200 bg-gray-50 px-4 py-3">
+                            <h4 class="text-sm font-medium text-gray-900">Computed feature snapshots</h4>
+                          </div>
+                          <div class="overflow-x-auto">
+                            <table class="min-w-full text-sm">
+                              <thead class="bg-white text-left text-xs uppercase tracking-wide text-gray-500">
+                                <tr>
+                                  <th class="px-4 py-2 font-medium">Feature</th>
+                                  <th class="px-4 py-2 font-medium">Version</th>
+                                  <th class="px-4 py-2 font-medium">As-of range</th>
+                                  <th class="px-4 py-2 font-medium text-right">Matched events</th>
+                                  <th class="px-4 py-2 font-medium text-right">Warnings</th>
+                                </tr>
+                              </thead>
+                              <tbody class="divide-y divide-gray-100">
+                                <tr *ngFor="let snapshot of taskResult.feature_snapshots" class="text-gray-700">
+                                  <td class="px-4 py-2 font-mono text-xs text-gray-900">{{ snapshot.stat_path }}</td>
+                                  <td class="px-4 py-2">{{ snapshot.feature_version || '—' }}</td>
+                                  <td class="px-4 py-2 text-xs">{{ snapshot.as_of_start | date:'short' }} – {{ snapshot.as_of_end | date:'short' }}</td>
+                                  <td class="px-4 py-2 text-right">{{ snapshot.matched_event_count_min }}–{{ snapshot.matched_event_count_max }}</td>
+                                  <td class="px-4 py-2 text-right">{{ snapshot.warning_count }}</td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                          <ul *ngIf="taskResult.feature_snapshot_warnings?.length" class="border-t border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 list-disc pl-8 space-y-1">
+                            <li *ngFor="let warning of taskResult.feature_snapshot_warnings">{{ warning }}</li>
+                          </ul>
+                        </div>
+
                         <div class="grid gap-3 md:grid-cols-3 mb-4" data-testid="backtest-quality-summary">
                           <div class="border border-gray-200 rounded-lg p-4 bg-gray-50">
                             <h4 class="text-sm font-medium text-gray-700 mb-2">Historical Labels</h4>

--- a/ezrules/frontend/src/app/services/backtesting.service.ts
+++ b/ezrules/frontend/src/app/services/backtesting.service.ts
@@ -47,6 +47,20 @@ export interface BacktestQualitySummary {
   worst_pair: string | null;
 }
 
+export interface FeatureSnapshotSummary {
+  stat_path: string;
+  feature_id?: number | null;
+  feature_kind?: string | null;
+  feature_version?: number | null;
+  as_of_start: string;
+  as_of_end: string;
+  window_start: string;
+  matched_event_count_min: number;
+  matched_event_count_max: number;
+  resolution_status_counts: Record<string, number>;
+  warning_count: number;
+}
+
 export interface BacktestTaskResult {
   status: string;
   queue_status?: string | null;
@@ -65,6 +79,8 @@ export interface BacktestTaskResult {
   proposed_quality_summary?: BacktestQualitySummary | null;
   stored_quality_metrics?: BacktestQualityMetric[];
   proposed_quality_metrics?: BacktestQualityMetric[];
+  feature_snapshots?: FeatureSnapshotSummary[];
+  feature_snapshot_warnings?: string[];
   warnings?: string[];
   error?: string;
 }

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -1035,6 +1035,38 @@ class GraphEventEntityLink(Base):
     event_version: Mapped["EventVersion"] = relationship()
 
 
+class FeatureSnapshotResolution(Base):
+    __tablename__ = "feature_snapshot_resolutions"
+    __table_args__ = (
+        Index("ix_feature_snapshot_resolutions_o_id_ed_id", "o_id", "ed_id"),
+        Index("ix_feature_snapshot_resolutions_o_id_backtest_task", "o_id", "backtest_task_id"),
+        Index("ix_feature_snapshot_resolutions_o_id_stat_as_of", "o_id", "stat_path", "as_of"),
+    )
+
+    fsr_id = Column(Integer, unique=True, primary_key=True)
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), nullable=False)
+    ed_id: Mapped[int | None] = mapped_column(
+        ForeignKey("evaluation_decisions.ed_id", ondelete="CASCADE"), nullable=True
+    )
+    backtest_task_id = Column(String, nullable=True)
+    backtest_record_index = Column(Integer, nullable=True)
+    fd_id: Mapped[int | None] = mapped_column(ForeignKey("feature_definitions.fd_id"), nullable=True)
+    stat_path = Column(String(255), nullable=False)
+    feature_kind = Column(String(32), nullable=True)
+    feature_version = Column(Integer, nullable=True)
+    as_of = Column(CoerceDateTime, nullable=False)
+    window_start = Column(CoerceDateTime, nullable=False)
+    matched_event_count = Column(Integer, nullable=False, default=0)
+    entity_value_hash = Column(String(64), nullable=True)
+    resolution_status = Column(String(32), nullable=False, default="resolved")
+    warning = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+
+    org: Mapped["Organisation"] = relationship()
+    evaluation_decision: Mapped["EvaluationDecision"] = relationship()
+    feature_definition: Mapped["FeatureDefinition"] = relationship()
+
+
 class FeatureDefinition(Base):
     __tablename__ = "feature_definitions"
     __table_args__ = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.24.2"
+version = "1.25.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_backtesting_features.py
+++ b/tests/test_backtesting_features.py
@@ -3,13 +3,18 @@
 from datetime import UTC, datetime
 
 import pytest
+from fastapi.testclient import TestClient
 
 from ezrules.backend.backtesting import BacktestRecord, compute_backtest_metrics
 from ezrules.backend.features import FeatureResolver
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.api_v2.routes import evaluator as evaluator_router
+from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
 from ezrules.backend.tasks import app as celery_app
-from ezrules.backend.tasks import backtest_rule_change
+from ezrules.backend.tasks import backtest_rule_change, execute_backtest_rule_change
 from ezrules.core.rule import Rule
-from ezrules.models.backend_core import EventVersion, FeatureDefinition, Organisation
+from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager
+from ezrules.models.backend_core import EventVersion, FeatureDefinition, FeatureSnapshotResolution, Organisation
 from ezrules.models.backend_core import Rule as RuleModel
 from tests.canonical_helpers import _hash_payload, add_served_decision
 
@@ -23,18 +28,35 @@ def _ensure_org(session) -> Organisation:
     return org
 
 
-def _add_event_version(session, *, org_id: int, transaction_id: str, effective_at: datetime, event_data: dict):
-    session.add(
-        EventVersion(
-            o_id=org_id,
-            transaction_id=transaction_id,
-            event_version=1,
-            effective_at=effective_at,
-            observed_at=effective_at,
-            event_data=event_data,
-            payload_hash=_hash_payload(event_data),
-        )
+def _add_event_version(
+    session,
+    *,
+    org_id: int,
+    transaction_id: str,
+    effective_at: datetime,
+    event_data: dict,
+    observed_at: datetime | None = None,
+    terminal_state: bool = False,
+):
+    latest = (
+        session.query(EventVersion)
+        .filter(EventVersion.o_id == org_id, EventVersion.transaction_id == transaction_id)
+        .order_by(EventVersion.event_version.desc(), EventVersion.ev_id.desc())
+        .first()
     )
+    event_version = EventVersion(
+        o_id=org_id,
+        transaction_id=transaction_id,
+        event_version=1 if latest is None else int(latest.event_version) + 1,
+        effective_at=effective_at,
+        observed_at=observed_at or effective_at,
+        event_data=event_data,
+        payload_hash=_hash_payload(event_data),
+        terminal_state=terminal_state,
+        supersedes_ev_id=None if latest is None else int(latest.ev_id),
+    )
+    session.add(event_version)
+    return event_version
 
 
 def _active_sum_feature(org_id: int) -> FeatureDefinition:
@@ -85,6 +107,44 @@ def test_compute_backtest_metrics_resolves_stats_as_of_record_time(session):
     assert payload["total_records"] == 1
     assert payload["stored_result"] == {"PASS": 1}
     assert payload["proposed_result"] == {"HOLD": 1}
+
+
+def test_aggregate_features_use_current_transaction_version_as_of_observed_time(session):
+    org = _ensure_org(session)
+    session.add(_active_sum_feature(int(org.o_id)))
+    effective_at = datetime(2026, 5, 5, 12, 0, tzinfo=UTC)
+    _add_event_version(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="corrected-txn",
+        effective_at=effective_at,
+        observed_at=datetime(2026, 5, 5, 12, 1, tzinfo=UTC),
+        event_data={"sender_id": "S1", "amount": 100},
+    )
+    _add_event_version(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="corrected-txn",
+        effective_at=effective_at,
+        observed_at=datetime(2026, 5, 5, 14, 0, tzinfo=UTC),
+        event_data={"sender_id": "S1", "amount": 10},
+    )
+    session.commit()
+
+    resolver = FeatureResolver(session, int(org.o_id))
+    before_correction = resolver.resolve(
+        {"sender_id": "S1", "amount": 1},
+        datetime(2026, 5, 5, 13, 0, tzinfo=UTC),
+        {"sender.sent_amount_sum_24h"},
+    )
+    after_correction = resolver.resolve(
+        {"sender_id": "S1", "amount": 1},
+        datetime(2026, 5, 5, 15, 0, tzinfo=UTC),
+        {"sender.sent_amount_sum_24h"},
+    )
+
+    assert before_correction == {"sender.sent_amount_sum_24h": 100.0}
+    assert after_correction == {"sender.sent_amount_sum_24h": 10.0}
 
 
 def test_compute_backtest_metrics_skips_records_missing_entity_key_for_stats(session):
@@ -162,3 +222,90 @@ def test_backtest_task_resolves_stats_as_of_event_time(session):
 
     celery_app.conf.task_always_eager = False
     celery_app.conf.task_eager_propagates = False
+
+
+def test_backtest_task_persists_feature_snapshot_summary(session):
+    org = _ensure_org(session)
+    session.add(_active_sum_feature(int(org.o_id)))
+    rule = RuleModel(
+        rid="bt_feature_trace_rule",
+        logic="if $amount > 0:\n\treturn !PASS",
+        description="Backtest baseline rule",
+        o_id=org.o_id,
+    )
+    session.add(rule)
+    _add_event_version(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="prior-trace",
+        effective_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        event_data={"sender_id": "S1", "amount": 60},
+    )
+    add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="current-trace",
+        effective_at=int(datetime(2026, 5, 5, 13, 0, tzinfo=UTC).timestamp()),
+        event_data={"sender_id": "S1", "amount": 5},
+    )
+    session.commit()
+
+    result = execute_backtest_rule_change(
+        int(rule.r_id),
+        "if stat[sender.sent_amount_sum_24h] > 50:\n\treturn !HOLD",
+        int(org.o_id),
+        task_id="feature-trace-task",
+    )
+
+    assert result["feature_snapshots"][0]["stat_path"] == "sender.sent_amount_sum_24h"
+    assert result["feature_snapshots"][0]["matched_event_count_min"] == 1
+    assert result["feature_snapshots"][0]["resolution_status_counts"] == {"resolved": 1}
+    trace = session.query(FeatureSnapshotResolution).filter_by(backtest_task_id="feature-trace-task").one()
+    assert trace.backtest_record_index == 0
+    assert trace.ed_id is None
+
+
+def test_live_evaluation_persists_feature_snapshot_trace(session, live_api_key):
+    org = _ensure_org(session)
+    org_id = int(org.o_id)
+    session.add(_active_sum_feature(org_id))
+    session.add(
+        RuleModel(
+            logic="if stat[sender.sent_amount_sum_24h] > 50:\n\treturn !HOLD",
+            description="Hold senders with prior volume",
+            rid="BT_FEATURE_TRACE:001",
+            o_id=org_id,
+            r_id=9401,
+        )
+    )
+    _add_event_version(
+        session,
+        org_id=org_id,
+        transaction_id="prior-live-trace",
+        effective_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        event_data={"sender_id": "S1", "amount": 60},
+    )
+    session.commit()
+
+    config_producer = RDBRuleEngineConfigProducer(db=session, o_id=org_id)
+    config_producer.save_config(RDBRuleManager(db=session, o_id=org_id))
+    evaluator_router._lre = LocalRuleExecutorSQL(db=session, o_id=org_id)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/evaluate",
+            json={
+                "transaction_id": "current-live-trace",
+                "effective_at": "2026-05-05T13:00:00Z",
+                "event_data": {"sender_id": "S1", "amount": 5},
+            },
+            headers={"X-API-Key": live_api_key},
+        )
+
+    evaluator_router._lre = None
+    assert response.status_code == 200
+    evaluation_id = response.json()["evaluation_id"]
+    trace = session.query(FeatureSnapshotResolution).filter_by(ed_id=evaluation_id).one()
+    assert trace.stat_path == "sender.sent_amount_sum_24h"
+    assert trace.backtest_task_id is None
+    assert trace.matched_event_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.24.2"
+version = "1.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- make aggregate computed features use current-as-of transaction semantics so late corrections and superseded versions do not leak into historical backtests
- persist feature snapshot resolution metadata for served evaluations and backtest rows
- expose compact computed-feature snapshot summaries in existing backtest task results and Rule Detail UI
- add migration, docs, release notes, and regression coverage for corrected transaction versions and snapshot persistence

## Why

Backtests using aggregate `stat[...]` features could query all effective event versions in the historical window. That protected against future effective timestamps, but not against late observed corrections or superseded transaction versions. This PR aligns aggregate features with the graph-feature current-as-of behavior and records the reconstruction assumptions used for auditability.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run poe check`
- `EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_69aa_feature_snapshots EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_backtesting_features.py` — 7 passed
- `EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_69aa_full_backend EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q --cov=ezrules.backend --cov=ezrules.core --cov-report=xml tests` — 724 passed
- `TEST_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_69aa_cli EZRULES_APP_SECRET=test-secret UV_CACHE_DIR=/tmp/uv-cache ./test_cli.sh`
- `UV_CACHE_DIR=/tmp/uv-cache uv run mkdocs build --strict`
- `npm run test:e2e` — 321 passed, 1 skipped after restarting API with SMTP enabled for email-flow tests
- `docker compose -f docker-compose.demo.yml up --build`; verified API `/ping` and frontend HTTP 200, then tore down

## Notes

- Backtest snapshot output is summary-only in v1; raw per-row audit records are persisted but not exposed through a standalone audit browser.
- Entity values in snapshot records are hashed rather than stored raw.
