### PR TITLE
Anchor Tested Events metadata to evaluation time

### DIFF
--- a/alembic/versions/20260625_0032_evaluation_rule_metadata_snapshots.py
+++ b/alembic/versions/20260625_0032_evaluation_rule_metadata_snapshots.py
@@ -1,0 +1,38 @@
+"""Snapshot evaluation rule metadata.
+
+Revision ID: 20260625_0032
+Revises: 20260604_0031
+Create Date: 2026-06-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260625_0032"
+down_revision: str | None = "20260604_0031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("evaluation_rule_results", sa.Column("rule_rid", sa.String(), nullable=True))
+    op.add_column("evaluation_rule_results", sa.Column("rule_description", sa.String(), nullable=True))
+    op.add_column("evaluation_rule_results", sa.Column("rule_logic", sa.Text(), nullable=True))
+    op.add_column("evaluation_rule_results", sa.Column("referenced_fields", postgresql.JSONB(), nullable=True))
+    op.add_column(
+        "evaluation_rule_results",
+        sa.Column("metadata_source", sa.String(length=32), nullable=False, server_default="evaluation_snapshot"),
+    )
+    op.alter_column("evaluation_rule_results", "metadata_source", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("evaluation_rule_results", "metadata_source")
+    op.drop_column("evaluation_rule_results", "referenced_fields")
+    op.drop_column("evaluation_rule_results", "rule_logic")
+    op.drop_column("evaluation_rule_results", "rule_description")
+    op.drop_column("evaluation_rule_results", "rule_rid")

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -159,7 +159,7 @@ Rule lifecycle fields on rule responses:
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
-| `GET` | `/api/v2/tested-events` | Bearer + `VIEW_RULES` | Recent stored event evaluations with uploaded `label_name`, transaction lifecycle timestamps (`first_effective_at`, `first_observed_at`), raw payload, and triggered rules (`?limit=50`). Add `include_referenced_fields=true` to include each rule's referenced top-level fields. |
+| `GET` | `/api/v2/tested-events` | Bearer + `VIEW_RULES` | Recent stored event evaluations with uploaded `label_name`, transaction lifecycle timestamps (`first_effective_at`, `first_observed_at`), raw payload, and triggered rules (`?limit=50`). Triggered rules include `metadata_source` to show whether rule metadata came from the evaluation-time snapshot or a current-rule fallback. Add `include_referenced_fields=true` to include each rule's evaluation-time referenced fields. |
 | `GET` | `/api/v2/tested-events/{evaluation_decision_id}/graph` | Bearer + `VIEW_RULES` | Bounded event/entity graph for a stored served decision. Use `max_events` to cap returned event nodes and `max_hops` to configure event-to-event traversal depth (default 3). Pass `expand_entity_type` plus `expand_entity_value_hash` to expand traffic connected through a specific entity node. |
 
 ### Outcomes

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.24.3
+
+* **Tested Events historical explanations**: Triggered rule metadata in Tested Events is now captured at evaluation time, so referenced fields and rule descriptions stay stable after later rule edits.
+* **Rule metadata provenance**: Tested Events now labels triggered-rule metadata as historical evaluation metadata or current-rule fallback metadata.
+
 ## v1.24.2
 
 * **Backtest stat resolution**: Rule backtests now resolve `stat[...]` computed features as of each historical event's `effective_at`, matching live evaluation semantics and excluding future data from feature windows.

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -198,9 +198,10 @@ def _evaluate_rollout_result(
     assignment_key: str,
     list_provider: PersistentUserListManager,
     stats: dict[str, Any],
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[int, dict[str, Any]]]:
     ordered_rules = list(lre.rule_engine.rules if lre.rule_engine is not None else [])
     rollout_by_rule_id = {int(entry["r_id"]): entry for entry in rollout_entries if "r_id" in entry}
+    rule_metadata_by_id = data_utils.build_rule_metadata_from_rules(ordered_rules)
     all_rule_results: dict[int, Any] = {}
     rollout_logs: list[dict[str, Any]] = []
 
@@ -225,6 +226,7 @@ def _evaluate_rollout_result(
             selected_variant = DEPLOYMENT_VARIANT_CANDIDATE if bucket < traffic_percent else DEPLOYMENT_VARIANT_CONTROL
             if selected_variant == DEPLOYMENT_VARIANT_CANDIDATE and candidate_succeeded:
                 returned_result = candidate_result
+                rule_metadata_by_id.update(data_utils.build_rule_metadata_from_rules([candidate_rule]))
 
             rollout_logs.append(
                 {
@@ -243,7 +245,7 @@ def _evaluate_rollout_result(
         if lre.execution_mode == RULE_EXECUTION_MODE_FIRST_MATCH and returned_result is not None:
             break
 
-    return _build_response_from_all_results(all_rule_results), rollout_logs
+    return _build_response_from_all_results(all_rule_results), rollout_logs, rule_metadata_by_id
 
 
 def _persist_evaluate_observations(db: Any, event_data: dict, o_id: int) -> None:
@@ -305,6 +307,7 @@ def evaluate(
         allowlist_result = allowlist_lre.evaluate_rules(event.event_data, as_of=event.effective_at)
         if allowlist_result.get("rule_results"):
             result = _build_response_from_all_results(dict(allowlist_result.get("all_rule_results", {})))
+            result["_rule_metadata_by_id"] = data_utils.build_rule_metadata_from_engine(allowlist_lre.rule_engine)
             result, _ = data_utils.eval_and_store(lre, event, response=result)
             enqueue_alert_detection(
                 o_id=int(lre.o_id),
@@ -353,7 +356,7 @@ def evaluate(
     if rollout_entries:
         assert list_provider is not None
         assignment_key = _get_assignment_key(event)
-        result, rollout_logs = _evaluate_rollout_result(
+        result, rollout_logs, rule_metadata_by_id = _evaluate_rollout_result(
             event_data=event.event_data,
             lre=lre,
             rollout_entries=rollout_entries,
@@ -361,6 +364,7 @@ def evaluate(
             list_provider=list_provider,
             stats=stats,
         )
+        result["_rule_metadata_by_id"] = rule_metadata_by_id
     else:
         result = production_result
 
@@ -491,7 +495,7 @@ def test_event(
             production_result = lre.evaluate_rules(event.event_data, as_of=event.effective_at, stats=stats)
             if rollout_entries:
                 assert list_provider is not None
-                result, rollout_logs = _evaluate_rollout_result(
+                result, rollout_logs, _rule_metadata_by_id = _evaluate_rollout_result(
                     event_data=event.event_data,
                     lre=lre,
                     rollout_entries=rollout_entries,

--- a/ezrules/backend/api_v2/routes/tested_events.py
+++ b/ezrules/backend/api_v2/routes/tested_events.py
@@ -38,6 +38,7 @@ from ezrules.models.backend_core import (
 )
 
 router = APIRouter(prefix="/api/v2/tested-events", tags=["Tested Events"])
+RULE_METADATA_SOURCE_CURRENT_FALLBACK = "current_rule_fallback"
 
 
 def _utc_isoformat(value: datetime) -> str:
@@ -313,7 +314,7 @@ def list_tested_events(
     )
 
     triggered_rules_by_decision: dict[int, list[TriggeredRuleItem]] = defaultdict(list)
-    referenced_fields_by_rule_id: dict[int, list[str]] = {}
+    current_referenced_fields_by_rule_id: dict[int, list[str]] = {}
     decision_ids = [int(decision.ed_id) for decision, _event_version, _current_version, _label_name in records]
 
     if decision_ids:
@@ -325,6 +326,10 @@ def list_tested_events(
                 Rule.description,
                 Rule.logic,
                 EvaluationRuleResult.rule_result,
+                EvaluationRuleResult.rule_rid,
+                EvaluationRuleResult.rule_description,
+                EvaluationRuleResult.referenced_fields,
+                EvaluationRuleResult.metadata_source,
             )
             .join(EvaluationRuleResult, EvaluationRuleResult.ed_id == EvaluationDecision.ed_id)
             .join(Rule, Rule.r_id == EvaluationRuleResult.r_id)
@@ -333,19 +338,41 @@ def list_tested_events(
             .all()
         )
 
-        for ed_id, r_id, rid, description, rule_logic, rule_result in rule_rows:
+        for (
+            ed_id,
+            r_id,
+            current_rid,
+            current_description,
+            current_rule_logic,
+            rule_result,
+            snapshot_rid,
+            snapshot_description,
+            snapshot_referenced_fields,
+            metadata_source,
+        ) in rule_rows:
             rule_id = int(r_id)
-            if include_referenced_fields and rule_id not in referenced_fields_by_rule_id:
-                referenced_fields_by_rule_id[rule_id] = _extract_referenced_fields(str(rule_logic))
+            if snapshot_rid is not None or snapshot_description is not None or snapshot_referenced_fields is not None:
+                rid = str(snapshot_rid or current_rid)
+                description = str(snapshot_description or current_description)
+                source = str(metadata_source or "evaluation_snapshot")
+                referenced_fields = sorted(str(field) for field in (snapshot_referenced_fields or []))
+            else:
+                rid = str(current_rid)
+                description = str(current_description)
+                source = RULE_METADATA_SOURCE_CURRENT_FALLBACK
+                if include_referenced_fields and rule_id not in current_referenced_fields_by_rule_id:
+                    current_referenced_fields_by_rule_id[rule_id] = _extract_referenced_fields(str(current_rule_logic))
+                referenced_fields = current_referenced_fields_by_rule_id.get(rule_id, [])
 
             triggered_rule = TriggeredRuleItem(
                 r_id=rule_id,
-                rid=str(rid),
-                description=str(description),
+                rid=rid,
+                description=description,
                 outcome=str(rule_result),
+                metadata_source=source,
             )
             if include_referenced_fields:
-                triggered_rule.referenced_fields = referenced_fields_by_rule_id[rule_id]
+                triggered_rule.referenced_fields = referenced_fields
             triggered_rules_by_decision[int(ed_id)].append(triggered_rule)
 
     events = [

--- a/ezrules/backend/api_v2/schemas/tested_events.py
+++ b/ezrules/backend/api_v2/schemas/tested_events.py
@@ -12,6 +12,10 @@ class TriggeredRuleItem(BaseModel):
     rid: str = Field(..., description="Stable rule identifier")
     description: str = Field(..., description="Rule description")
     outcome: str = Field(..., description="Outcome returned by the rule")
+    metadata_source: str = Field(
+        default="evaluation_snapshot",
+        description="Whether rule metadata came from the stored evaluation snapshot or a current-rule fallback",
+    )
     referenced_fields: list[str] | None = Field(
         default=None,
         description="Canonical dotted event fields referenced by the rule logic",

--- a/ezrules/backend/data_utils.py
+++ b/ezrules/backend/data_utils.py
@@ -59,6 +59,28 @@ def _hash_payload(event_data: dict) -> str:
 
 
 EvaluationStatus = Literal["new", "duplicate", "superseding"]
+RULE_METADATA_SOURCE_EVALUATION_SNAPSHOT = "evaluation_snapshot"
+
+
+def build_rule_metadata_from_rules(rules: list[Any]) -> dict[int, dict[str, Any]]:
+    metadata_by_rule_id: dict[int, dict[str, Any]] = {}
+    for rule in rules:
+        rule_id = getattr(rule, "r_id", None)
+        if rule_id is None:
+            continue
+        referenced_fields = sorted(str(field) for field in rule.get_rule_params())
+        metadata_by_rule_id[int(rule_id)] = {
+            "rule_rid": str(rule.rid),
+            "rule_description": str(rule.description),
+            "rule_logic": str(rule._source),
+            "referenced_fields": referenced_fields,
+            "metadata_source": RULE_METADATA_SOURCE_EVALUATION_SNAPSHOT,
+        }
+    return metadata_by_rule_id
+
+
+def build_rule_metadata_from_engine(rule_engine: Any) -> dict[int, dict[str, Any]]:
+    return build_rule_metadata_from_rules(list(getattr(rule_engine, "rules", []) or []))
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -186,14 +208,17 @@ def _min_utc(left: datetime, right: datetime) -> datetime:
 def eval_and_store(lre, event: Event, response: dict | None = None, commit: bool = True):
     if response is None:
         response = lre.evaluate_rules(event.event_data, as_of=event.effective_at)
+    current_cache_state = getattr(lre, "_current_cache_state", None)
+    rule_metadata_by_id = response.pop("_rule_metadata_by_id", None)
     response, decision_id = store_eval_result(
         db_session=lre.db,
         o_id=lre.o_id,
         event=event,
         response=response,
         rule_config_label=getattr(lre, "label", "production"),
-        rule_config_version=getattr(lre, "_current_rule_version", None),
+        rule_config_version=getattr(current_cache_state, "config_version", None),
         runtime_config={"execution_mode": getattr(lre, "execution_mode", None)},
+        rule_metadata_by_id=rule_metadata_by_id or build_rule_metadata_from_engine(getattr(lre, "rule_engine", None)),
         commit=commit,
     )
     return response, decision_id
@@ -212,6 +237,7 @@ def store_eval_result(
     rule_config_label: str = "production",
     rule_config_version: int | None = None,
     runtime_config: dict | None = None,
+    rule_metadata_by_id: dict[int, dict[str, Any]] | None = None,
 ):
     outcome_manager = DatabaseOutcome(db_session=db_session, o_id=o_id)
     lock_transaction_for_evaluation(db_session, o_id, event.transaction_id)
@@ -310,7 +336,19 @@ def store_eval_result(
         current.updated_at = datetime.now(UTC)
 
     for r_id, result in response["rule_results"].items():
-        db_session.add(EvaluationRuleResult(ed_id=int(decision.ed_id), r_id=int(r_id), rule_result=str(result)))
+        rule_metadata = (rule_metadata_by_id or {}).get(int(r_id), {})
+        db_session.add(
+            EvaluationRuleResult(
+                ed_id=int(decision.ed_id),
+                r_id=int(r_id),
+                rule_result=str(result),
+                rule_rid=rule_metadata.get("rule_rid"),
+                rule_description=rule_metadata.get("rule_description"),
+                rule_logic=rule_metadata.get("rule_logic"),
+                referenced_fields=rule_metadata.get("referenced_fields"),
+                metadata_source=rule_metadata.get("metadata_source", RULE_METADATA_SOURCE_EVALUATION_SNAPSHOT),
+            )
+        )
     response["transaction_id"] = event.transaction_id
     response["resolved_outcome"] = resolved_outcome
     response["event_version"] = event_version

--- a/ezrules/frontend/src/app/services/tested-event.service.ts
+++ b/ezrules/frontend/src/app/services/tested-event.service.ts
@@ -8,6 +8,7 @@ export interface TriggeredRule {
   rid: string;
   description: string;
   outcome: string;
+  metadata_source: string;
   referenced_fields: string[];
 }
 

--- a/ezrules/frontend/src/app/tested-events/tested-events.component.html
+++ b/ezrules/frontend/src/app/tested-events/tested-events.component.html
@@ -222,6 +222,12 @@
                                     <p class="text-xs text-gray-500 mt-3">{{ referencedFieldSummary(rule.referenced_fields) }}</p>
                                   </div>
                                   <div class="flex items-center gap-3">
+                                    <span
+                                      class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium"
+                                      [ngClass]="rule.metadata_source === 'current_rule_fallback' ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-800'"
+                                    >
+                                      {{ ruleMetadataSourceLabel(rule) }}
+                                    </span>
                                     <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                                       {{ rule.outcome }}
                                     </span>

--- a/ezrules/frontend/src/app/tested-events/tested-events.component.ts
+++ b/ezrules/frontend/src/app/tested-events/tested-events.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { SidebarComponent } from '../components/sidebar.component';
-import { TestedEvent, TestedEventService } from '../services/tested-event.service';
+import { TestedEvent, TestedEventService, TriggeredRule } from '../services/tested-event.service';
 import { buildHighlightedFieldPaths } from '../utils/field-paths';
 import { TestedEventGraphComponent } from './tested-event-graph.component';
 
@@ -183,6 +183,12 @@ export class TestedEventsComponent implements OnInit {
       return 'Hover to highlight 1 referenced field in the payload JSON.';
     }
     return `Hover to highlight ${fields.length} referenced fields in the payload JSON.`;
+  }
+
+  ruleMetadataSourceLabel(rule: TriggeredRule): string {
+    return rule.metadata_source === 'current_rule_fallback'
+      ? 'Current rule metadata fallback'
+      : 'Historical rule metadata';
   }
 
   private highlightedFields(event: TestedEvent): Set<string> {

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -473,6 +473,11 @@ class EvaluationRuleResult(Base):
     ed_id: Mapped[int] = mapped_column(ForeignKey("evaluation_decisions.ed_id", ondelete="CASCADE"), nullable=False)
     r_id: Mapped[int] = mapped_column(ForeignKey("rules.r_id"), nullable=False)
     rule_result = Column(String, nullable=False)
+    rule_rid = Column(String, nullable=True)
+    rule_description = Column(String, nullable=True)
+    rule_logic = Column(Text, nullable=True)
+    referenced_fields = Column(JSONB, nullable=True)
+    metadata_source = Column(String(32), nullable=False, default="evaluation_snapshot")
 
 
 class EventVersionLabel(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.24.2"
+version = "1.24.3"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/business_scenarios/test_product_journeys.py
+++ b/tests/business_scenarios/test_product_journeys.py
@@ -201,6 +201,7 @@ def test_rule_authoring_to_served_decision_product_journey(session, live_api_key
                 "rid": "JOURNEY_AMOUNT_REVIEW",
                 "description": "Review high-value product journey events",
                 "outcome": "REVIEW",
+                "metadata_source": "evaluation_snapshot",
                 "referenced_fields": ["amount"],
             }
         ]

--- a/tests/test_api_v2_tested_events.py
+++ b/tests/test_api_v2_tested_events.py
@@ -126,12 +126,14 @@ class TestListTestedEvents:
                 "rid": "EVENTS:001",
                 "description": "Always hold",
                 "outcome": "HOLD",
+                "metadata_source": "evaluation_snapshot",
             },
             {
                 "r_id": 9102,
                 "rid": "EVENTS:002",
                 "description": "Release high-value traffic",
                 "outcome": "RELEASE",
+                "metadata_source": "evaluation_snapshot",
             },
         ]
 

--- a/tests/test_api_v2_tested_events_rule_fields.py
+++ b/tests/test_api_v2_tested_events_rule_fields.py
@@ -122,6 +122,7 @@ def test_returns_referenced_fields_for_triggered_rules(session, tested_events_fi
             "rid": "EVENTS:FIELDS:001",
             "description": "Hold high-value traffic",
             "outcome": "HOLD",
+            "metadata_source": "evaluation_snapshot",
             "referenced_fields": ["amount"],
         },
         {
@@ -129,6 +130,65 @@ def test_returns_referenced_fields_for_triggered_rules(session, tested_events_fi
             "rid": "EVENTS:FIELDS:002",
             "description": "Release GB traffic",
             "outcome": "RELEASE",
+            "metadata_source": "evaluation_snapshot",
             "referenced_fields": ["country"],
         },
     ]
+
+
+def test_referenced_fields_stay_anchored_after_rule_edit(session, tested_events_field_client):
+    org = tested_events_field_client.test_data["org"]
+    token = tested_events_field_client.test_data["token"]
+
+    rule = Rule(
+        logic='if $customer_country == "GB":\n\treturn !RELEASE',
+        description="Release GB customer traffic",
+        rid="EVENTS:FIELDS:DRIFT",
+        o_id=org.o_id,
+        r_id=9203,
+    )
+    session.add(rule)
+    session.commit()
+    _save_rule_config(session, org.o_id)
+
+    _store_event(
+        session,
+        org.o_id,
+        "evt-historical-explanation",
+        1700000300,
+        {"customer_country": "GB", "merchant_category": "books"},
+    )
+
+    before_response = tested_events_field_client.get(
+        "/api/v2/tested-events",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"include_referenced_fields": "true"},
+    )
+    assert before_response.status_code == 200
+    before_event = before_response.json()["events"][0]
+    assert before_event["triggered_rules"] == [
+        {
+            "r_id": 9203,
+            "rid": "EVENTS:FIELDS:DRIFT",
+            "description": "Release GB customer traffic",
+            "outcome": "RELEASE",
+            "metadata_source": "evaluation_snapshot",
+            "referenced_fields": ["customer_country"],
+        }
+    ]
+
+    rule.logic = 'if $merchant_category == "books":\n\treturn !HOLD'
+    rule.description = "Hold book merchant traffic"
+    session.commit()
+    _save_rule_config(session, org.o_id)
+
+    after_response = tested_events_field_client.get(
+        "/api/v2/tested-events",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"include_referenced_fields": "true"},
+    )
+
+    assert after_response.status_code == 200
+    after_event = after_response.json()["events"][0]
+    assert after_event["transaction_id"] == "evt-historical-explanation"
+    assert after_event["triggered_rules"] == before_event["triggered_rules"]

--- a/tests/test_nested_tested_events.py
+++ b/tests/test_nested_tested_events.py
@@ -47,6 +47,7 @@ def test_tested_events_returns_nested_referenced_fields(session, tested_events_f
             "rid": "EVENTS:NESTED:001",
             "description": "Hold adult profiles",
             "outcome": "HOLD",
+            "metadata_source": "evaluation_snapshot",
             "referenced_fields": ["customer.profile.age"],
         }
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.24.2"
+version = "1.24.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Fixes historical Tested Events explanation drift after rule edits by storing evaluation-time rule metadata on each evaluation rule result.

## What changed

- Persisted rule RID, description, logic, referenced fields, and metadata source with evaluation rule results.
- Updated Tested Events reads to prefer persisted evaluation snapshots and explicitly label current-rule fallback metadata.
- Added frontend metadata-source badges for triggered rules.
- Added regression coverage proving referenced fields remain stable after a rule edit.
- Bumped version to 1.24.3 and updated docs/what's new.

## Validation

- `uv run poe check`
- Full backend pytest suite: `722 passed`
- Targeted Tested Events regression/backend tests
- `npm run build`
- `uv run mkdocs build --strict`
- Targeted Playwright cluster rerun: `7 passed`

## Notes

Full local Playwright encountered an unrelated `api-keys.spec.ts` state/order failure, but that spec passed when rerun alone. Demo Docker frontend/API returned 200; worker/beat were blocked by local Docker disk exhaustion in Postgres, not by this code path.
