### PR TITLE
Add case management with integration events

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ezrules gives fraud, risk, and compliance administrators a web workspace for man
 
 - **Own the rule lifecycle.** Create rules, keep drafts separate from live logic, pause risky rules, restore older revisions, and promote changes deliberately.
 - **See what happened.** Review canonical served decisions, the outcome returned, every rule that fired, and the exact event version those rules used.
+- **Work the exceptions.** Turn non-neutral decisions into resolvable cases, track rescoring changes, and publish case/evaluation events to external systems.
 - **Improve rules with evidence.** Use labels, precision/recall reports, backtests, shadow rules, and percentage rollouts before changing production decisions.
 - **Run with admin controls.** Manage roles, permissions, API keys, outcomes, user lists, field types, traffic persistence, and audit history inside the product.
 - **Self-host it.** Run the full stack yourself with PostgreSQL, Redis, FastAPI, Celery, and the web UI.
@@ -116,6 +117,7 @@ curl -X POST http://localhost:8888/api/v2/evaluate \
 ```
 
 The result is stored for review in the UI, including the winning outcome and the rules that contributed to the decision.
+Non-neutral decisions can also become case work items, while evaluation and case lifecycle events are available through the integration event stream.
 
 ## Core Workflows
 

--- a/alembic/versions/20260705_0034_case_management_integrations.py
+++ b/alembic/versions/20260705_0034_case_management_integrations.py
@@ -1,0 +1,181 @@
+"""Add case management and integration event outbox.
+
+Revision ID: 20260705_0034
+Revises: 20260630_0033
+Create Date: 2026-07-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260705_0034"
+down_revision: str | None = "20260630_0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cases",
+        sa.Column("case_id", sa.Integer(), nullable=False),
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("transaction_id", sa.String(), nullable=False),
+        sa.Column("current_ev_id", sa.Integer(), nullable=False),
+        sa.Column("current_ed_id", sa.Integer(), nullable=False),
+        sa.Column("opened_by_ed_id", sa.Integer(), nullable=False),
+        sa.Column("previous_ed_id", sa.Integer(), nullable=True),
+        sa.Column("resolved_outcome", sa.String(length=255), nullable=True),
+        sa.Column("previous_resolved_outcome", sa.String(length=255), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("decision_state", sa.String(length=32), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("assigned_to_user_id", sa.Integer(), nullable=True),
+        sa.Column("resolved_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("resolution_note", sa.Text(), nullable=True),
+        sa.Column("resolution_label_id", sa.Integer(), nullable=True),
+        sa.Column("reopened_from_case_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["assigned_to_user_id"], ["user.id"]),
+        sa.ForeignKeyConstraint(["current_ed_id"], ["evaluation_decisions.ed_id"]),
+        sa.ForeignKeyConstraint(["current_ev_id"], ["event_versions.ev_id"]),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"]),
+        sa.ForeignKeyConstraint(["opened_by_ed_id"], ["evaluation_decisions.ed_id"]),
+        sa.ForeignKeyConstraint(["previous_ed_id"], ["evaluation_decisions.ed_id"]),
+        sa.ForeignKeyConstraint(["reopened_from_case_id"], ["cases.case_id"]),
+        sa.ForeignKeyConstraint(["resolution_label_id"], ["event_labels.el_id"]),
+        sa.ForeignKeyConstraint(["resolved_by_user_id"], ["user.id"]),
+        sa.PrimaryKeyConstraint("case_id"),
+        sa.UniqueConstraint("case_id"),
+    )
+    op.create_index("ix_cases_o_id_current_ed", "cases", ["o_id", "current_ed_id"])
+    op.create_index("ix_cases_o_id_status_updated", "cases", ["o_id", "status", "updated_at"])
+    op.create_index("ix_cases_o_id_transaction", "cases", ["o_id", "transaction_id"])
+    op.create_index(
+        "uq_cases_active_org_transaction",
+        "cases",
+        ["o_id", "transaction_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('open', 'in_review', 'reopened')"),
+    )
+
+    op.create_table(
+        "case_events",
+        sa.Column("case_event_id", sa.Integer(), nullable=False),
+        sa.Column("case_id", sa.Integer(), nullable=False),
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("actor_user_id", sa.Integer(), nullable=True),
+        sa.Column("source_ed_id", sa.Integer(), nullable=True),
+        sa.Column("external_event_id", sa.String(length=64), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.Column("details", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["actor_user_id"], ["user.id"]),
+        sa.ForeignKeyConstraint(["case_id"], ["cases.case_id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"]),
+        sa.ForeignKeyConstraint(["source_ed_id"], ["evaluation_decisions.ed_id"]),
+        sa.PrimaryKeyConstraint("case_event_id"),
+        sa.UniqueConstraint("case_event_id"),
+        sa.UniqueConstraint("external_event_id", name="uq_case_events_external_event_id"),
+    )
+    op.create_index("ix_case_events_case_id_created", "case_events", ["case_id", "created_at"])
+    op.create_index("ix_case_events_o_id_created", "case_events", ["o_id", "created_at"])
+
+    op.create_table(
+        "integration_events",
+        sa.Column("integration_event_id", sa.Integer(), nullable=False),
+        sa.Column("external_event_id", sa.String(length=64), nullable=False),
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("source_type", sa.String(length=64), nullable=False),
+        sa.Column("source_id", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=128), nullable=False),
+        sa.Column("event_version", sa.Integer(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"]),
+        sa.PrimaryKeyConstraint("integration_event_id"),
+        sa.UniqueConstraint("external_event_id", name="uq_integration_events_external_event_id"),
+        sa.UniqueConstraint("integration_event_id"),
+    )
+    op.create_index("ix_integration_events_o_id_created", "integration_events", ["o_id", "created_at"])
+    op.create_index("ix_integration_events_o_id_source", "integration_events", ["o_id", "source_type", "source_id"])
+    op.create_index(
+        "ix_integration_events_o_id_type_created",
+        "integration_events",
+        ["o_id", "event_type", "created_at"],
+    )
+
+    op.create_table(
+        "integration_subscriptions",
+        sa.Column("subscription_id", sa.Integer(), nullable=False),
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("destination_type", sa.String(length=64), nullable=False),
+        sa.Column("config", sa.JSON(), nullable=False),
+        sa.Column("secret_ref", sa.String(length=255), nullable=True),
+        sa.Column("event_types", sa.JSON(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"]),
+        sa.PrimaryKeyConstraint("subscription_id"),
+        sa.UniqueConstraint("o_id", "name", name="uq_integration_subscriptions_org_name"),
+        sa.UniqueConstraint("subscription_id"),
+    )
+    op.create_index(
+        "ix_integration_subscriptions_o_id_enabled",
+        "integration_subscriptions",
+        ["o_id", "enabled"],
+    )
+
+    op.create_table(
+        "integration_outbox",
+        sa.Column("delivery_id", sa.Integer(), nullable=False),
+        sa.Column("o_id", sa.Integer(), nullable=False),
+        sa.Column("integration_event_id", sa.Integer(), nullable=False),
+        sa.Column("subscription_id", sa.Integer(), nullable=False),
+        sa.Column("destination_type", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("attempt_count", sa.Integer(), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(), nullable=False),
+        sa.Column("last_attempted_at", sa.DateTime(), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["integration_event_id"], ["integration_events.integration_event_id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["o_id"], ["organisation.o_id"]),
+        sa.ForeignKeyConstraint(["subscription_id"], ["integration_subscriptions.subscription_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("delivery_id"),
+        sa.UniqueConstraint("delivery_id"),
+        sa.UniqueConstraint("integration_event_id", "subscription_id", name="uq_integration_outbox_event_subscription"),
+    )
+    op.create_index("ix_integration_outbox_o_id_created", "integration_outbox", ["o_id", "created_at"])
+    op.create_index("ix_integration_outbox_status_next", "integration_outbox", ["status", "next_attempt_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_integration_outbox_status_next", table_name="integration_outbox")
+    op.drop_index("ix_integration_outbox_o_id_created", table_name="integration_outbox")
+    op.drop_table("integration_outbox")
+    op.drop_index("ix_integration_subscriptions_o_id_enabled", table_name="integration_subscriptions")
+    op.drop_table("integration_subscriptions")
+    op.drop_index("ix_integration_events_o_id_type_created", table_name="integration_events")
+    op.drop_index("ix_integration_events_o_id_source", table_name="integration_events")
+    op.drop_index("ix_integration_events_o_id_created", table_name="integration_events")
+    op.drop_table("integration_events")
+    op.drop_index("ix_case_events_o_id_created", table_name="case_events")
+    op.drop_index("ix_case_events_case_id_created", table_name="case_events")
+    op.drop_table("case_events")
+    op.drop_index("uq_cases_active_org_transaction", table_name="cases")
+    op.drop_index("ix_cases_o_id_transaction", table_name="cases")
+    op.drop_index("ix_cases_o_id_status_updated", table_name="cases")
+    op.drop_index("ix_cases_o_id_current_ed", table_name="cases")
+    op.drop_table("cases")

--- a/alembic/versions/20260705_0034_case_management_integrations.py
+++ b/alembic/versions/20260705_0034_case_management_integrations.py
@@ -16,8 +16,127 @@ down_revision: str | None = "20260630_0033"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+CASE_INTEGRATION_ACTIONS = (
+    ("view_cases", "View case-management work items", "case"),
+    ("manage_cases", "Assign and resolve case-management work items", "case"),
+    ("view_integrations", "View integration event streams and subscriptions", "integration"),
+    ("manage_integrations", "Create and update integration subscriptions", "integration"),
+)
+
+
+def _insert_case_integration_permissions() -> None:
+    conn = op.get_bind()
+    for name, description, resource_type in CASE_INTEGRATION_ACTIONS:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO actions (name, description, resource_type, created_at)
+                SELECT :name, :description, :resource_type, NOW()
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM actions
+                )
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM actions
+                    WHERE name = :name
+                )
+                """
+            ),
+            {
+                "name": name,
+                "description": description,
+                "resource_type": resource_type,
+            },
+        )
+
+        action_id = conn.execute(
+            sa.text(
+                """
+                SELECT id
+                FROM actions
+                WHERE name = :name
+                """
+            ),
+            {"name": name},
+        ).scalar_one_or_none()
+
+        if action_id is None:
+            continue
+
+        admin_role_ids = conn.execute(
+            sa.text(
+                """
+                SELECT id
+                FROM "role"
+                WHERE name = :role_name
+                """
+            ),
+            {"role_name": "admin"},
+        ).scalars()
+
+        for role_id in admin_role_ids:
+            conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO role_actions (role_id, action_id, resource_id, created_at)
+                    SELECT :role_id, :action_id, NULL, NOW()
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM role_actions
+                        WHERE role_id = :role_id
+                          AND action_id = :action_id
+                          AND resource_id IS NULL
+                    )
+                    """
+                ),
+                {
+                    "role_id": int(role_id),
+                    "action_id": int(action_id),
+                },
+            )
+
+
+def _delete_case_integration_permissions() -> None:
+    conn = op.get_bind()
+    action_names = tuple(name for name, _, _ in CASE_INTEGRATION_ACTIONS)
+    action_ids = conn.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM actions
+            WHERE name IN :action_names
+            """
+        ).bindparams(sa.bindparam("action_names", expanding=True)),
+        {"action_names": action_names},
+    ).scalars()
+    action_ids = [int(action_id) for action_id in action_ids]
+    if not action_ids:
+        return
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM role_actions
+            WHERE action_id IN :action_ids
+            """
+        ).bindparams(sa.bindparam("action_ids", expanding=True)),
+        {"action_ids": action_ids},
+    )
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM actions
+            WHERE id IN :action_ids
+            """
+        ).bindparams(sa.bindparam("action_ids", expanding=True)),
+        {"action_ids": action_ids},
+    )
+
 
 def upgrade() -> None:
+    _insert_case_integration_permissions()
+
     op.create_table(
         "cases",
         sa.Column("case_id", sa.Integer(), nullable=False),
@@ -179,3 +298,4 @@ def downgrade() -> None:
     op.drop_index("ix_cases_o_id_status_updated", table_name="cases")
     op.drop_index("ix_cases_o_id_current_ed", table_name="cases")
     op.drop_table("cases")
+    _delete_case_integration_permissions()

--- a/alembic/versions/20260706_0035_case_resolution_workflow.py
+++ b/alembic/versions/20260706_0035_case_resolution_workflow.py
@@ -1,0 +1,27 @@
+"""Add structured case resolution workflow fields.
+
+Revision ID: 20260706_0035
+Revises: 20260705_0034
+Create Date: 2026-07-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260706_0035"
+down_revision: str | None = "20260705_0034"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("cases", sa.Column("resolution_disposition", sa.String(length=64), nullable=True))
+    op.add_column("cases", sa.Column("resolution_action", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("cases", "resolution_action")
+    op.drop_column("cases", "resolution_disposition")

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -271,10 +271,12 @@ Alert detection source of truth:
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
-| `GET` | `/api/v2/cases` | Bearer + `VIEW_CASES` | List case-management work items for non-neutral served decisions |
-| `GET` | `/api/v2/cases/{case_id}` | Bearer + `VIEW_CASES` | Read one case plus its immutable case-event timeline |
+| `GET` | `/api/v2/cases` | Bearer + `VIEW_CASES` | List case-management work items for non-neutral served decisions; supports filters such as `status`, `assigned_to`, `outcome`, `priority_min`, `decision_state`, and `q` |
+| `GET` | `/api/v2/cases/assignees` | Bearer + `VIEW_CASES` | List active same-org users available for case assignment |
+| `GET` | `/api/v2/cases/{case_id}` | Bearer + `VIEW_CASES` | Read one case, its immutable case-event timeline, and the current evaluation context |
 | `PATCH` | `/api/v2/cases/{case_id}` | Bearer + `MANAGE_CASES` | Assign or unassign a case |
-| `POST` | `/api/v2/cases/{case_id}/resolve` | Bearer + `MANAGE_CASES` | Resolve a case with a note and optional expected current evaluation id |
+| `POST` | `/api/v2/cases/{case_id}/notes` | Bearer + `MANAGE_CASES` | Add an analyst note to a case timeline |
+| `POST` | `/api/v2/cases/{case_id}/resolve` | Bearer + `MANAGE_CASES` | Resolve a case with `resolution_disposition`, `resolution_action`, a note, and optional expected current evaluation id |
 | `GET` | `/api/v2/integration-events` | Bearer + `VIEW_INTEGRATIONS` | Cursor-read versioned events such as `evaluation.completed` and `case.resolved` |
 | `GET` | `/api/v2/integration-subscriptions` | Bearer + `VIEW_INTEGRATIONS` | List outbound integration subscriptions |
 | `POST` | `/api/v2/integration-subscriptions` | Bearer + `MANAGE_INTEGRATIONS` | Create an outbound subscription such as a webhook destination |
@@ -282,6 +284,8 @@ Alert detection source of truth:
 
 Case lifecycle notes:
 - Case creation is driven by canonical served `evaluation_decisions`: missing outcomes and the configured `neutral_outcome` do not create cases.
+- Case detail includes the current transaction payload, event/evaluation identifiers, resolved outcome counters, and triggered-rule metadata when available.
+- Assignment changes emit `case.assigned`; analyst notes emit `case.note`; structured resolutions emit `case.resolved` with disposition and intended action.
 - A rescore of an active case updates the same case with the new `current_evaluation_decision_id` and records a `case.rescored` integration event.
 - A rescore to neutral/no outcome keeps the case open with a non-current decision state so an analyst can close it intentionally.
 - Resolve requests can include `expected_current_ed_id`; the API returns `409` if the case was rescored after the UI loaded.

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -255,6 +255,7 @@ Case lifecycle notes:
 - A rescore to neutral/no outcome keeps the case open with a non-current decision state so an analyst can close it intentionally.
 - Resolve requests can include `expected_current_ed_id`; the API returns `409` if the case was rescored after the UI loaded.
 - `POST /api/v2/evaluate` remains response-compatible. External systems should consume `evaluation.completed` and case lifecycle changes through `/api/v2/integration-events` or configured outbound delivery.
+- Webhook subscriptions require `config.url` to be a valid HTTPS URL. Responses omit any configured webhook `secret`.
 
 ### Settings
 

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -236,6 +236,26 @@ Alert detection source of truth:
 - Evaluation-time detection is queued after the served decision is persisted; Celery beat also sweeps enabled alert rules as a repair loop.
 - V1 delivers via the in-app notification channel. Notification channel and policy tables are intentionally separate so email, Slack, PagerDuty, and webhook channels can be added later.
 
+### Cases and Integration Events
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| `GET` | `/api/v2/cases` | Bearer + `VIEW_CASES` | List case-management work items for non-neutral served decisions |
+| `GET` | `/api/v2/cases/{case_id}` | Bearer + `VIEW_CASES` | Read one case plus its immutable case-event timeline |
+| `PATCH` | `/api/v2/cases/{case_id}` | Bearer + `MANAGE_CASES` | Assign or unassign a case |
+| `POST` | `/api/v2/cases/{case_id}/resolve` | Bearer + `MANAGE_CASES` | Resolve a case with a note and optional expected current evaluation id |
+| `GET` | `/api/v2/integration-events` | Bearer + `VIEW_INTEGRATIONS` | Cursor-read versioned events such as `evaluation.completed` and `case.resolved` |
+| `GET` | `/api/v2/integration-subscriptions` | Bearer + `VIEW_INTEGRATIONS` | List outbound integration subscriptions |
+| `POST` | `/api/v2/integration-subscriptions` | Bearer + `MANAGE_INTEGRATIONS` | Create an outbound subscription such as a webhook destination |
+| `PATCH` | `/api/v2/integration-subscriptions/{subscription_id}` | Bearer + `MANAGE_INTEGRATIONS` | Update subscription destination, event filters, or enabled state |
+
+Case lifecycle notes:
+- Case creation is driven by canonical served `evaluation_decisions`: missing outcomes and the configured `neutral_outcome` do not create cases.
+- A rescore of an active case updates the same case with the new `current_evaluation_decision_id` and records a `case.rescored` integration event.
+- A rescore to neutral/no outcome keeps the case open with a non-current decision state so an analyst can close it intentionally.
+- Resolve requests can include `expected_current_ed_id`; the API returns `409` if the case was rescored after the UI loaded.
+- `POST /api/v2/evaluate` remains response-compatible. External systems should consume `evaluation.completed` and case lifecycle changes through `/api/v2/integration-events` or configured outbound delivery.
+
 ### Settings
 
 | Method | Path | Auth | Notes |

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -271,7 +271,7 @@ Alert detection source of truth:
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
-| `GET` | `/api/v2/cases` | Bearer + `VIEW_CASES` | List case-management work items for non-neutral served decisions; supports filters such as `status`, `assigned_to`, `outcome`, `priority_min`, `decision_state`, and `q` |
+| `GET` | `/api/v2/cases` | Bearer + `VIEW_CASES` | List case-management work items for non-neutral served decisions; supports queue/search filters such as `status`, `assigned_to`, `outcome`, `priority_min`, `decision_state`, `transaction_id`, `q`, `created_from`, `created_to`, `updated_from`, and `updated_to` |
 | `GET` | `/api/v2/cases/assignees` | Bearer + `VIEW_CASES` | List active same-org users available for case assignment |
 | `GET` | `/api/v2/cases/{case_id}` | Bearer + `VIEW_CASES` | Read one case, its immutable case-event timeline, and the current evaluation context |
 | `PATCH` | `/api/v2/cases/{case_id}` | Bearer + `MANAGE_CASES` | Assign or unassign a case |
@@ -284,8 +284,13 @@ Alert detection source of truth:
 
 Case lifecycle notes:
 - Case creation is driven by canonical served `evaluation_decisions`: missing outcomes and the configured `neutral_outcome` do not create cases.
+- Case queues are assignment filters over the case list: `assigned_to=me` for the caller's queue, `assigned_to=unassigned` for unclaimed work, or `assigned_to=<user_id>` for a specific analyst.
+- Case date filters accept ISO datetimes or plain `YYYY-MM-DD` dates; date-only upper bounds include the full day.
 - Case detail includes the current transaction payload, event/evaluation identifiers, resolved outcome counters, and triggered-rule metadata when available.
 - Assignment changes emit `case.assigned`; analyst notes emit `case.note`; structured resolutions emit `case.resolved` with disposition and intended action.
+- Case lifecycle integration payloads include top-level consumer fields (`case_id`, `transaction_id`, `case_event_type`, actor/source IDs, current evaluation/event IDs, status, decision state, resolution fields, and `downstream_action`) plus nested `case` and `case_event` objects for full context.
+- `downstream_action` records analyst intent only. For example, `resolution_action=release_transaction` means an external consumer should decide whether and how to release the transaction in its own system; ezrules does not execute the release/cancel/block action itself.
+- Consumers should use the integration event `external_event_id` as the idempotency key. Webhook deliveries also send this value as `event_id` in the body and `X-Ezrules-Event-Id` in headers.
 - A rescore of an active case updates the same case with the new `current_evaluation_decision_id` and records a `case.rescored` integration event.
 - A rescore to neutral/no outcome keeps the case open with a non-current decision state so an analyst can close it intentionally.
 - Resolve requests can include `expected_current_ed_id`; the API returns `409` if the case was rescored after the UI loaded.

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -286,6 +286,7 @@ Case lifecycle notes:
 - Case creation is driven by canonical served `evaluation_decisions`: missing outcomes and the configured `neutral_outcome` do not create cases.
 - Case queues are assignment filters over the case list: `assigned_to=me` for the caller's queue, `assigned_to=unassigned` for unclaimed work, or `assigned_to=<user_id>` for a specific analyst.
 - Case date filters accept ISO datetimes or plain `YYYY-MM-DD` dates; date-only upper bounds include the full day.
+- `decision_state` filters exact stored case states, currently `current`, `rescored_neutral`, and `rescored_non_caseable`.
 - Case detail includes the current transaction payload, event/evaluation identifiers, resolved outcome counters, and triggered-rule metadata when available.
 - Assignment changes emit `case.assigned`; analyst notes emit `case.note`; structured resolutions emit `case.resolved` with disposition and intended action.
 - Case lifecycle integration payloads include top-level consumer fields (`case_id`, `transaction_id`, `case_event_type`, actor/source IDs, current evaluation/event IDs, status, decision state, resolution fields, and `downstream_action`) plus nested `case` and `case_event` objects for full context.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -168,6 +168,11 @@ If you use async field-observation buffering or async shadow evaluation:
 - keep Celery beat running so queue drain tasks execute on schedule
 - tune the `*_DRAIN_INTERVAL_SECONDS`, `*_DRAIN_BATCH_SIZE`, and `*_MAX_BATCHES_PER_DRAIN` settings only if you need different throughput or lag tradeoffs
 
+If you use outbound integration webhooks:
+
+- keep Celery workers and Celery beat running so `dispatch-integration-outbox` can deliver pending webhook events
+- expect case and evaluation events to be persisted before webhook delivery; delivery retries are handled asynchronously from the integration outbox
+
 AI-assisted rule authoring is enabled in Settings by default for new organisations. To make draft generation usable:
 
 - set `EZRULES_AI_AUTHORING_BASE_URL` if you need a non-default OpenAI endpoint

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -61,7 +61,7 @@ By the end of this page, you should have:
 
 1. Open [http://localhost:4200](http://localhost:4200)
 2. Sign in with your created user
-3. Confirm sidebar shows: **Dashboard**, **Rules**, **Shadow Rules**, **Rule Rollouts**, **Labels**, **Outcomes**, **Analytics**, **Rule Quality**, **Alerts**
+3. Confirm sidebar shows: **Dashboard**, **Rules**, **Shadow Rules**, **Rule Rollouts**, **Labels**, **Outcomes**, **Analytics**, **Rule Quality**, **Alerts**, **Cases**
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ ezrules provides building blocks to define rule-based decisions, evaluate live e
 - **Transaction Labeling** - Label events through REST API flows and analyze label trends in the UI
 - **Analytics Dashboard** - Monitor transaction volume and outcome trends with configurable time ranges
 - **Outcome Spike Alerts** - Notify operators in-app when configured outcomes exceed rolling thresholds
+- **Case Management** - Review, rescore, and resolve non-neutral decisions while publishing evaluation and case events to external systems
 - **Audit Trail** - Track rule revisions plus user list, outcome, label, and configuration history for compliance requirements
 
 ---
@@ -59,6 +60,7 @@ ezrules provides building blocks to define rule-based decisions, evaluate live e
 | **Security** | 32 permission actions with role-based access control |
 | **Labeling** | API and bulk CSV upload for transaction labels |
 | **Analytics & Alerts** | Time-series charts with 1h, 6h, 12h, 24h, 30d ranges plus outcome spike notifications |
+| **Case Management** | Resolvable cases for non-neutral served decisions plus a generic integration event stream |
 | **Database** | PostgreSQL backend with SQLAlchemy ORM |
 | **Audit Trail** | History for rules, config, user lists, outcomes, and labels |
 | **Backtesting** | Test rule changes against historical data |

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,13 +1,17 @@
 # What's New
 
-## v1.27.0
+## v1.28.0
 
 * **Case management inbox**: Non-neutral live evaluation decisions now create durable case work items linked to the canonical evaluation ledger, with a new **Cases** page for reviewing and resolving cases.
 * **Case investigation details**: Case detail now includes the transaction id, event payload, evaluation counters, and triggered-rule context so analysts can understand why a case exists before resolving it.
-* **Case workflow controls**: Analysts can now claim, assign, filter, note, and resolve cases with structured disposition/action fields that are published in case integration events.
+* **Case workflow controls**: Analysts can now claim, assign, filter queue views by ownership/search/date/priority/state, note, and resolve cases with structured disposition/action fields that are published in case integration events.
+* **Case downstream action contract**: Case lifecycle events now expose top-level consumer fields and a `downstream_action` object so external systems can react idempotently to analyst resolution intent without changing the live evaluation response.
 * **Rescoring-aware case lifecycle**: Rescored transactions update the active case with old/new decision references, while resolved cases remain auditable and later case-worthy scores create a new linked case.
 * **Generic integration events**: Evaluation completion and case lifecycle actions now write versioned integration events with a transactional outbox so external systems can poll or receive pushed delivery without changing the `/evaluate` response contract.
 * **Case and integration permissions**: Upgrades now seed the new case/integration permissions for existing admin roles, and webhook subscriptions validate HTTPS destinations before events enter the outbox.
+
+## v1.27.0
+
 * **Deterministic agent tools API**: Added `/api/v2/agent-tools` endpoints that let future fraud-management agents request bounded, permission-gated evidence instead of broad database access.
 * **Rule blast-radius analysis**: Added `POST /api/v2/agent-tools/rule-blast-radius` to compare proposed rule logic against recent served decisions, including outcome deltas, grouped single-rule outcome flip rates, representative flipped events, and replay warnings.
 * **Rule counterexample mining**: Added `POST /api/v2/agent-tools/rule-counterexamples` to return labeled false-positive, missed-positive, candidate-fix, and candidate-regression examples for rule review workflows.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -3,6 +3,8 @@
 ## v1.27.0
 
 * **Case management inbox**: Non-neutral live evaluation decisions now create durable case work items linked to the canonical evaluation ledger, with a new **Cases** page for reviewing and resolving cases.
+* **Case investigation details**: Case detail now includes the transaction id, event payload, evaluation counters, and triggered-rule context so analysts can understand why a case exists before resolving it.
+* **Case workflow controls**: Analysts can now claim, assign, filter, note, and resolve cases with structured disposition/action fields that are published in case integration events.
 * **Rescoring-aware case lifecycle**: Rescored transactions update the active case with old/new decision references, while resolved cases remain auditable and later case-worthy scores create a new linked case.
 * **Generic integration events**: Evaluation completion and case lifecycle actions now write versioned integration events with a transactional outbox so external systems can poll or receive pushed delivery without changing the `/evaluate` response contract.
 * **Case and integration permissions**: Upgrades now seed the new case/integration permissions for existing admin roles, and webhook subscriptions validate HTTPS destinations before events enter the outbox.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.27.0
+
+* **Case management inbox**: Non-neutral live evaluation decisions now create durable case work items linked to the canonical evaluation ledger, with a new **Cases** page for reviewing and resolving cases.
+* **Rescoring-aware case lifecycle**: Rescored transactions update the active case with old/new decision references, while resolved cases remain auditable and later case-worthy scores create a new linked case.
+* **Generic integration events**: Evaluation completion and case lifecycle actions now write versioned integration events with a transactional outbox so external systems can poll or receive pushed delivery without changing the `/evaluate` response contract.
+
 ## v1.26.0
 
 * **Recent rule triggers**: Rule detail pages now show recent served transactions where the rule produced an outcome, with a fixed-size **Load more** flow for reviewing additional trigger history without leaving the page.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -5,6 +5,7 @@
 * **Case management inbox**: Non-neutral live evaluation decisions now create durable case work items linked to the canonical evaluation ledger, with a new **Cases** page for reviewing and resolving cases.
 * **Rescoring-aware case lifecycle**: Rescored transactions update the active case with old/new decision references, while resolved cases remain auditable and later case-worthy scores create a new linked case.
 * **Generic integration events**: Evaluation completion and case lifecycle actions now write versioned integration events with a transactional outbox so external systems can poll or receive pushed delivery without changing the `/evaluate` response contract.
+* **Case and integration permissions**: Upgrades now seed the new case/integration permissions for existing admin roles, and webhook subscriptions validate HTTPS destinations before events enter the outbox.
 
 ## v1.26.0
 

--- a/ezrules/backend/api_v2/main.py
+++ b/ezrules/backend/api_v2/main.py
@@ -25,6 +25,7 @@ from ezrules.backend.api_v2.routes import (
     audit,
     auth,
     backtesting,
+    cases,
     evaluator,
     features,
     field_types,
@@ -189,3 +190,6 @@ app.include_router(api_keys.router)
 
 # Runtime settings routes: /api/v2/settings/*
 app.include_router(settings.router)
+
+# Case management and integration event routes: /api/v2/cases/*, /api/v2/integration-*
+app.include_router(cases.router)

--- a/ezrules/backend/api_v2/routes/cases.py
+++ b/ezrules/backend/api_v2/routes/cases.py
@@ -26,7 +26,7 @@ from ezrules.backend.api_v2.schemas.cases import (
     IntegrationSubscriptionsResponse,
     IntegrationSubscriptionUpdate,
 )
-from ezrules.backend.cases import CaseConflictError, CaseNotFoundError, assign_case, resolve_case
+from ezrules.backend.cases import CaseConflictError, CaseNotFoundError, CaseValidationError, assign_case, resolve_case
 from ezrules.backend.integrations import list_integration_events
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import Case, CaseEvent, IntegrationEvent, IntegrationSubscription, User
@@ -175,6 +175,8 @@ def update_case(
         )
     except CaseNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found") from exc
+    except CaseValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     db.commit()
     return CaseMutationResponse(success=True, message="Case updated", case=_case_to_response(case))
 

--- a/ezrules/backend/api_v2/routes/cases.py
+++ b/ezrules/backend/api_v2/routes/cases.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlparse
 
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from ezrules.backend.api_v2.auth.dependencies import (
@@ -130,7 +131,7 @@ def list_cases(
     if status_filter:
         query = query.filter(Case.status == status_filter)
     if outcome:
-        query = query.filter(Case.resolved_outcome == outcome.strip().upper())
+        query = query.filter(sa.func.upper(Case.resolved_outcome) == outcome.strip().upper())
     total = int(query.count())
     cases = query.order_by(Case.updated_at.desc(), Case.case_id.desc()).offset(offset).limit(limit).all()
     return CaseListResponse(cases=[_case_to_response(case) for case in cases], total=total)
@@ -165,6 +166,12 @@ def update_case(
     current_org_id: int = Depends(get_current_org_id),
     db: Any = Depends(get_db),
 ) -> CaseMutationResponse:
+    if "assigned_to_user_id" not in payload.model_fields_set:
+        case = db.query(Case).filter(Case.o_id == current_org_id, Case.case_id == case_id).first()
+        if case is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+        return CaseMutationResponse(success=True, message="Case unchanged", case=_case_to_response(case))
+
     try:
         case = assign_case(
             db,
@@ -204,6 +211,8 @@ def resolve_case_route(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found") from exc
     except CaseConflictError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except CaseValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     db.commit()
     return CaseMutationResponse(success=True, message="Case resolved", case=_case_to_response(case))
 
@@ -299,7 +308,9 @@ def update_subscription(
         if payload.destination_type is not None
         else str(subscription.destination_type)
     )
-    config = dict(payload.config) if payload.config is not None else dict(subscription.config or {})
+    config = dict(subscription.config or {})
+    if payload.config is not None:
+        config.update(payload.config)
     _validate_subscription_config(destination_type=destination_type, config=config)
     if payload.name is not None:
         subscription.name = payload.name.strip()

--- a/ezrules/backend/api_v2/routes/cases.py
+++ b/ezrules/backend/api_v2/routes/cases.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import sqlalchemy as sa
@@ -12,10 +12,15 @@ from ezrules.backend.api_v2.auth.dependencies import (
     require_permission,
 )
 from ezrules.backend.api_v2.schemas.cases import (
+    CaseAssigneeResponse,
+    CaseAssigneesResponse,
     CaseDetailResponse,
+    CaseEvaluationResponse,
+    CaseEventMutationResponse,
     CaseEventResponse,
     CaseListResponse,
     CaseMutationResponse,
+    CaseNoteRequest,
     CaseResolveRequest,
     CaseResponse,
     CaseUpdateRequest,
@@ -27,12 +32,32 @@ from ezrules.backend.api_v2.schemas.cases import (
     IntegrationSubscriptionsResponse,
     IntegrationSubscriptionUpdate,
 )
-from ezrules.backend.cases import CaseConflictError, CaseNotFoundError, CaseValidationError, assign_case, resolve_case
+from ezrules.backend.api_v2.schemas.tested_events import TriggeredRuleItem
+from ezrules.backend.cases import (
+    CaseConflictError,
+    CaseNotFoundError,
+    CaseValidationError,
+    add_case_note,
+    assign_case,
+    resolve_case,
+)
 from ezrules.backend.integrations import list_integration_events
 from ezrules.core.permissions_constants import PermissionAction
-from ezrules.models.backend_core import Case, CaseEvent, IntegrationEvent, IntegrationSubscription, User
+from ezrules.models.backend_core import (
+    Case,
+    CaseEvent,
+    EvaluationDecision,
+    EvaluationRuleResult,
+    EventVersion,
+    IntegrationEvent,
+    IntegrationSubscription,
+    Rule,
+    User,
+)
 
 router = APIRouter(prefix="/api/v2", tags=["Cases"])
+RULE_METADATA_SOURCE_CURRENT_FALLBACK = "current_rule_fallback"
+RULE_METADATA_SOURCE_UNAVAILABLE = "unavailable"
 
 
 def _validate_subscription_config(*, destination_type: str, config: dict[str, Any]) -> None:
@@ -48,7 +73,10 @@ def _validate_subscription_config(*, destination_type: str, config: dict[str, An
         )
 
 
-def _case_to_response(case: Case) -> CaseResponse:
+def _case_to_response(case: Case, user_emails_by_id: dict[int, str] | None = None) -> CaseResponse:
+    user_emails_by_id = user_emails_by_id or {}
+    assigned_to_user_id = int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None
+    resolved_by_user_id = int(case.resolved_by_user_id) if case.resolved_by_user_id is not None else None
     return CaseResponse(
         id=int(case.case_id),
         transaction_id=str(case.transaction_id),
@@ -61,8 +89,12 @@ def _case_to_response(case: Case) -> CaseResponse:
         status=str(case.status),
         decision_state=str(case.decision_state),
         priority=int(case.priority),
-        assigned_to_user_id=int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None,
-        resolved_by_user_id=int(case.resolved_by_user_id) if case.resolved_by_user_id is not None else None,
+        assigned_to_user_id=assigned_to_user_id,
+        assigned_to_email=user_emails_by_id.get(assigned_to_user_id) if assigned_to_user_id is not None else None,
+        resolved_by_user_id=resolved_by_user_id,
+        resolved_by_email=user_emails_by_id.get(resolved_by_user_id) if resolved_by_user_id is not None else None,
+        resolution_disposition=str(case.resolution_disposition) if case.resolution_disposition else None,
+        resolution_action=str(case.resolution_action) if case.resolution_action else None,
         resolution_note=str(case.resolution_note) if case.resolution_note else None,
         resolution_label_id=int(case.resolution_label_id) if case.resolution_label_id is not None else None,
         reopened_from_case_id=int(case.reopened_from_case_id) if case.reopened_from_case_id is not None else None,
@@ -70,6 +102,21 @@ def _case_to_response(case: Case) -> CaseResponse:
         updated_at=case.updated_at,  # type: ignore[arg-type]
         resolved_at=case.resolved_at if case.resolved_at else None,  # type: ignore[arg-type]
     )
+
+
+def _user_emails_for_cases(db: Any, *, cases: list[Case], current_org_id: int) -> dict[int, str]:
+    user_ids = {
+        int(user_id)
+        for case in cases
+        for user_id in (case.assigned_to_user_id, case.resolved_by_user_id)
+        if user_id is not None
+    }
+    if not user_ids:
+        return {}
+    return {
+        int(user.id): str(user.email)
+        for user in db.query(User).filter(User.o_id == current_org_id, User.id.in_(sorted(user_ids))).all()
+    }
 
 
 def _case_event_to_response(event: CaseEvent) -> CaseEventResponse:
@@ -83,6 +130,122 @@ def _case_event_to_response(event: CaseEvent) -> CaseEventResponse:
         occurred_at=event.occurred_at,  # type: ignore[arg-type]
         details=event.details if isinstance(event.details, dict) else {},
         created_at=event.created_at,  # type: ignore[arg-type]
+    )
+
+
+def _triggered_rule_response(
+    *,
+    r_id: int,
+    outcome: Any,
+    rule: Rule | None,
+    snapshot_rid: str | None = None,
+    snapshot_description: str | None = None,
+    snapshot_referenced_fields: list[Any] | None = None,
+    metadata_source: str | None = None,
+) -> TriggeredRuleItem:
+    if snapshot_rid is not None or snapshot_description is not None or snapshot_referenced_fields is not None:
+        fallback_rid = str(rule.rid) if rule is not None else f"rule-{r_id}"
+        fallback_description = str(rule.description) if rule is not None else ""
+        rid = str(snapshot_rid or fallback_rid)
+        description = str(snapshot_description or fallback_description)
+        source = str(metadata_source or "evaluation_snapshot")
+        referenced_fields = sorted(str(field) for field in (snapshot_referenced_fields or []))
+    elif rule is not None:
+        rid = str(rule.rid)
+        description = str(rule.description)
+        source = RULE_METADATA_SOURCE_CURRENT_FALLBACK
+        referenced_fields = None
+    else:
+        rid = f"rule-{r_id}"
+        description = "Rule metadata unavailable"
+        source = RULE_METADATA_SOURCE_UNAVAILABLE
+        referenced_fields = None
+
+    return TriggeredRuleItem(
+        r_id=r_id,
+        rid=rid,
+        description=description,
+        outcome=str(outcome),
+        metadata_source=source,
+        referenced_fields=referenced_fields,
+    )
+
+
+def _case_evaluation_to_response(db: Any, *, current_org_id: int, case: Case) -> CaseEvaluationResponse | None:
+    decision = (
+        db.query(EvaluationDecision)
+        .filter(EvaluationDecision.o_id == current_org_id, EvaluationDecision.ed_id == case.current_ed_id)
+        .first()
+    )
+    event_version = (
+        db.query(EventVersion)
+        .filter(EventVersion.o_id == current_org_id, EventVersion.ev_id == case.current_ev_id)
+        .first()
+    )
+    if decision is None or event_version is None:
+        return None
+
+    triggered_rules: list[TriggeredRuleItem] = []
+    seen_rule_ids: set[int] = set()
+    rule_result_rows = (
+        db.query(EvaluationRuleResult, Rule)
+        .outerjoin(Rule, Rule.r_id == EvaluationRuleResult.r_id)
+        .filter(EvaluationRuleResult.ed_id == decision.ed_id)
+        .order_by(EvaluationRuleResult.r_id.asc())
+        .all()
+    )
+    for rule_result, rule in rule_result_rows:
+        rule_id = int(rule_result.r_id)
+        seen_rule_ids.add(rule_id)
+        referenced_fields = rule_result.referenced_fields if isinstance(rule_result.referenced_fields, list) else None
+        triggered_rules.append(
+            _triggered_rule_response(
+                r_id=rule_id,
+                outcome=rule_result.rule_result,
+                rule=rule,
+                snapshot_rid=rule_result.rule_rid,
+                snapshot_description=rule_result.rule_description,
+                snapshot_referenced_fields=referenced_fields,
+                metadata_source=rule_result.metadata_source,
+            )
+        )
+
+    all_rule_results = dict(cast(dict[Any, Any], decision.all_rule_results or {}))
+    missing_rule_results = [
+        (int(rule_id), outcome)
+        for rule_id, outcome in all_rule_results.items()
+        if str(rule_id).isdigit() and outcome is not None and int(rule_id) not in seen_rule_ids
+    ]
+    rules_by_id = {}
+    if missing_rule_results:
+        rules_by_id = {
+            int(rule.r_id): rule
+            for rule in db.query(Rule)
+            .filter(Rule.o_id == current_org_id, Rule.r_id.in_([rule_id for rule_id, _outcome in missing_rule_results]))
+            .all()
+        }
+    for rule_id, outcome in missing_rule_results:
+        triggered_rules.append(
+            _triggered_rule_response(
+                r_id=rule_id,
+                outcome=outcome,
+                rule=rules_by_id.get(rule_id),
+            )
+        )
+
+    return CaseEvaluationResponse(
+        evaluation_decision_id=int(decision.ed_id),
+        transaction_id=str(decision.transaction_id),
+        event_version_id=int(event_version.ev_id),
+        event_version=int(decision.event_version),
+        effective_at=decision.effective_at,  # type: ignore[arg-type]
+        observed_at=decision.observed_at,  # type: ignore[arg-type]
+        evaluated_at=decision.evaluated_at,  # type: ignore[arg-type]
+        is_current=bool(decision.is_current),
+        resolved_outcome=str(decision.resolved_outcome) if decision.resolved_outcome is not None else None,
+        outcome_counters=dict(cast(dict[str, int], decision.outcome_counters or {})),
+        event_data=dict(cast(dict[str, Any], event_version.event_data or {})),
+        triggered_rules=triggered_rules,
     )
 
 
@@ -120,6 +283,10 @@ def _subscription_to_response(subscription: IntegrationSubscription) -> Integrat
 def list_cases(
     status_filter: str | None = Query(default=None, alias="status"),
     outcome: str | None = None,
+    assigned_to: str | None = None,
+    priority_min: int | None = Query(default=None, ge=0),
+    decision_state: str | None = None,
+    q: str | None = None,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     user: User = Depends(get_current_active_user),
@@ -132,9 +299,40 @@ def list_cases(
         query = query.filter(Case.status == status_filter)
     if outcome:
         query = query.filter(sa.func.upper(Case.resolved_outcome) == outcome.strip().upper())
+    if assigned_to:
+        normalized_assigned_to = assigned_to.strip().lower()
+        if normalized_assigned_to in {"me", "assigned_to_me"}:
+            query = query.filter(Case.assigned_to_user_id == int(user.id))
+        elif normalized_assigned_to in {"none", "unassigned"}:
+            query = query.filter(Case.assigned_to_user_id.is_(None))
+        elif normalized_assigned_to.isdigit():
+            query = query.filter(Case.assigned_to_user_id == int(normalized_assigned_to))
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="assigned_to must be 'me', 'unassigned', or a user id.",
+            )
+    if priority_min is not None:
+        query = query.filter(Case.priority >= priority_min)
+    if decision_state:
+        query = query.filter(Case.decision_state == decision_state.strip())
+    if q:
+        query = query.filter(Case.transaction_id.ilike(f"%{q.strip()}%"))
     total = int(query.count())
     cases = query.order_by(Case.updated_at.desc(), Case.case_id.desc()).offset(offset).limit(limit).all()
-    return CaseListResponse(cases=[_case_to_response(case) for case in cases], total=total)
+    user_emails = _user_emails_for_cases(db, cases=cases, current_org_id=current_org_id)
+    return CaseListResponse(cases=[_case_to_response(case, user_emails) for case in cases], total=total)
+
+
+@router.get("/cases/assignees", response_model=CaseAssigneesResponse)
+def list_case_assignees(
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> CaseAssigneesResponse:
+    users = db.query(User).filter(User.o_id == current_org_id, User.active.is_(True)).order_by(User.email.asc()).all()
+    return CaseAssigneesResponse(users=[CaseAssigneeResponse(id=int(item.id), email=str(item.email)) for item in users])
 
 
 @router.get("/cases/{case_id}", response_model=CaseDetailResponse)
@@ -154,7 +352,12 @@ def get_case(
         .order_by(CaseEvent.created_at.asc(), CaseEvent.case_event_id.asc())
         .all()
     )
-    return CaseDetailResponse(case=_case_to_response(case), events=[_case_event_to_response(event) for event in events])
+    user_emails = _user_emails_for_cases(db, cases=[case], current_org_id=current_org_id)
+    return CaseDetailResponse(
+        case=_case_to_response(case, user_emails),
+        events=[_case_event_to_response(event) for event in events],
+        evaluation=_case_evaluation_to_response(db, current_org_id=current_org_id, case=case),
+    )
 
 
 @router.patch("/cases/{case_id}", response_model=CaseMutationResponse)
@@ -170,7 +373,8 @@ def update_case(
         case = db.query(Case).filter(Case.o_id == current_org_id, Case.case_id == case_id).first()
         if case is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
-        return CaseMutationResponse(success=True, message="Case unchanged", case=_case_to_response(case))
+        user_emails = _user_emails_for_cases(db, cases=[case], current_org_id=current_org_id)
+        return CaseMutationResponse(success=True, message="Case unchanged", case=_case_to_response(case, user_emails))
 
     try:
         case = assign_case(
@@ -185,7 +389,31 @@ def update_case(
     except CaseValidationError as exc:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     db.commit()
-    return CaseMutationResponse(success=True, message="Case updated", case=_case_to_response(case))
+    user_emails = _user_emails_for_cases(db, cases=[case], current_org_id=current_org_id)
+    return CaseMutationResponse(success=True, message="Case updated", case=_case_to_response(case, user_emails))
+
+
+@router.post("/cases/{case_id}/notes", response_model=CaseEventMutationResponse, status_code=status.HTTP_201_CREATED)
+def add_case_note_route(
+    case_id: int,
+    payload: CaseNoteRequest,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.MANAGE_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> CaseEventMutationResponse:
+    try:
+        event = add_case_note(
+            db,
+            o_id=current_org_id,
+            case_id=case_id,
+            actor_user_id=int(user.id),
+            note=payload.note,
+        )
+    except CaseNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found") from exc
+    db.commit()
+    return CaseEventMutationResponse(success=True, message="Case note added", event=_case_event_to_response(event))
 
 
 @router.post("/cases/{case_id}/resolve", response_model=CaseMutationResponse)
@@ -203,6 +431,8 @@ def resolve_case_route(
             o_id=current_org_id,
             case_id=case_id,
             actor_user_id=int(user.id),
+            resolution_disposition=payload.resolution_disposition,
+            resolution_action=payload.resolution_action,
             resolution_note=payload.resolution_note,
             resolution_label_id=payload.resolution_label_id,
             expected_current_ed_id=payload.expected_current_ed_id,
@@ -214,7 +444,8 @@ def resolve_case_route(
     except CaseValidationError as exc:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     db.commit()
-    return CaseMutationResponse(success=True, message="Case resolved", case=_case_to_response(case))
+    user_emails = _user_emails_for_cases(db, cases=[case], current_org_id=current_org_id)
+    return CaseMutationResponse(success=True, message="Case resolved", case=_case_to_response(case, user_emails))
 
 
 @router.get("/integration-events", response_model=IntegrationEventsResponse)

--- a/ezrules/backend/api_v2/routes/cases.py
+++ b/ezrules/backend/api_v2/routes/cases.py
@@ -1,0 +1,294 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ezrules.backend.api_v2.auth.dependencies import (
+    get_current_active_user,
+    get_current_org_id,
+    get_db,
+    require_permission,
+)
+from ezrules.backend.api_v2.schemas.cases import (
+    CaseDetailResponse,
+    CaseEventResponse,
+    CaseListResponse,
+    CaseMutationResponse,
+    CaseResolveRequest,
+    CaseResponse,
+    CaseUpdateRequest,
+    IntegrationEventResponse,
+    IntegrationEventsResponse,
+    IntegrationSubscriptionCreate,
+    IntegrationSubscriptionMutationResponse,
+    IntegrationSubscriptionResponse,
+    IntegrationSubscriptionsResponse,
+    IntegrationSubscriptionUpdate,
+)
+from ezrules.backend.cases import CaseConflictError, CaseNotFoundError, assign_case, resolve_case
+from ezrules.backend.integrations import list_integration_events
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import Case, CaseEvent, IntegrationEvent, IntegrationSubscription, User
+
+router = APIRouter(prefix="/api/v2", tags=["Cases"])
+
+
+def _case_to_response(case: Case) -> CaseResponse:
+    return CaseResponse(
+        id=int(case.case_id),
+        transaction_id=str(case.transaction_id),
+        current_event_version_id=int(case.current_ev_id),
+        current_evaluation_decision_id=int(case.current_ed_id),
+        opened_by_evaluation_decision_id=int(case.opened_by_ed_id),
+        previous_evaluation_decision_id=int(case.previous_ed_id) if case.previous_ed_id is not None else None,
+        resolved_outcome=str(case.resolved_outcome) if case.resolved_outcome else None,
+        previous_resolved_outcome=str(case.previous_resolved_outcome) if case.previous_resolved_outcome else None,
+        status=str(case.status),
+        decision_state=str(case.decision_state),
+        priority=int(case.priority),
+        assigned_to_user_id=int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None,
+        resolved_by_user_id=int(case.resolved_by_user_id) if case.resolved_by_user_id is not None else None,
+        resolution_note=str(case.resolution_note) if case.resolution_note else None,
+        resolution_label_id=int(case.resolution_label_id) if case.resolution_label_id is not None else None,
+        reopened_from_case_id=int(case.reopened_from_case_id) if case.reopened_from_case_id is not None else None,
+        created_at=case.created_at,  # type: ignore[arg-type]
+        updated_at=case.updated_at,  # type: ignore[arg-type]
+        resolved_at=case.resolved_at if case.resolved_at else None,  # type: ignore[arg-type]
+    )
+
+
+def _case_event_to_response(event: CaseEvent) -> CaseEventResponse:
+    return CaseEventResponse(
+        id=int(event.case_event_id),
+        case_id=int(event.case_id),
+        event_type=str(event.event_type),
+        actor_user_id=int(event.actor_user_id) if event.actor_user_id is not None else None,
+        source_ed_id=int(event.source_ed_id) if event.source_ed_id is not None else None,
+        external_event_id=str(event.external_event_id),
+        occurred_at=event.occurred_at,  # type: ignore[arg-type]
+        details=event.details if isinstance(event.details, dict) else {},
+        created_at=event.created_at,  # type: ignore[arg-type]
+    )
+
+
+def _integration_event_to_response(event: IntegrationEvent) -> IntegrationEventResponse:
+    return IntegrationEventResponse(
+        id=int(event.integration_event_id),
+        external_event_id=str(event.external_event_id),
+        source_type=str(event.source_type),
+        source_id=int(event.source_id),
+        event_type=str(event.event_type),
+        event_version=int(event.event_version),
+        occurred_at=event.occurred_at,  # type: ignore[arg-type]
+        payload=event.payload if isinstance(event.payload, dict) else {},
+        created_at=event.created_at,  # type: ignore[arg-type]
+    )
+
+
+def _subscription_to_response(subscription: IntegrationSubscription) -> IntegrationSubscriptionResponse:
+    event_types = subscription.event_types if isinstance(subscription.event_types, list) else []
+    config = dict(subscription.config) if isinstance(subscription.config, dict) else {}
+    config.pop("secret", None)
+    return IntegrationSubscriptionResponse(
+        id=int(subscription.subscription_id),
+        name=str(subscription.name),
+        destination_type=str(subscription.destination_type),
+        config=config,
+        event_types=[str(event_type) for event_type in event_types],
+        enabled=bool(subscription.enabled),
+        created_at=subscription.created_at,  # type: ignore[arg-type]
+        updated_at=subscription.updated_at,  # type: ignore[arg-type]
+    )
+
+
+@router.get("/cases", response_model=CaseListResponse)
+def list_cases(
+    status_filter: str | None = Query(default=None, alias="status"),
+    outcome: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> CaseListResponse:
+    query = db.query(Case).filter(Case.o_id == current_org_id)
+    if status_filter:
+        query = query.filter(Case.status == status_filter)
+    if outcome:
+        query = query.filter(Case.resolved_outcome == outcome.strip().upper())
+    total = int(query.count())
+    cases = query.order_by(Case.updated_at.desc(), Case.case_id.desc()).offset(offset).limit(limit).all()
+    return CaseListResponse(cases=[_case_to_response(case) for case in cases], total=total)
+
+
+@router.get("/cases/{case_id}", response_model=CaseDetailResponse)
+def get_case(
+    case_id: int,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> CaseDetailResponse:
+    case = db.query(Case).filter(Case.o_id == current_org_id, Case.case_id == case_id).first()
+    if case is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found")
+    events = (
+        db.query(CaseEvent)
+        .filter(CaseEvent.o_id == current_org_id, CaseEvent.case_id == case_id)
+        .order_by(CaseEvent.created_at.asc(), CaseEvent.case_event_id.asc())
+        .all()
+    )
+    return CaseDetailResponse(case=_case_to_response(case), events=[_case_event_to_response(event) for event in events])
+
+
+@router.patch("/cases/{case_id}", response_model=CaseMutationResponse)
+def update_case(
+    case_id: int,
+    payload: CaseUpdateRequest,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.MANAGE_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> CaseMutationResponse:
+    try:
+        case = assign_case(
+            db,
+            o_id=current_org_id,
+            case_id=case_id,
+            actor_user_id=int(user.id),
+            assignee_user_id=payload.assigned_to_user_id,
+        )
+    except CaseNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found") from exc
+    db.commit()
+    return CaseMutationResponse(success=True, message="Case updated", case=_case_to_response(case))
+
+
+@router.post("/cases/{case_id}/resolve", response_model=CaseMutationResponse)
+def resolve_case_route(
+    case_id: int,
+    payload: CaseResolveRequest,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.MANAGE_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> CaseMutationResponse:
+    try:
+        case = resolve_case(
+            db,
+            o_id=current_org_id,
+            case_id=case_id,
+            actor_user_id=int(user.id),
+            resolution_note=payload.resolution_note,
+            resolution_label_id=payload.resolution_label_id,
+            expected_current_ed_id=payload.expected_current_ed_id,
+        )
+    except CaseNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Case not found") from exc
+    except CaseConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    db.commit()
+    return CaseMutationResponse(success=True, message="Case resolved", case=_case_to_response(case))
+
+
+@router.get("/integration-events", response_model=IntegrationEventsResponse)
+def list_events(
+    cursor: int | None = Query(default=None, ge=1),
+    event_type: str | None = None,
+    limit: int = Query(default=100, ge=1, le=500),
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_INTEGRATIONS)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> IntegrationEventsResponse:
+    events = list_integration_events(db, o_id=current_org_id, after_id=cursor, event_type=event_type, limit=limit)
+    next_cursor = int(events[-1].integration_event_id) if len(events) == limit else None
+    return IntegrationEventsResponse(
+        events=[_integration_event_to_response(event) for event in events], next_cursor=next_cursor
+    )
+
+
+@router.get("/integration-subscriptions", response_model=IntegrationSubscriptionsResponse)
+def list_subscriptions(
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_INTEGRATIONS)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> IntegrationSubscriptionsResponse:
+    subscriptions = (
+        db.query(IntegrationSubscription)
+        .filter(IntegrationSubscription.o_id == current_org_id)
+        .order_by(IntegrationSubscription.created_at.desc(), IntegrationSubscription.subscription_id.desc())
+        .all()
+    )
+    return IntegrationSubscriptionsResponse(subscriptions=[_subscription_to_response(item) for item in subscriptions])
+
+
+@router.post(
+    "/integration-subscriptions",
+    response_model=IntegrationSubscriptionMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_subscription(
+    payload: IntegrationSubscriptionCreate,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.MANAGE_INTEGRATIONS)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> IntegrationSubscriptionMutationResponse:
+    now = datetime.now(UTC)
+    subscription = IntegrationSubscription(
+        o_id=current_org_id,
+        name=payload.name.strip(),
+        destination_type=payload.destination_type.strip(),
+        config=payload.config,
+        event_types=payload.event_types,
+        enabled=payload.enabled,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(subscription)
+    db.commit()
+    return IntegrationSubscriptionMutationResponse(
+        success=True,
+        message="Integration subscription created",
+        subscription=_subscription_to_response(subscription),
+    )
+
+
+@router.patch("/integration-subscriptions/{subscription_id}", response_model=IntegrationSubscriptionMutationResponse)
+def update_subscription(
+    subscription_id: int,
+    payload: IntegrationSubscriptionUpdate,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.MANAGE_INTEGRATIONS)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> IntegrationSubscriptionMutationResponse:
+    subscription = (
+        db.query(IntegrationSubscription)
+        .filter(
+            IntegrationSubscription.o_id == current_org_id, IntegrationSubscription.subscription_id == subscription_id
+        )
+        .first()
+    )
+    if subscription is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Integration subscription not found")
+    if payload.name is not None:
+        subscription.name = payload.name.strip()
+    if payload.destination_type is not None:
+        subscription.destination_type = payload.destination_type.strip()
+    if payload.config is not None:
+        subscription.config = payload.config
+    if payload.event_types is not None:
+        subscription.event_types = payload.event_types
+    if payload.enabled is not None:
+        subscription.enabled = payload.enabled
+    subscription.updated_at = datetime.now(UTC)
+    db.commit()
+    return IntegrationSubscriptionMutationResponse(
+        success=True,
+        message="Integration subscription updated",
+        subscription=_subscription_to_response(subscription),
+    )

--- a/ezrules/backend/api_v2/routes/cases.py
+++ b/ezrules/backend/api_v2/routes/cases.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, time
 from typing import Any, cast
 from urllib.parse import urlparse
 
@@ -71,6 +71,31 @@ def _validate_subscription_config(*, destination_type: str, config: dict[str, An
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Webhook subscriptions require config.url to be an HTTPS URL.",
         )
+
+
+def _parse_case_filter_datetime(raw_value: str | None, *, param_name: str, end_of_day: bool = False) -> datetime | None:
+    if not raw_value:
+        return None
+
+    value = raw_value.strip()
+    if not value:
+        return None
+
+    try:
+        if len(value) == 10:
+            parsed_date = date.fromisoformat(value)
+            boundary = time.max if end_of_day else time.min
+            return datetime.combine(parsed_date, boundary, tzinfo=UTC)
+        parsed_datetime = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"{param_name} must be an ISO date or datetime.",
+        ) from exc
+
+    if parsed_datetime.tzinfo is None:
+        return parsed_datetime.replace(tzinfo=UTC)
+    return parsed_datetime
 
 
 def _case_to_response(case: Case, user_emails_by_id: dict[int, str] | None = None) -> CaseResponse:
@@ -286,7 +311,12 @@ def list_cases(
     assigned_to: str | None = None,
     priority_min: int | None = Query(default=None, ge=0),
     decision_state: str | None = None,
+    transaction_id: str | None = None,
     q: str | None = None,
+    created_from: str | None = None,
+    created_to: str | None = None,
+    updated_from: str | None = None,
+    updated_to: str | None = None,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
     user: User = Depends(get_current_active_user),
@@ -316,8 +346,22 @@ def list_cases(
         query = query.filter(Case.priority >= priority_min)
     if decision_state:
         query = query.filter(Case.decision_state == decision_state.strip())
+    if transaction_id:
+        query = query.filter(Case.transaction_id == transaction_id.strip())
     if q:
         query = query.filter(Case.transaction_id.ilike(f"%{q.strip()}%"))
+    created_from_value = _parse_case_filter_datetime(created_from, param_name="created_from")
+    created_to_value = _parse_case_filter_datetime(created_to, param_name="created_to", end_of_day=True)
+    updated_from_value = _parse_case_filter_datetime(updated_from, param_name="updated_from")
+    updated_to_value = _parse_case_filter_datetime(updated_to, param_name="updated_to", end_of_day=True)
+    if created_from_value is not None:
+        query = query.filter(Case.created_at >= created_from_value)
+    if created_to_value is not None:
+        query = query.filter(Case.created_at <= created_to_value)
+    if updated_from_value is not None:
+        query = query.filter(Case.updated_at >= updated_from_value)
+    if updated_to_value is not None:
+        query = query.filter(Case.updated_at <= updated_to_value)
     total = int(query.count())
     cases = query.order_by(Case.updated_at.desc(), Case.case_id.desc()).offset(offset).limit(limit).all()
     user_emails = _user_emails_for_cases(db, cases=cases, current_org_id=current_org_id)

--- a/ezrules/backend/api_v2/routes/cases.py
+++ b/ezrules/backend/api_v2/routes/cases.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -31,6 +32,19 @@ from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import Case, CaseEvent, IntegrationEvent, IntegrationSubscription, User
 
 router = APIRouter(prefix="/api/v2", tags=["Cases"])
+
+
+def _validate_subscription_config(*, destination_type: str, config: dict[str, Any]) -> None:
+    if destination_type.strip().lower() != "webhook":
+        return
+
+    url = str(config.get("url") or "").strip()
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Webhook subscriptions require config.url to be an HTTPS URL.",
+        )
 
 
 def _case_to_response(case: Case) -> CaseResponse:
@@ -238,11 +252,14 @@ def create_subscription(
     db: Any = Depends(get_db),
 ) -> IntegrationSubscriptionMutationResponse:
     now = datetime.now(UTC)
+    destination_type = payload.destination_type.strip().lower()
+    config = dict(payload.config)
+    _validate_subscription_config(destination_type=destination_type, config=config)
     subscription = IntegrationSubscription(
         o_id=current_org_id,
         name=payload.name.strip(),
-        destination_type=payload.destination_type.strip(),
-        config=payload.config,
+        destination_type=destination_type,
+        config=config,
         event_types=payload.event_types,
         enabled=payload.enabled,
         created_at=now,
@@ -275,12 +292,19 @@ def update_subscription(
     )
     if subscription is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Integration subscription not found")
+    destination_type = (
+        payload.destination_type.strip().lower()
+        if payload.destination_type is not None
+        else str(subscription.destination_type)
+    )
+    config = dict(payload.config) if payload.config is not None else dict(subscription.config or {})
+    _validate_subscription_config(destination_type=destination_type, config=config)
     if payload.name is not None:
         subscription.name = payload.name.strip()
     if payload.destination_type is not None:
-        subscription.destination_type = payload.destination_type.strip()
+        subscription.destination_type = destination_type
     if payload.config is not None:
-        subscription.config = payload.config
+        subscription.config = config
     if payload.event_types is not None:
         subscription.event_types = payload.event_types
     if payload.enabled is not None:

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -318,7 +318,6 @@ def evaluate(
             enqueue_case_detection(
                 o_id=int(lre.o_id),
                 evaluation_decision_id=int(result["evaluation_decision_id"]),
-                resolved_outcome=result.get("resolved_outcome"),
             )
             _persist_evaluate_observations(db, request_data.event_data, lre.o_id)
             return EvaluateResponse(
@@ -387,7 +386,6 @@ def evaluate(
         enqueue_case_detection(
             o_id=int(lre.o_id),
             evaluation_decision_id=int(evaluation_decision_id),
-            resolved_outcome=result.get("resolved_outcome"),
         )
     except Exception as exc:
         raise HTTPException(

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -291,6 +291,17 @@ def evaluate(
     data_utils.lock_transaction_for_evaluation(db, lre.o_id, event.transaction_id)
     duplicate = data_utils.find_duplicate_evaluation(db, lre.o_id, event)
     if duplicate is not None:
+        duplicate_evaluation_id = duplicate.get("evaluation_id")
+        if duplicate_evaluation_id is not None:
+            enqueue_alert_detection(
+                o_id=int(lre.o_id),
+                evaluation_decision_id=int(duplicate_evaluation_id),
+                resolved_outcome=duplicate.get("resolved_outcome"),
+            )
+            enqueue_case_detection(
+                o_id=int(lre.o_id),
+                evaluation_decision_id=int(duplicate_evaluation_id),
+            )
         return EvaluateResponse(
             transaction_id=duplicate["transaction_id"],
             outcome_counters=duplicate["outcome_counters"],
@@ -376,8 +387,6 @@ def evaluate(
     try:
         # `result` already contains the merged served outcome; passing it avoids a second rule evaluation.
         result, evaluation_decision_id = data_utils.eval_and_store(lre, event, response=result)
-        FeatureResolver(db, lre.o_id).persist_traces(feature_traces, evaluation_decision_id=int(evaluation_decision_id))
-        db.commit()
         enqueue_alert_detection(
             o_id=int(lre.o_id),
             evaluation_decision_id=int(evaluation_decision_id),
@@ -387,6 +396,8 @@ def evaluate(
             o_id=int(lre.o_id),
             evaluation_decision_id=int(evaluation_decision_id),
         )
+        FeatureResolver(db, lre.o_id).persist_traces(feature_traces, evaluation_decision_id=int(evaluation_decision_id))
+        db.commit()
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -396,13 +396,22 @@ def evaluate(
             o_id=int(lre.o_id),
             evaluation_decision_id=int(evaluation_decision_id),
         )
-        FeatureResolver(db, lre.o_id).persist_traces(feature_traces, evaluation_decision_id=int(evaluation_decision_id))
-        db.commit()
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Evaluation failed",
         ) from exc
+
+    try:
+        FeatureResolver(db, lre.o_id).persist_traces(feature_traces, evaluation_decision_id=int(evaluation_decision_id))
+        db.commit()
+    except Exception:
+        logger.exception(
+            "Failed to persist feature traces for evaluation_decision_id=%s org_id=%s",
+            evaluation_decision_id,
+            lre.o_id,
+        )
+        db.rollback()
 
     if rollout_logs:
         try:

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -23,6 +23,7 @@ from ezrules.backend.api_v2.schemas.evaluator import (
     EventTestResponse,
     EventTestRuleResult,
 )
+from ezrules.backend.cases import enqueue_case_detection
 from ezrules.backend.data_utils import Event
 from ezrules.backend.features import FeatureResolutionError, FeatureResolutionTrace, FeatureResolver
 from ezrules.backend.observation_queue import enqueue_observations
@@ -314,6 +315,11 @@ def evaluate(
                 evaluation_decision_id=int(result["evaluation_decision_id"]),
                 resolved_outcome=result.get("resolved_outcome"),
             )
+            enqueue_case_detection(
+                o_id=int(lre.o_id),
+                evaluation_decision_id=int(result["evaluation_decision_id"]),
+                resolved_outcome=result.get("resolved_outcome"),
+            )
             _persist_evaluate_observations(db, request_data.event_data, lre.o_id)
             return EvaluateResponse(
                 transaction_id=result["transaction_id"],
@@ -374,6 +380,11 @@ def evaluate(
         FeatureResolver(db, lre.o_id).persist_traces(feature_traces, evaluation_decision_id=int(evaluation_decision_id))
         db.commit()
         enqueue_alert_detection(
+            o_id=int(lre.o_id),
+            evaluation_decision_id=int(evaluation_decision_id),
+            resolved_outcome=result.get("resolved_outcome"),
+        )
+        enqueue_case_detection(
             o_id=int(lre.o_id),
             evaluation_decision_id=int(evaluation_decision_id),
             resolved_outcome=result.get("resolved_outcome"),

--- a/ezrules/backend/api_v2/schemas/cases.py
+++ b/ezrules/backend/api_v2/schemas/cases.py
@@ -1,6 +1,26 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
+
+from ezrules.backend.api_v2.schemas.tested_events import TriggeredRuleItem
+
+CaseResolutionDisposition = Literal[
+    "confirmed_fraud",
+    "false_positive",
+    "approved",
+    "rejected",
+    "duplicate",
+    "unable_to_verify",
+    "escalated",
+]
+CaseResolutionAction = Literal[
+    "none",
+    "release_transaction",
+    "cancel_transaction",
+    "block_customer",
+    "escalate_external_review",
+]
 
 
 class CaseEventResponse(BaseModel):
@@ -28,7 +48,11 @@ class CaseResponse(BaseModel):
     decision_state: str
     priority: int
     assigned_to_user_id: int | None = None
+    assigned_to_email: str | None = None
     resolved_by_user_id: int | None = None
+    resolved_by_email: str | None = None
+    resolution_disposition: str | None = None
+    resolution_action: str | None = None
     resolution_note: str | None = None
     resolution_label_id: int | None = None
     reopened_from_case_id: int | None = None
@@ -42,16 +66,46 @@ class CaseListResponse(BaseModel):
     total: int
 
 
+class CaseEvaluationResponse(BaseModel):
+    evaluation_decision_id: int
+    transaction_id: str
+    event_version_id: int
+    event_version: int
+    effective_at: datetime
+    observed_at: datetime
+    evaluated_at: datetime
+    is_current: bool
+    resolved_outcome: str | None = None
+    outcome_counters: dict[str, int] = Field(default_factory=dict)
+    event_data: dict = Field(default_factory=dict)
+    triggered_rules: list[TriggeredRuleItem] = Field(default_factory=list)
+
+
 class CaseDetailResponse(BaseModel):
     case: CaseResponse
     events: list[CaseEventResponse]
+    evaluation: CaseEvaluationResponse | None = None
 
 
 class CaseUpdateRequest(BaseModel):
     assigned_to_user_id: int | None = None
 
 
+class CaseNoteRequest(BaseModel):
+    note: str = Field(..., min_length=1, max_length=5000)
+
+    @field_validator("note")
+    @classmethod
+    def normalize_note(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("note cannot be empty")
+        return stripped
+
+
 class CaseResolveRequest(BaseModel):
+    resolution_disposition: CaseResolutionDisposition
+    resolution_action: CaseResolutionAction = "none"
     resolution_note: str = Field(..., min_length=1, max_length=5000)
     resolution_label_id: int | None = None
     expected_current_ed_id: int | None = None
@@ -69,6 +123,21 @@ class CaseMutationResponse(BaseModel):
     success: bool
     message: str
     case: CaseResponse
+
+
+class CaseEventMutationResponse(BaseModel):
+    success: bool
+    message: str
+    event: CaseEventResponse
+
+
+class CaseAssigneeResponse(BaseModel):
+    id: int
+    email: str
+
+
+class CaseAssigneesResponse(BaseModel):
+    users: list[CaseAssigneeResponse]
 
 
 class IntegrationEventResponse(BaseModel):

--- a/ezrules/backend/api_v2/schemas/cases.py
+++ b/ezrules/backend/api_v2/schemas/cases.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class CaseEventResponse(BaseModel):
+    id: int
+    case_id: int
+    event_type: str
+    actor_user_id: int | None = None
+    source_ed_id: int | None = None
+    external_event_id: str
+    occurred_at: datetime
+    details: dict
+    created_at: datetime
+
+
+class CaseResponse(BaseModel):
+    id: int
+    transaction_id: str
+    current_event_version_id: int
+    current_evaluation_decision_id: int
+    opened_by_evaluation_decision_id: int
+    previous_evaluation_decision_id: int | None = None
+    resolved_outcome: str | None = None
+    previous_resolved_outcome: str | None = None
+    status: str
+    decision_state: str
+    priority: int
+    assigned_to_user_id: int | None = None
+    resolved_by_user_id: int | None = None
+    resolution_note: str | None = None
+    resolution_label_id: int | None = None
+    reopened_from_case_id: int | None = None
+    created_at: datetime
+    updated_at: datetime
+    resolved_at: datetime | None = None
+
+
+class CaseListResponse(BaseModel):
+    cases: list[CaseResponse]
+    total: int
+
+
+class CaseDetailResponse(BaseModel):
+    case: CaseResponse
+    events: list[CaseEventResponse]
+
+
+class CaseUpdateRequest(BaseModel):
+    assigned_to_user_id: int | None = None
+
+
+class CaseResolveRequest(BaseModel):
+    resolution_note: str = Field(..., min_length=1, max_length=5000)
+    resolution_label_id: int | None = None
+    expected_current_ed_id: int | None = None
+
+    @field_validator("resolution_note")
+    @classmethod
+    def normalize_note(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("resolution_note cannot be empty")
+        return stripped
+
+
+class CaseMutationResponse(BaseModel):
+    success: bool
+    message: str
+    case: CaseResponse
+
+
+class IntegrationEventResponse(BaseModel):
+    id: int
+    external_event_id: str
+    source_type: str
+    source_id: int
+    event_type: str
+    event_version: int
+    occurred_at: datetime
+    payload: dict
+    created_at: datetime
+
+
+class IntegrationEventsResponse(BaseModel):
+    events: list[IntegrationEventResponse]
+    next_cursor: int | None = None
+
+
+class IntegrationSubscriptionResponse(BaseModel):
+    id: int
+    name: str
+    destination_type: str
+    config: dict
+    event_types: list[str]
+    enabled: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class IntegrationSubscriptionsResponse(BaseModel):
+    subscriptions: list[IntegrationSubscriptionResponse]
+
+
+class IntegrationSubscriptionCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    destination_type: str = Field(..., min_length=1, max_length=64)
+    config: dict = Field(default_factory=dict)
+    event_types: list[str] = Field(default_factory=list)
+    enabled: bool = True
+
+
+class IntegrationSubscriptionUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    destination_type: str | None = Field(default=None, min_length=1, max_length=64)
+    config: dict | None = None
+    event_types: list[str] | None = None
+    enabled: bool | None = None
+
+
+class IntegrationSubscriptionMutationResponse(BaseModel):
+    success: bool
+    message: str
+    subscription: IntegrationSubscriptionResponse

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -6,9 +6,11 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+import sqlalchemy as sa
+
 from ezrules.backend.integrations import publish_integration_event
 from ezrules.backend.runtime_settings import get_neutral_outcome
-from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision
+from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision, User
 from ezrules.models.database import db_session
 from ezrules.settings import app_settings
 
@@ -32,6 +34,10 @@ class CaseConflictError(Exception):
 
 class CaseNotFoundError(Exception):
     """Raised when a case does not exist in the caller's organisation."""
+
+
+class CaseValidationError(Exception):
+    """Raised when a case mutation payload is invalid for the caller's organisation."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,7 +72,14 @@ def _outcome_priority(db: Any, *, o_id: int, outcome: str | None) -> int:
 def _is_caseable_outcome(db: Any, *, o_id: int, outcome: str | None) -> bool:
     if not outcome:
         return False
-    return outcome != get_neutral_outcome(db, o_id)
+    return outcome.upper() != get_neutral_outcome(db, o_id).upper()
+
+
+def _lock_case_transaction(db: Any, *, o_id: int, transaction_id: str) -> None:
+    db.execute(
+        sa.text("SELECT pg_advisory_xact_lock(:o_id, hashtext(:transaction_id))"),
+        {"o_id": o_id, "transaction_id": transaction_id},
+    )
 
 
 def _active_case_for_transaction(db: Any, *, o_id: int, transaction_id: str) -> Case | None:
@@ -206,6 +219,7 @@ def ensure_case_for_decision(db: Any, *, o_id: int, evaluation_decision_id: int)
 
     outcome = str(decision.resolved_outcome) if decision.resolved_outcome else None
     caseable = _is_caseable_outcome(db, o_id=o_id, outcome=outcome)
+    _lock_case_transaction(db, o_id=o_id, transaction_id=str(decision.transaction_id))
     active_case = _active_case_for_transaction(db, o_id=o_id, transaction_id=str(decision.transaction_id))
 
     if active_case is not None:
@@ -311,9 +325,15 @@ def get_case_for_update(db: Any, *, o_id: int, case_id: int) -> Case:
 
 def assign_case(db: Any, *, o_id: int, case_id: int, actor_user_id: int, assignee_user_id: int | None) -> Case:
     case = get_case_for_update(db, o_id=o_id, case_id=case_id)
+    if assignee_user_id is not None:
+        assignee = db.query(User.id).filter(User.id == assignee_user_id, User.o_id == o_id).first()
+        if assignee is None:
+            raise CaseValidationError("Assignee must belong to the case organisation")
     previous_assignee = int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None
     case.assigned_to_user_id = assignee_user_id
-    if case.status == CASE_STATUS_OPEN:
+    if assignee_user_id is None and case.status == CASE_STATUS_IN_REVIEW:
+        case.status = CASE_STATUS_OPEN
+    elif assignee_user_id is not None and case.status == CASE_STATUS_OPEN:
         case.status = CASE_STATUS_IN_REVIEW
     case.updated_at = _utcnow()
     db.flush()
@@ -344,6 +364,9 @@ def resolve_case(
     case = get_case_for_update(db, o_id=o_id, case_id=case_id)
     if expected_current_ed_id is not None and int(case.current_ed_id) != expected_current_ed_id:
         raise CaseConflictError("Case score changed; reload before resolving")
+
+    if case.status in {CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED}:
+        return case
 
     previous_status = str(case.status)
     case.status = CASE_STATUS_RESOLVED

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -129,17 +129,37 @@ def _case_payload(case: Case) -> dict[str, Any]:
     return {
         "case_id": int(case.case_id),
         "transaction_id": str(case.transaction_id),
+        "current_event_version_id": int(case.current_ev_id),
+        "current_evaluation_decision_id": int(case.current_ed_id),
+        "previous_evaluation_decision_id": int(case.previous_ed_id) if case.previous_ed_id is not None else None,
+        "opened_by_evaluation_decision_id": int(case.opened_by_ed_id),
         "status": str(case.status),
         "decision_state": str(case.decision_state),
+        "priority": int(case.priority),
         "resolved_outcome": str(case.resolved_outcome) if case.resolved_outcome else None,
         "previous_resolved_outcome": str(case.previous_resolved_outcome) if case.previous_resolved_outcome else None,
         "assigned_to_user_id": int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None,
         "resolved_by_user_id": int(case.resolved_by_user_id) if case.resolved_by_user_id is not None else None,
         "resolution_disposition": str(case.resolution_disposition) if case.resolution_disposition else None,
         "resolution_action": str(case.resolution_action) if case.resolution_action else None,
-        "current_evaluation_decision_id": int(case.current_ed_id),
-        "previous_evaluation_decision_id": int(case.previous_ed_id) if case.previous_ed_id is not None else None,
-        "opened_by_evaluation_decision_id": int(case.opened_by_ed_id),
+        "resolution_note": str(case.resolution_note) if case.resolution_note else None,
+        "resolution_label_id": int(case.resolution_label_id) if case.resolution_label_id is not None else None,
+        "reopened_from_case_id": int(case.reopened_from_case_id) if case.reopened_from_case_id is not None else None,
+        "resolved_at": case.resolved_at.isoformat() if case.resolved_at else None,
+        "created_at": case.created_at.isoformat(),
+        "updated_at": case.updated_at.isoformat(),
+    }
+
+
+def _downstream_action_payload(case: Case, *, event_type: str) -> dict[str, Any]:
+    action = str(case.resolution_action) if case.resolution_action else "none"
+    requested = event_type == "resolved" and action != "none"
+    return {
+        "requested": requested,
+        "action": action,
+        "status": "requested" if requested else "none",
+        "source": "analyst_resolution" if event_type == "resolved" else "case_lifecycle_event",
+        "executed_by_ezrules": False,
     }
 
 
@@ -167,6 +187,7 @@ def record_case_event(
     db.add(case_event)
     db.flush()
 
+    case_payload = _case_payload(case)
     publish_integration_event(
         db,
         o_id=int(case.o_id),
@@ -176,11 +197,35 @@ def record_case_event(
         external_event_id=f"evt_case_event_{case_event.case_event_id}",
         occurred_at=now,
         payload={
-            "case": _case_payload(case),
+            "case_id": case_payload["case_id"],
+            "transaction_id": case_payload["transaction_id"],
+            "case_event_id": int(case_event.case_event_id),
+            "case_event_type": event_type,
+            "case_event_external_event_id": str(case_event.external_event_id),
+            "actor_user_id": actor_user_id,
+            "source_evaluation_decision_id": source_ed_id,
+            "current_event_version_id": case_payload["current_event_version_id"],
+            "current_evaluation_decision_id": case_payload["current_evaluation_decision_id"],
+            "opened_by_evaluation_decision_id": case_payload["opened_by_evaluation_decision_id"],
+            "previous_evaluation_decision_id": case_payload["previous_evaluation_decision_id"],
+            "status": case_payload["status"],
+            "decision_state": case_payload["decision_state"],
+            "resolved_outcome": case_payload["resolved_outcome"],
+            "previous_resolved_outcome": case_payload["previous_resolved_outcome"],
+            "assigned_to_user_id": case_payload["assigned_to_user_id"],
+            "resolved_by_user_id": case_payload["resolved_by_user_id"],
+            "resolution_disposition": case_payload["resolution_disposition"],
+            "resolution_action": case_payload["resolution_action"],
+            "resolution_note": case_payload["resolution_note"],
+            "resolution_label_id": case_payload["resolution_label_id"],
+            "downstream_action": _downstream_action_payload(case, event_type=event_type),
+            "occurred_at": now.isoformat(),
+            "case": case_payload,
             "case_event": {
                 "case_event_id": int(case_event.case_event_id),
                 "event_type": event_type,
                 "external_event_id": str(case_event.external_event_id),
+                "occurred_at": now.isoformat(),
                 "details": case_event.details,
             },
             "actor": {"user_id": actor_user_id},

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 from ezrules.backend.integrations import publish_integration_event
 from ezrules.backend.runtime_settings import get_neutral_outcome
-from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision, User
+from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision, Label, User
 from ezrules.models.database import db_session
 from ezrules.settings import app_settings
 
@@ -325,6 +325,8 @@ def get_case_for_update(db: Any, *, o_id: int, case_id: int) -> Case:
 
 def assign_case(db: Any, *, o_id: int, case_id: int, actor_user_id: int, assignee_user_id: int | None) -> Case:
     case = get_case_for_update(db, o_id=o_id, case_id=case_id)
+    if case.status in {CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED}:
+        raise CaseValidationError("Resolved cases cannot be assigned")
     if assignee_user_id is not None:
         assignee = db.query(User.id).filter(User.id == assignee_user_id, User.o_id == o_id).first()
         if assignee is None:
@@ -367,6 +369,11 @@ def resolve_case(
 
     if case.status in {CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED}:
         return case
+
+    if resolution_label_id is not None:
+        label = db.query(Label.el_id).filter(Label.el_id == resolution_label_id, Label.o_id == o_id).first()
+        if label is None:
+            raise CaseValidationError("Resolution label must belong to the case organisation")
 
     previous_status = str(case.status)
     case.status = CASE_STATUS_RESOLVED

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -385,8 +385,12 @@ def process_evaluation_for_cases(db: Any, *, o_id: int, evaluation_decision_id: 
 
 
 def enqueue_case_detection(*, o_id: int, evaluation_decision_id: int) -> None:
-    process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
-    db_session.commit()
+    try:
+        process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        raise
 
 
 def get_case_for_update(db: Any, *, o_id: int, case_id: int) -> Case:

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import logging
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -12,8 +11,6 @@ from ezrules.backend.integrations import publish_integration_event
 from ezrules.backend.runtime_settings import get_neutral_outcome
 from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision, Label, User
 from ezrules.models.database import db_session
-
-logger = logging.getLogger(__name__)
 
 CASE_STATUS_OPEN = "open"
 CASE_STATUS_IN_REVIEW = "in_review"
@@ -298,16 +295,8 @@ def process_evaluation_for_cases(db: Any, *, o_id: int, evaluation_decision_id: 
 
 
 def enqueue_case_detection(*, o_id: int, evaluation_decision_id: int) -> None:
-    try:
-        process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
-        db_session.commit()
-    except Exception:
-        db_session.rollback()
-        logger.exception(
-            "Failed to process case detection for org_id=%s evaluation_decision_id=%s",
-            o_id,
-            evaluation_decision_id,
-        )
+    process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
+    db_session.commit()
 
 
 def get_case_for_update(db: Any, *, o_id: int, case_id: int) -> Case:

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -22,6 +22,26 @@ ACTIVE_CASE_STATUSES = (CASE_STATUS_OPEN, CASE_STATUS_IN_REVIEW, CASE_STATUS_REO
 CASE_DECISION_CURRENT = "current"
 CASE_DECISION_RESCORED_NEUTRAL = "rescored_neutral"
 CASE_DECISION_RESCORED_NON_CASEABLE = "rescored_non_caseable"
+CASE_RESOLUTION_DISPOSITIONS = frozenset(
+    {
+        "confirmed_fraud",
+        "false_positive",
+        "approved",
+        "rejected",
+        "duplicate",
+        "unable_to_verify",
+        "escalated",
+    }
+)
+CASE_RESOLUTION_ACTIONS = frozenset(
+    {
+        "none",
+        "release_transaction",
+        "cancel_transaction",
+        "block_customer",
+        "escalate_external_review",
+    }
+)
 
 
 class CaseConflictError(Exception):
@@ -113,6 +133,10 @@ def _case_payload(case: Case) -> dict[str, Any]:
         "decision_state": str(case.decision_state),
         "resolved_outcome": str(case.resolved_outcome) if case.resolved_outcome else None,
         "previous_resolved_outcome": str(case.previous_resolved_outcome) if case.previous_resolved_outcome else None,
+        "assigned_to_user_id": int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None,
+        "resolved_by_user_id": int(case.resolved_by_user_id) if case.resolved_by_user_id is not None else None,
+        "resolution_disposition": str(case.resolution_disposition) if case.resolution_disposition else None,
+        "resolution_action": str(case.resolution_action) if case.resolution_action else None,
         "current_evaluation_decision_id": int(case.current_ed_id),
         "previous_evaluation_decision_id": int(case.previous_ed_id) if case.previous_ed_id is not None else None,
         "opened_by_evaluation_decision_id": int(case.opened_by_ed_id),
@@ -338,12 +362,26 @@ def assign_case(db: Any, *, o_id: int, case_id: int, actor_user_id: int, assigne
     return case
 
 
+def add_case_note(db: Any, *, o_id: int, case_id: int, actor_user_id: int, note: str) -> CaseEvent:
+    case = get_case_for_update(db, o_id=o_id, case_id=case_id)
+    return record_case_event(
+        db,
+        case=case,
+        event_type="note",
+        actor_user_id=actor_user_id,
+        source_ed_id=int(case.current_ed_id),
+        details={"note": note.strip()},
+    )
+
+
 def resolve_case(
     db: Any,
     *,
     o_id: int,
     case_id: int,
     actor_user_id: int,
+    resolution_disposition: str,
+    resolution_action: str,
     resolution_note: str,
     resolution_label_id: int | None = None,
     expected_current_ed_id: int | None = None,
@@ -355,6 +393,13 @@ def resolve_case(
     if case.status in {CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED}:
         return case
 
+    normalized_disposition = resolution_disposition.strip().lower()
+    if normalized_disposition not in CASE_RESOLUTION_DISPOSITIONS:
+        raise CaseValidationError("Resolution disposition is not supported")
+    normalized_action = resolution_action.strip().lower()
+    if normalized_action not in CASE_RESOLUTION_ACTIONS:
+        raise CaseValidationError("Resolution action is not supported")
+
     if resolution_label_id is not None:
         label = db.query(Label.el_id).filter(Label.el_id == resolution_label_id, Label.o_id == o_id).first()
         if label is None:
@@ -363,6 +408,8 @@ def resolve_case(
     previous_status = str(case.status)
     case.status = CASE_STATUS_RESOLVED
     case.resolved_by_user_id = actor_user_id
+    case.resolution_disposition = normalized_disposition
+    case.resolution_action = normalized_action
     case.resolution_note = resolution_note.strip()
     case.resolution_label_id = resolution_label_id
     case.resolved_at = _utcnow()
@@ -378,6 +425,8 @@ def resolve_case(
         details={
             "previous_status": previous_status,
             "status": CASE_STATUS_RESOLVED,
+            "resolution_disposition": normalized_disposition,
+            "resolution_action": normalized_action,
             "resolution_note": case.resolution_note,
             "resolution_label_id": resolution_label_id,
         },

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import datetime
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from ezrules.backend.integrations import publish_integration_event
+from ezrules.backend.runtime_settings import get_neutral_outcome
+from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision
+from ezrules.models.database import db_session
+from ezrules.settings import app_settings
+
+logger = logging.getLogger(__name__)
+
+CASE_STATUS_OPEN = "open"
+CASE_STATUS_IN_REVIEW = "in_review"
+CASE_STATUS_REOPENED = "reopened"
+CASE_STATUS_RESOLVED = "resolved"
+CASE_STATUS_CLOSED = "closed"
+ACTIVE_CASE_STATUSES = (CASE_STATUS_OPEN, CASE_STATUS_IN_REVIEW, CASE_STATUS_REOPENED)
+
+CASE_DECISION_CURRENT = "current"
+CASE_DECISION_RESCORED_NEUTRAL = "rescored_neutral"
+CASE_DECISION_RESCORED_NON_CASEABLE = "rescored_non_caseable"
+
+
+class CaseConflictError(Exception):
+    """Raised when a case action was based on a stale decision pointer."""
+
+
+class CaseNotFoundError(Exception):
+    """Raised when a case does not exist in the caller's organisation."""
+
+
+@dataclass(frozen=True, slots=True)
+class CaseProcessingResult:
+    case_id: int | None
+    action: str
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _new_case_event_id() -> str:
+    return f"case_evt_{uuid.uuid4().hex}"
+
+
+def _event_type_for_integration(case_event_type: str) -> str:
+    return f"case.{case_event_type}"
+
+
+def _outcome_priority(db: Any, *, o_id: int, outcome: str | None) -> int:
+    if not outcome:
+        return 0
+    row = (
+        db.query(AllowedOutcome.severity_rank)
+        .filter(AllowedOutcome.o_id == o_id, AllowedOutcome.outcome_name == outcome)
+        .first()
+    )
+    return int(row[0]) if row is not None else 0
+
+
+def _is_caseable_outcome(db: Any, *, o_id: int, outcome: str | None) -> bool:
+    if not outcome:
+        return False
+    return outcome != get_neutral_outcome(db, o_id)
+
+
+def _active_case_for_transaction(db: Any, *, o_id: int, transaction_id: str) -> Case | None:
+    return (
+        db.query(Case)
+        .filter(
+            Case.o_id == o_id,
+            Case.transaction_id == transaction_id,
+            Case.status.in_(ACTIVE_CASE_STATUSES),
+        )
+        .order_by(Case.case_id.desc())
+        .with_for_update()
+        .first()
+    )
+
+
+def _latest_inactive_case_for_transaction(db: Any, *, o_id: int, transaction_id: str) -> Case | None:
+    return (
+        db.query(Case)
+        .filter(
+            Case.o_id == o_id,
+            Case.transaction_id == transaction_id,
+            Case.status.in_([CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED]),
+        )
+        .order_by(Case.updated_at.desc(), Case.case_id.desc())
+        .first()
+    )
+
+
+def _case_payload(case: Case) -> dict[str, Any]:
+    return {
+        "case_id": int(case.case_id),
+        "transaction_id": str(case.transaction_id),
+        "status": str(case.status),
+        "decision_state": str(case.decision_state),
+        "resolved_outcome": str(case.resolved_outcome) if case.resolved_outcome else None,
+        "previous_resolved_outcome": str(case.previous_resolved_outcome) if case.previous_resolved_outcome else None,
+        "current_evaluation_decision_id": int(case.current_ed_id),
+        "previous_evaluation_decision_id": int(case.previous_ed_id) if case.previous_ed_id is not None else None,
+        "opened_by_evaluation_decision_id": int(case.opened_by_ed_id),
+    }
+
+
+def record_case_event(
+    db: Any,
+    *,
+    case: Case,
+    event_type: str,
+    actor_user_id: int | None = None,
+    source_ed_id: int | None = None,
+    details: dict[str, Any] | None = None,
+) -> CaseEvent:
+    now = _utcnow()
+    case_event = CaseEvent(
+        case_id=int(case.case_id),
+        o_id=int(case.o_id),
+        event_type=event_type,
+        actor_user_id=actor_user_id,
+        source_ed_id=source_ed_id,
+        external_event_id=_new_case_event_id(),
+        occurred_at=now,
+        details=details or {},
+        created_at=now,
+    )
+    db.add(case_event)
+    db.flush()
+
+    publish_integration_event(
+        db,
+        o_id=int(case.o_id),
+        source_type="case_event",
+        source_id=int(case_event.case_event_id),
+        event_type=_event_type_for_integration(event_type),
+        external_event_id=f"evt_case_event_{case_event.case_event_id}",
+        occurred_at=now,
+        payload={
+            "case": _case_payload(case),
+            "case_event": {
+                "case_event_id": int(case_event.case_event_id),
+                "event_type": event_type,
+                "external_event_id": str(case_event.external_event_id),
+                "details": case_event.details,
+            },
+            "actor": {"user_id": actor_user_id},
+        },
+    )
+    return case_event
+
+
+def publish_evaluation_completed(
+    db: Any,
+    *,
+    o_id: int,
+    evaluation_decision_id: int,
+    case_id: int | None = None,
+) -> None:
+    decision = (
+        db.query(EvaluationDecision)
+        .filter(EvaluationDecision.o_id == o_id, EvaluationDecision.ed_id == evaluation_decision_id)
+        .first()
+    )
+    if decision is None:
+        return
+    publish_integration_event(
+        db,
+        o_id=o_id,
+        source_type="evaluation_decision",
+        source_id=evaluation_decision_id,
+        event_type="evaluation.completed",
+        external_event_id=f"evt_evaluation_completed_{evaluation_decision_id}",
+        occurred_at=decision.evaluated_at,
+        payload={
+            "evaluation_decision_id": evaluation_decision_id,
+            "transaction_id": str(decision.transaction_id),
+            "event_version": int(decision.event_version),
+            "resolved_outcome": str(decision.resolved_outcome) if decision.resolved_outcome else None,
+            "outcome_counters": decision.outcome_counters if isinstance(decision.outcome_counters, dict) else {},
+            "decision_type": str(decision.decision_type),
+            "served": bool(decision.served),
+            "is_current": bool(decision.is_current),
+            "case_id": case_id,
+        },
+    )
+
+
+def ensure_case_for_decision(db: Any, *, o_id: int, evaluation_decision_id: int) -> CaseProcessingResult:
+    decision = (
+        db.query(EvaluationDecision)
+        .filter(EvaluationDecision.o_id == o_id, EvaluationDecision.ed_id == evaluation_decision_id)
+        .first()
+    )
+    if decision is None:
+        return CaseProcessingResult(case_id=None, action="missing_decision")
+
+    if not bool(decision.served) or decision.decision_type != "served" or not bool(decision.is_current):
+        return CaseProcessingResult(case_id=None, action="ignored_decision")
+
+    outcome = str(decision.resolved_outcome) if decision.resolved_outcome else None
+    caseable = _is_caseable_outcome(db, o_id=o_id, outcome=outcome)
+    active_case = _active_case_for_transaction(db, o_id=o_id, transaction_id=str(decision.transaction_id))
+
+    if active_case is not None:
+        if int(active_case.current_ed_id) == evaluation_decision_id:
+            return CaseProcessingResult(case_id=int(active_case.case_id), action="unchanged")
+
+        previous_ed_id = int(active_case.current_ed_id)
+        previous_outcome = str(active_case.resolved_outcome) if active_case.resolved_outcome else None
+        active_case.previous_ed_id = previous_ed_id
+        active_case.previous_resolved_outcome = previous_outcome
+        active_case.current_ed_id = evaluation_decision_id
+        active_case.current_ev_id = int(decision.ev_id)
+        active_case.resolved_outcome = outcome
+        active_case.priority = _outcome_priority(db, o_id=o_id, outcome=outcome)
+        if caseable:
+            active_case.decision_state = CASE_DECISION_CURRENT
+            event_type = "rescored"
+        else:
+            active_case.decision_state = (
+                CASE_DECISION_RESCORED_NEUTRAL if outcome else CASE_DECISION_RESCORED_NON_CASEABLE
+            )
+            event_type = "rescored_non_caseable"
+        active_case.updated_at = _utcnow()
+        db.flush()
+        record_case_event(
+            db,
+            case=active_case,
+            event_type=event_type,
+            source_ed_id=evaluation_decision_id,
+            details={
+                "previous_evaluation_decision_id": previous_ed_id,
+                "current_evaluation_decision_id": evaluation_decision_id,
+                "previous_resolved_outcome": previous_outcome,
+                "current_resolved_outcome": outcome,
+            },
+        )
+        return CaseProcessingResult(case_id=int(active_case.case_id), action=event_type)
+
+    if not caseable:
+        return CaseProcessingResult(case_id=None, action="not_caseable")
+
+    prior_case = _latest_inactive_case_for_transaction(db, o_id=o_id, transaction_id=str(decision.transaction_id))
+    case = Case(
+        o_id=o_id,
+        transaction_id=str(decision.transaction_id),
+        current_ev_id=int(decision.ev_id),
+        current_ed_id=evaluation_decision_id,
+        opened_by_ed_id=evaluation_decision_id,
+        resolved_outcome=outcome,
+        status=CASE_STATUS_OPEN,
+        decision_state=CASE_DECISION_CURRENT,
+        priority=_outcome_priority(db, o_id=o_id, outcome=outcome),
+        reopened_from_case_id=int(prior_case.case_id) if prior_case is not None else None,
+        created_at=_utcnow(),
+        updated_at=_utcnow(),
+    )
+    db.add(case)
+    db.flush()
+    record_case_event(
+        db,
+        case=case,
+        event_type="created",
+        source_ed_id=evaluation_decision_id,
+        details={
+            "current_evaluation_decision_id": evaluation_decision_id,
+            "resolved_outcome": outcome,
+            "reopened_from_case_id": int(prior_case.case_id) if prior_case is not None else None,
+        },
+    )
+    return CaseProcessingResult(case_id=int(case.case_id), action="created")
+
+
+def process_evaluation_for_cases(db: Any, *, o_id: int, evaluation_decision_id: int) -> CaseProcessingResult:
+    result = ensure_case_for_decision(db, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
+    publish_evaluation_completed(db, o_id=o_id, evaluation_decision_id=evaluation_decision_id, case_id=result.case_id)
+    return result
+
+
+def enqueue_case_detection(*, o_id: int, evaluation_decision_id: int, resolved_outcome: str | None = None) -> None:
+    if app_settings.TESTING:
+        process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
+        db_session.commit()
+        return
+
+    try:
+        from ezrules.backend.tasks import process_evaluation_for_cases_task
+
+        process_evaluation_for_cases_task.delay(o_id, evaluation_decision_id)
+    except Exception:
+        logger.exception(
+            "Failed to enqueue case detection for org_id=%s evaluation_decision_id=%s",
+            o_id,
+            evaluation_decision_id,
+        )
+
+
+def get_case_for_update(db: Any, *, o_id: int, case_id: int) -> Case:
+    case = db.query(Case).filter(Case.o_id == o_id, Case.case_id == case_id).with_for_update().first()
+    if case is None:
+        raise CaseNotFoundError(f"Case {case_id} not found")
+    return case
+
+
+def assign_case(db: Any, *, o_id: int, case_id: int, actor_user_id: int, assignee_user_id: int | None) -> Case:
+    case = get_case_for_update(db, o_id=o_id, case_id=case_id)
+    previous_assignee = int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None
+    case.assigned_to_user_id = assignee_user_id
+    if case.status == CASE_STATUS_OPEN:
+        case.status = CASE_STATUS_IN_REVIEW
+    case.updated_at = _utcnow()
+    db.flush()
+    record_case_event(
+        db,
+        case=case,
+        event_type="assigned",
+        actor_user_id=actor_user_id,
+        source_ed_id=int(case.current_ed_id),
+        details={
+            "previous_assigned_to_user_id": previous_assignee,
+            "assigned_to_user_id": assignee_user_id,
+        },
+    )
+    return case
+
+
+def resolve_case(
+    db: Any,
+    *,
+    o_id: int,
+    case_id: int,
+    actor_user_id: int,
+    resolution_note: str,
+    resolution_label_id: int | None = None,
+    expected_current_ed_id: int | None = None,
+) -> Case:
+    case = get_case_for_update(db, o_id=o_id, case_id=case_id)
+    if expected_current_ed_id is not None and int(case.current_ed_id) != expected_current_ed_id:
+        raise CaseConflictError("Case score changed; reload before resolving")
+
+    previous_status = str(case.status)
+    case.status = CASE_STATUS_RESOLVED
+    case.resolved_by_user_id = actor_user_id
+    case.resolution_note = resolution_note.strip()
+    case.resolution_label_id = resolution_label_id
+    case.resolved_at = _utcnow()
+    case.assigned_to_user_id = None
+    case.updated_at = _utcnow()
+    db.flush()
+    record_case_event(
+        db,
+        case=case,
+        event_type="resolved",
+        actor_user_id=actor_user_id,
+        source_ed_id=int(case.current_ed_id),
+        details={
+            "previous_status": previous_status,
+            "status": CASE_STATUS_RESOLVED,
+            "resolution_note": case.resolution_note,
+            "resolution_label_id": resolution_label_id,
+        },
+    )
+    return case

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -284,7 +284,7 @@ def process_evaluation_for_cases(db: Any, *, o_id: int, evaluation_decision_id: 
     return result
 
 
-def enqueue_case_detection(*, o_id: int, evaluation_decision_id: int, resolved_outcome: str | None = None) -> None:
+def enqueue_case_detection(*, o_id: int, evaluation_decision_id: int) -> None:
     if app_settings.TESTING:
         process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
         db_session.commit()

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -9,7 +9,15 @@ import sqlalchemy as sa
 
 from ezrules.backend.integrations import publish_integration_event
 from ezrules.backend.runtime_settings import get_neutral_outcome
-from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision, Label, User
+from ezrules.models.backend_core import (
+    AllowedOutcome,
+    Case,
+    CaseEvent,
+    EvaluationDecision,
+    IntegrationEvent,
+    Label,
+    User,
+)
 from ezrules.models.database import db_session
 
 CASE_STATUS_OPEN = "open"
@@ -248,6 +256,19 @@ def publish_evaluation_completed(
     )
     if decision is None:
         return
+    effective_case_id = case_id
+    if effective_case_id is None:
+        existing_event = (
+            db.query(IntegrationEvent.payload)
+            .filter(IntegrationEvent.external_event_id == f"evt_evaluation_completed_{evaluation_decision_id}")
+            .first()
+        )
+        existing_payload = (
+            existing_event[0] if existing_event is not None and isinstance(existing_event[0], dict) else {}
+        )
+        existing_case_id = existing_payload.get("case_id")
+        effective_case_id = int(existing_case_id) if isinstance(existing_case_id, int) else None
+
     publish_integration_event(
         db,
         o_id=o_id,
@@ -265,7 +286,7 @@ def publish_evaluation_completed(
             "decision_type": str(decision.decision_type),
             "served": bool(decision.served),
             "is_current": bool(decision.is_current),
-            "case_id": case_id,
+            "case_id": effective_case_id,
         },
     )
 
@@ -380,9 +401,11 @@ def assign_case(db: Any, *, o_id: int, case_id: int, actor_user_id: int, assigne
     if case.status in {CASE_STATUS_RESOLVED, CASE_STATUS_CLOSED}:
         raise CaseValidationError("Resolved cases cannot be assigned")
     if assignee_user_id is not None:
-        assignee = db.query(User.id).filter(User.id == assignee_user_id, User.o_id == o_id).first()
+        assignee = (
+            db.query(User.id).filter(User.id == assignee_user_id, User.o_id == o_id, User.active.is_(True)).first()
+        )
         if assignee is None:
-            raise CaseValidationError("Assignee must belong to the case organisation")
+            raise CaseValidationError("Assignee must be an active user in the case organisation")
     previous_assignee = int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None
     if previous_assignee == assignee_user_id:
         return case

--- a/ezrules/backend/cases.py
+++ b/ezrules/backend/cases.py
@@ -12,7 +12,6 @@ from ezrules.backend.integrations import publish_integration_event
 from ezrules.backend.runtime_settings import get_neutral_outcome
 from ezrules.models.backend_core import AllowedOutcome, Case, CaseEvent, EvaluationDecision, Label, User
 from ezrules.models.database import db_session
-from ezrules.settings import app_settings
 
 logger = logging.getLogger(__name__)
 
@@ -299,18 +298,13 @@ def process_evaluation_for_cases(db: Any, *, o_id: int, evaluation_decision_id: 
 
 
 def enqueue_case_detection(*, o_id: int, evaluation_decision_id: int) -> None:
-    if app_settings.TESTING:
+    try:
         process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
         db_session.commit()
-        return
-
-    try:
-        from ezrules.backend.tasks import process_evaluation_for_cases_task
-
-        process_evaluation_for_cases_task.delay(o_id, evaluation_decision_id)
     except Exception:
+        db_session.rollback()
         logger.exception(
-            "Failed to enqueue case detection for org_id=%s evaluation_decision_id=%s",
+            "Failed to process case detection for org_id=%s evaluation_decision_id=%s",
             o_id,
             evaluation_decision_id,
         )
@@ -332,6 +326,8 @@ def assign_case(db: Any, *, o_id: int, case_id: int, actor_user_id: int, assigne
         if assignee is None:
             raise CaseValidationError("Assignee must belong to the case organisation")
     previous_assignee = int(case.assigned_to_user_id) if case.assigned_to_user_id is not None else None
+    if previous_assignee == assignee_user_id:
+        return case
     case.assigned_to_user_id = assignee_user_id
     if assignee_user_id is None and case.status == CASE_STATUS_IN_REVIEW:
         case.status = CASE_STATUS_OPEN

--- a/ezrules/backend/integrations.py
+++ b/ezrules/backend/integrations.py
@@ -95,6 +95,13 @@ def publish_integration_event(
     if external_event_id is not None:
         existing = db.query(IntegrationEvent).filter(IntegrationEvent.external_event_id == external_event_id).first()
         if existing is not None:
+            existing.o_id = o_id
+            existing.source_type = source_type
+            existing.source_id = source_id
+            existing.event_type = event_type
+            existing.occurred_at = occurred_at or existing.occurred_at
+            existing.payload = payload
+            db.flush()
             return IntegrationPublishResult(
                 event=existing, delivery_count=_enqueue_outbox_deliveries(db, event=existing)
             )

--- a/ezrules/backend/integrations.py
+++ b/ezrules/backend/integrations.py
@@ -20,6 +20,7 @@ OUTBOX_PENDING = "pending"
 OUTBOX_DELIVERED = "delivered"
 OUTBOX_FAILED = "failed"
 OUTBOX_DEAD_LETTERED = "dead_lettered"
+OUTBOX_SKIPPED = "skipped"
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +53,34 @@ def _subscriptions_for_event(db: Any, *, o_id: int, event_type: str) -> list[Int
     return [subscription for subscription in subscriptions if _subscription_matches(subscription, event_type)]
 
 
+def _enqueue_outbox_deliveries(db: Any, *, event: IntegrationEvent) -> int:
+    delivery_count = 0
+    for subscription in _subscriptions_for_event(db, o_id=int(event.o_id), event_type=str(event.event_type)):
+        existing = (
+            db.query(IntegrationOutbox.delivery_id)
+            .filter(
+                IntegrationOutbox.integration_event_id == int(event.integration_event_id),
+                IntegrationOutbox.subscription_id == int(subscription.subscription_id),
+            )
+            .first()
+        )
+        if existing is not None:
+            continue
+        db.add(
+            IntegrationOutbox(
+                o_id=int(event.o_id),
+                integration_event_id=int(event.integration_event_id),
+                subscription_id=int(subscription.subscription_id),
+                destination_type=str(subscription.destination_type),
+                status=OUTBOX_PENDING,
+                attempt_count=0,
+                next_attempt_at=_utcnow(),
+            )
+        )
+        delivery_count += 1
+    return delivery_count
+
+
 def publish_integration_event(
     db: Any,
     *,
@@ -66,7 +95,9 @@ def publish_integration_event(
     if external_event_id is not None:
         existing = db.query(IntegrationEvent).filter(IntegrationEvent.external_event_id == external_event_id).first()
         if existing is not None:
-            return IntegrationPublishResult(event=existing, delivery_count=0)
+            return IntegrationPublishResult(
+                event=existing, delivery_count=_enqueue_outbox_deliveries(db, event=existing)
+            )
 
     event = IntegrationEvent(
         external_event_id=external_event_id or _new_event_id(),
@@ -82,21 +113,7 @@ def publish_integration_event(
     db.add(event)
     db.flush()
 
-    delivery_count = 0
-    for subscription in _subscriptions_for_event(db, o_id=o_id, event_type=event_type):
-        db.add(
-            IntegrationOutbox(
-                o_id=o_id,
-                integration_event_id=int(event.integration_event_id),
-                subscription_id=int(subscription.subscription_id),
-                destination_type=str(subscription.destination_type),
-                status=OUTBOX_PENDING,
-                attempt_count=0,
-                next_attempt_at=_utcnow(),
-            )
-        )
-        delivery_count += 1
-    return IntegrationPublishResult(event=event, delivery_count=delivery_count)
+    return IntegrationPublishResult(event=event, delivery_count=_enqueue_outbox_deliveries(db, event=event))
 
 
 def list_integration_events(
@@ -157,7 +174,6 @@ def dispatch_pending_outbox(db: Any, *, limit: int = 100) -> dict[str, int]:
         .filter(
             IntegrationOutbox.status.in_([OUTBOX_PENDING, OUTBOX_FAILED]),
             IntegrationOutbox.next_attempt_at <= now,
-            IntegrationSubscription.enabled.is_(True),
         )
         .order_by(IntegrationOutbox.next_attempt_at.asc(), IntegrationOutbox.delivery_id.asc())
         .with_for_update(skip_locked=True, of=IntegrationOutbox)
@@ -168,6 +184,11 @@ def dispatch_pending_outbox(db: Any, *, limit: int = 100) -> dict[str, int]:
     delivered = 0
     failed = 0
     for delivery, event, subscription in deliveries:
+        if not bool(subscription.enabled):
+            delivery.status = OUTBOX_SKIPPED
+            delivery.last_error = "Subscription disabled before delivery"
+            delivery.updated_at = _utcnow()
+            continue
         delivery.attempt_count = int(delivery.attempt_count or 0) + 1
         delivery.last_attempted_at = now
         try:

--- a/ezrules/backend/integrations.py
+++ b/ezrules/backend/integrations.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from ezrules.models.backend_core import IntegrationEvent, IntegrationOutbox, IntegrationSubscription
+
+logger = logging.getLogger(__name__)
+
+INTEGRATION_EVENT_VERSION = 1
+OUTBOX_PENDING = "pending"
+OUTBOX_DELIVERED = "delivered"
+OUTBOX_FAILED = "failed"
+OUTBOX_DEAD_LETTERED = "dead_lettered"
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationPublishResult:
+    event: IntegrationEvent
+    delivery_count: int
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.UTC)
+
+
+def _new_event_id(prefix: str = "evt") -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _subscription_matches(subscription: IntegrationSubscription, event_type: str) -> bool:
+    configured = subscription.event_types if isinstance(subscription.event_types, list) else []
+    if not configured:
+        return True
+    return event_type in {str(item) for item in configured}
+
+
+def _subscriptions_for_event(db: Any, *, o_id: int, event_type: str) -> list[IntegrationSubscription]:
+    subscriptions = (
+        db.query(IntegrationSubscription)
+        .filter(IntegrationSubscription.o_id == o_id, IntegrationSubscription.enabled.is_(True))
+        .all()
+    )
+    return [subscription for subscription in subscriptions if _subscription_matches(subscription, event_type)]
+
+
+def publish_integration_event(
+    db: Any,
+    *,
+    o_id: int,
+    source_type: str,
+    source_id: int,
+    event_type: str,
+    payload: dict[str, Any],
+    external_event_id: str | None = None,
+    occurred_at: datetime.datetime | None = None,
+) -> IntegrationPublishResult:
+    if external_event_id is not None:
+        existing = db.query(IntegrationEvent).filter(IntegrationEvent.external_event_id == external_event_id).first()
+        if existing is not None:
+            return IntegrationPublishResult(event=existing, delivery_count=0)
+
+    event = IntegrationEvent(
+        external_event_id=external_event_id or _new_event_id(),
+        o_id=o_id,
+        source_type=source_type,
+        source_id=source_id,
+        event_type=event_type,
+        event_version=INTEGRATION_EVENT_VERSION,
+        occurred_at=occurred_at or _utcnow(),
+        payload=payload,
+        created_at=_utcnow(),
+    )
+    db.add(event)
+    db.flush()
+
+    delivery_count = 0
+    for subscription in _subscriptions_for_event(db, o_id=o_id, event_type=event_type):
+        db.add(
+            IntegrationOutbox(
+                o_id=o_id,
+                integration_event_id=int(event.integration_event_id),
+                subscription_id=int(subscription.subscription_id),
+                destination_type=str(subscription.destination_type),
+                status=OUTBOX_PENDING,
+                attempt_count=0,
+                next_attempt_at=_utcnow(),
+            )
+        )
+        delivery_count += 1
+    return IntegrationPublishResult(event=event, delivery_count=delivery_count)
+
+
+def list_integration_events(
+    db: Any,
+    *,
+    o_id: int,
+    after_id: int | None = None,
+    event_type: str | None = None,
+    limit: int = 100,
+) -> list[IntegrationEvent]:
+    query = db.query(IntegrationEvent).filter(IntegrationEvent.o_id == o_id)
+    if after_id is not None:
+        query = query.filter(IntegrationEvent.integration_event_id > after_id)
+    if event_type:
+        query = query.filter(IntegrationEvent.event_type == event_type)
+    return query.order_by(IntegrationEvent.integration_event_id.asc()).limit(limit).all()
+
+
+def _signature(secret: str, payload: str) -> str:
+    digest = hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _deliver_webhook(subscription: IntegrationSubscription, event: IntegrationEvent) -> None:
+    config = subscription.config if isinstance(subscription.config, dict) else {}
+    url = str(config.get("url") or "").strip()
+    if not url:
+        raise ValueError("Webhook subscription is missing config.url")
+
+    payload = {
+        "event_id": event.external_event_id,
+        "event_type": event.event_type,
+        "event_version": event.event_version,
+        "occurred_at": event.occurred_at.isoformat(),
+        "organisation_id": event.o_id,
+        "payload": event.payload,
+    }
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    headers = {"Content-Type": "application/json", "X-Ezrules-Event-Id": str(event.external_event_id)}
+    configured_headers = config.get("headers")
+    if isinstance(configured_headers, dict):
+        headers.update({str(key): str(value) for key, value in configured_headers.items()})
+    secret = str(config.get("secret") or subscription.secret_ref or "")
+    if secret:
+        headers["X-Ezrules-Signature"] = _signature(secret, body)
+
+    response = requests.post(url, data=body, headers=headers, timeout=10)
+    if response.status_code >= 400:
+        raise ValueError(f"Webhook returned HTTP {response.status_code}")
+
+
+def dispatch_pending_outbox(db: Any, *, limit: int = 100) -> dict[str, int]:
+    now = _utcnow()
+    deliveries = (
+        db.query(IntegrationOutbox, IntegrationEvent, IntegrationSubscription)
+        .join(IntegrationEvent, IntegrationEvent.integration_event_id == IntegrationOutbox.integration_event_id)
+        .join(IntegrationSubscription, IntegrationSubscription.subscription_id == IntegrationOutbox.subscription_id)
+        .filter(
+            IntegrationOutbox.status.in_([OUTBOX_PENDING, OUTBOX_FAILED]),
+            IntegrationOutbox.next_attempt_at <= now,
+            IntegrationSubscription.enabled.is_(True),
+        )
+        .order_by(IntegrationOutbox.next_attempt_at.asc(), IntegrationOutbox.delivery_id.asc())
+        .limit(limit)
+        .all()
+    )
+
+    delivered = 0
+    failed = 0
+    for delivery, event, subscription in deliveries:
+        delivery.attempt_count = int(delivery.attempt_count or 0) + 1
+        delivery.last_attempted_at = now
+        try:
+            if subscription.destination_type == "webhook":
+                _deliver_webhook(subscription, event)
+            else:
+                raise ValueError(f"Unsupported integration destination: {subscription.destination_type}")
+        except Exception as exc:
+            logger.exception("Integration delivery failed for delivery_id=%s", delivery.delivery_id)
+            delivery.last_error = str(exc)
+            delivery.status = OUTBOX_DEAD_LETTERED if delivery.attempt_count >= 10 else OUTBOX_FAILED
+            delay_seconds = min(3600, 30 * (2 ** min(delivery.attempt_count - 1, 6)))
+            delivery.next_attempt_at = now + datetime.timedelta(seconds=delay_seconds)
+            failed += 1
+        else:
+            delivery.status = OUTBOX_DELIVERED
+            delivery.last_error = None
+            delivered += 1
+        delivery.updated_at = _utcnow()
+    db.commit()
+    return {"delivered": delivered, "failed": failed}

--- a/ezrules/backend/integrations.py
+++ b/ezrules/backend/integrations.py
@@ -160,6 +160,7 @@ def dispatch_pending_outbox(db: Any, *, limit: int = 100) -> dict[str, int]:
             IntegrationSubscription.enabled.is_(True),
         )
         .order_by(IntegrationOutbox.next_attempt_at.asc(), IntegrationOutbox.delivery_id.asc())
+        .with_for_update(skip_locked=True, of=IntegrationOutbox)
         .limit(limit)
         .all()
     )

--- a/ezrules/backend/tasks.py
+++ b/ezrules/backend/tasks.py
@@ -12,7 +12,9 @@ from ezrules.backend.backtesting import (
     BacktestRecord,
     compute_backtest_metrics,
 )
+from ezrules.backend.cases import process_evaluation_for_cases
 from ezrules.backend.features import FeatureResolver, summarize_feature_snapshot_resolutions
+from ezrules.backend.integrations import dispatch_pending_outbox
 from ezrules.backend.observation_queue import drain_observation_queue
 from ezrules.backend.rule_quality import (
     compute_rule_quality_metrics,
@@ -49,6 +51,10 @@ app.conf.beat_schedule = {
     "sweep-alert-rules": {
         "task": "ezrules.backend.tasks.sweep_alert_rules_task",
         "schedule": timedelta(seconds=app_settings.ALERT_SWEEP_INTERVAL_SECONDS),
+    },
+    "dispatch-integration-outbox": {
+        "task": "ezrules.backend.tasks.dispatch_integration_outbox_task",
+        "schedule": timedelta(seconds=60),
     },
 }
 
@@ -348,6 +354,18 @@ def drain_shadow_evaluation_queue_task() -> dict[str, int]:
 def detect_alerts_for_decision_task(o_id: int, evaluation_decision_id: int) -> dict[str, int]:
     incident_ids = detect_alerts_for_decision(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
     return {"incidents": len(incident_ids)}
+
+
+@app.task(name="ezrules.backend.tasks.process_evaluation_for_cases_task")
+def process_evaluation_for_cases_task(o_id: int, evaluation_decision_id: int) -> dict[str, str | int | None]:
+    result = process_evaluation_for_cases(db_session, o_id=o_id, evaluation_decision_id=evaluation_decision_id)
+    db_session.commit()
+    return {"case_id": result.case_id, "action": result.action}
+
+
+@app.task(name="ezrules.backend.tasks.dispatch_integration_outbox_task")
+def dispatch_integration_outbox_task() -> dict[str, int]:
+    return dispatch_pending_outbox(db_session)
 
 
 @app.task(name="ezrules.backend.tasks.sweep_alert_rules_task")

--- a/ezrules/core/permissions_constants.py
+++ b/ezrules/core/permissions_constants.py
@@ -67,6 +67,14 @@ class PermissionAction(Enum):
     VIEW_ALERTS = "view_alerts"
     MANAGE_ALERTS = "manage_alerts"
 
+    # Case Management
+    VIEW_CASES = "view_cases"
+    MANAGE_CASES = "manage_cases"
+
+    # Integration Management
+    VIEW_INTEGRATIONS = "view_integrations"
+    MANAGE_INTEGRATIONS = "manage_integrations"
+
     @classmethod
     def get_default_actions(cls):
         """Get list of (action_name, description, resource_type) tuples for initialization."""
@@ -112,6 +120,10 @@ class PermissionAction(Enum):
             (cls.MANAGE_API_KEYS.value, "Manage API keys for service integration", "api_key"),
             (cls.VIEW_ALERTS.value, "View alert rules, incidents, and notifications", "alert"),
             (cls.MANAGE_ALERTS.value, "Create and update alert rules and notification policies", "alert"),
+            (cls.VIEW_CASES.value, "View case management work items", "case"),
+            (cls.MANAGE_CASES.value, "Assign and resolve case management work items", "case"),
+            (cls.VIEW_INTEGRATIONS.value, "View integration event streams and subscriptions", "integration"),
+            (cls.MANAGE_INTEGRATIONS.value, "Create and update integration subscriptions", "integration"),
         ]
 
 

--- a/ezrules/frontend/e2e/pages/cases.page.ts
+++ b/ezrules/frontend/e2e/pages/cases.page.ts
@@ -1,0 +1,31 @@
+import { Locator, Page } from '@playwright/test';
+
+export class CasesPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly casesTable: Locator;
+  readonly caseRows: Locator;
+  readonly detail: Locator;
+  readonly resolutionNote: Locator;
+  readonly resolveButton: Locator;
+  readonly eventsList: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.locator('h1');
+    this.casesTable = page.locator('[data-testid="cases-table"]');
+    this.caseRows = page.locator('[data-testid="case-row"]');
+    this.detail = page.locator('[data-testid="case-detail"]');
+    this.resolutionNote = page.locator('[data-testid="case-resolution-note"]');
+    this.resolveButton = page.locator('[data-testid="case-resolve-button"]');
+    this.eventsList = page.locator('[data-testid="case-events"]');
+  }
+
+  async goto() {
+    await this.page.goto('/cases');
+  }
+
+  async waitForLoad() {
+    await this.heading.waitFor({ state: 'visible', timeout: 10000 });
+  }
+}

--- a/ezrules/frontend/e2e/tests/cases.spec.ts
+++ b/ezrules/frontend/e2e/tests/cases.spec.ts
@@ -34,7 +34,11 @@ const caseItem = {
   decision_state: 'current',
   priority: 2,
   assigned_to_user_id: null,
+  assigned_to_email: null,
   resolved_by_user_id: null,
+  resolved_by_email: null,
+  resolution_disposition: null,
+  resolution_action: null,
   resolution_note: null,
   resolution_label_id: null,
   reopened_from_case_id: null,
@@ -55,12 +59,63 @@ test.describe('Cases', () => {
         body: JSON.stringify({ cases: [caseItem], total: 1 }),
       });
     });
+    await page.route('**/api/v2/cases/assignees', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ users: [{ id: 1, email: 'case.manager@example.com' }] }),
+      });
+    });
     await page.route('**/api/v2/cases/42', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            message: 'Case updated',
+            case: {
+              ...caseItem,
+              status: 'in_review',
+              assigned_to_user_id: 1,
+              assigned_to_email: 'case.manager@example.com',
+            },
+          }),
+        });
+        return;
+      }
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
           case: caseItem,
+          evaluation: {
+            evaluation_decision_id: 200,
+            transaction_id: 'txn-premium-review-001',
+            event_version_id: 100,
+            event_version: 1,
+            effective_at: '2026-07-05T09:58:00Z',
+            observed_at: '2026-07-05T10:00:00Z',
+            evaluated_at: '2026-07-05T10:00:00Z',
+            is_current: true,
+            resolved_outcome: 'HOLD',
+            outcome_counters: { HOLD: 1 },
+            event_data: {
+              transaction_id: 'txn-premium-review-001',
+              amount: 12500,
+              sender_id: 'premium-customer-884',
+            },
+            triggered_rules: [
+              {
+                r_id: 7,
+                rid: 'premium_amount_hold',
+                description: 'Premium transfer requires manual review',
+                outcome: 'HOLD',
+                metadata_source: 'evaluation_snapshot',
+                referenced_fields: ['amount', 'sender_id'],
+              },
+            ],
+          },
           events: [
             {
               id: 1,
@@ -74,6 +129,27 @@ test.describe('Cases', () => {
               created_at: '2026-07-05T10:00:00Z',
             },
           ],
+        }),
+      });
+    });
+    await page.route('**/api/v2/cases/42/notes', async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          message: 'Case note added',
+          event: {
+            id: 2,
+            case_id: 42,
+            event_type: 'note',
+            actor_user_id: 1,
+            source_ed_id: 200,
+            external_event_id: 'case_evt_note',
+            occurred_at: '2026-07-05T10:03:00Z',
+            details: { note: 'Customer confirmed this transfer was expected.' },
+            created_at: '2026-07-05T10:03:00Z',
+          },
         }),
       });
     });
@@ -110,6 +186,9 @@ test.describe('Cases', () => {
             ...caseItem,
             status: 'resolved',
             resolved_by_user_id: 1,
+            resolved_by_email: 'case.manager@example.com',
+            resolution_disposition: 'false_positive',
+            resolution_action: 'release_transaction',
             resolution_note: 'Verified customer profile and cleared case.',
             resolved_at: '2026-07-05T10:05:00Z',
           },
@@ -123,9 +202,21 @@ test.describe('Cases', () => {
     await expect(casesPage.casesTable).toBeVisible();
     await expect(casesPage.caseRows.first()).toContainText('txn-premium-review-001');
     await expect(casesPage.detail).toContainText('HOLD');
+    await expect(casesPage.detail).toContainText('txn-premium-review-001');
+    await expect(page.locator('[data-testid="case-evaluation-context"]')).toContainText('Event version');
+    await expect(page.locator('[data-testid="case-triggered-rules"]')).toContainText('premium_amount_hold');
+    await expect(page.locator('[data-testid="case-triggered-rules"]')).toContainText('Premium transfer requires manual review');
+    await expect(page.locator('[data-testid="case-event-payload"]')).toContainText('premium-customer-884');
     await expect(casesPage.eventsList).toContainText('created');
     await expect(page.locator('text=evaluation.completed')).toBeVisible();
 
+    await page.locator('[data-testid="case-claim-button"]').click();
+    await expect(page.locator('text=Case assignment updated.')).toBeVisible();
+    await page.locator('[data-testid="case-note"]').fill('Customer confirmed this transfer was expected.');
+    await page.locator('[data-testid="case-add-note-button"]').click();
+    await expect(page.locator('text=Case note added.')).toBeVisible();
+    await page.locator('[data-testid="case-resolution-disposition"]').selectOption('false_positive');
+    await page.locator('[data-testid="case-resolution-action"]').selectOption('release_transaction');
     await casesPage.resolutionNote.fill('Verified customer profile and cleared case.');
     await casesPage.resolveButton.click();
 

--- a/ezrules/frontend/e2e/tests/cases.spec.ts
+++ b/ezrules/frontend/e2e/tests/cases.spec.ts
@@ -1,0 +1,143 @@
+import { expect, Page, test } from '@playwright/test';
+import { CasesPage } from '../pages/cases.page';
+
+function mockAuthMe(page: Page, permissions: string[]) {
+  page.addInitScript(() => {
+    window.localStorage.setItem('ezrules_access_token', 'case-spec-token');
+  });
+  return page.route('**/api/v2/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 1,
+        email: 'case.manager@example.com',
+        active: true,
+        roles: [{ id: 1, name: 'case_manager', description: 'Case manager' }],
+        permissions,
+        last_login_at: null,
+      }),
+    });
+  });
+}
+
+const caseItem = {
+  id: 42,
+  transaction_id: 'txn-premium-review-001',
+  current_event_version_id: 100,
+  current_evaluation_decision_id: 200,
+  opened_by_evaluation_decision_id: 200,
+  previous_evaluation_decision_id: null,
+  resolved_outcome: 'HOLD',
+  previous_resolved_outcome: null,
+  status: 'open',
+  decision_state: 'current',
+  priority: 2,
+  assigned_to_user_id: null,
+  resolved_by_user_id: null,
+  resolution_note: null,
+  resolution_label_id: null,
+  reopened_from_case_id: null,
+  created_at: '2026-07-05T10:00:00Z',
+  updated_at: '2026-07-05T10:00:00Z',
+  resolved_at: null,
+};
+
+test.describe('Cases', () => {
+  test('lists and resolves a case while showing integration events', async ({ page }) => {
+    const casesPage = new CasesPage(page);
+    await mockAuthMe(page, ['view_cases', 'manage_cases', 'view_integrations']);
+
+    await page.route('**/api/v2/cases?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ cases: [caseItem], total: 1 }),
+      });
+    });
+    await page.route('**/api/v2/cases/42', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          case: caseItem,
+          events: [
+            {
+              id: 1,
+              case_id: 42,
+              event_type: 'created',
+              actor_user_id: null,
+              source_ed_id: 200,
+              external_event_id: 'case_evt_created',
+              occurred_at: '2026-07-05T10:00:00Z',
+              details: {},
+              created_at: '2026-07-05T10:00:00Z',
+            },
+          ],
+        }),
+      });
+    });
+    await page.route('**/api/v2/integration-events?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          events: [
+            {
+              id: 10,
+              external_event_id: 'evt_evaluation_completed_200',
+              source_type: 'evaluation_decision',
+              source_id: 200,
+              event_type: 'evaluation.completed',
+              event_version: 1,
+              occurred_at: '2026-07-05T10:00:00Z',
+              payload: {},
+              created_at: '2026-07-05T10:00:00Z',
+            },
+          ],
+          next_cursor: null,
+        }),
+      });
+    });
+    await page.route('**/api/v2/cases/42/resolve', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          message: 'Case resolved',
+          case: {
+            ...caseItem,
+            status: 'resolved',
+            resolved_by_user_id: 1,
+            resolution_note: 'Verified customer profile and cleared case.',
+            resolved_at: '2026-07-05T10:05:00Z',
+          },
+        }),
+      });
+    });
+
+    await casesPage.goto();
+    await casesPage.waitForLoad();
+
+    await expect(casesPage.casesTable).toBeVisible();
+    await expect(casesPage.caseRows.first()).toContainText('txn-premium-review-001');
+    await expect(casesPage.detail).toContainText('HOLD');
+    await expect(casesPage.eventsList).toContainText('created');
+    await expect(page.locator('text=evaluation.completed')).toBeVisible();
+
+    await casesPage.resolutionNote.fill('Verified customer profile and cleared case.');
+    await casesPage.resolveButton.click();
+
+    await expect(page.locator('text=Case resolved.')).toBeVisible();
+  });
+
+  test('requires case view permission', async ({ page }) => {
+    await mockAuthMe(page, ['view_rules']);
+
+    await page.goto('/cases');
+
+    await expect(page).toHaveURL(/\/access-denied/);
+    await expect(page.locator('text=View cases')).toBeVisible();
+  });
+});

--- a/ezrules/frontend/e2e/tests/cases.spec.ts
+++ b/ezrules/frontend/e2e/tests/cases.spec.ts
@@ -51,8 +51,10 @@ test.describe('Cases', () => {
   test('lists and resolves a case while showing integration events', async ({ page }) => {
     const casesPage = new CasesPage(page);
     await mockAuthMe(page, ['view_cases', 'manage_cases', 'view_integrations']);
+    const caseListUrls: string[] = [];
 
     await page.route('**/api/v2/cases?**', async (route) => {
+      caseListUrls.push(route.request().url());
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -209,6 +211,29 @@ test.describe('Cases', () => {
     await expect(page.locator('[data-testid="case-event-payload"]')).toContainText('premium-customer-884');
     await expect(casesPage.eventsList).toContainText('created');
     await expect(page.locator('text=evaluation.completed')).toBeVisible();
+
+    await page.locator('[data-testid="case-queue-me"]').click();
+    await page.locator('[data-testid="case-priority-min-filter"]').selectOption({ label: '2+' });
+    await page.locator('[data-testid="case-decision-state-filter"]').selectOption('current');
+    await page.locator('[data-testid="case-created-from-filter"]').fill('2026-07-05');
+    await page.locator('[data-testid="case-created-from-filter"]').dispatchEvent('change');
+    await page.locator('[data-testid="case-updated-to-filter"]').fill('2026-07-06');
+    await page.locator('[data-testid="case-updated-to-filter"]').dispatchEvent('change');
+    await expect.poll(() => {
+      const lastUrl = caseListUrls.at(-1);
+      if (!lastUrl) {
+        return false;
+      }
+      const params = new URL(lastUrl).searchParams;
+      return (
+        params.get('assigned_to') === 'me' &&
+        params.get('status') === 'open' &&
+        params.get('priority_min') === '2' &&
+        params.get('decision_state') === 'current' &&
+        params.get('created_from') === '2026-07-05' &&
+        params.get('updated_to') === '2026-07-06'
+      );
+    }).toBeTruthy();
 
     await page.locator('[data-testid="case-claim-button"]').click();
     await expect(page.locator('text=Case assignment updated.')).toBeVisible();

--- a/ezrules/frontend/e2e/tests/cases.spec.ts
+++ b/ezrules/frontend/e2e/tests/cases.spec.ts
@@ -214,7 +214,7 @@ test.describe('Cases', () => {
 
     await page.locator('[data-testid="case-queue-me"]').click();
     await page.locator('[data-testid="case-priority-min-filter"]').selectOption({ label: '2+' });
-    await page.locator('[data-testid="case-decision-state-filter"]').selectOption('current');
+    await page.locator('[data-testid="case-decision-state-filter"]').selectOption('rescored_neutral');
     await page.locator('[data-testid="case-created-from-filter"]').fill('2026-07-05');
     await page.locator('[data-testid="case-created-from-filter"]').dispatchEvent('change');
     await page.locator('[data-testid="case-updated-to-filter"]').fill('2026-07-06');
@@ -229,7 +229,7 @@ test.describe('Cases', () => {
         params.get('assigned_to') === 'me' &&
         params.get('status') === 'open' &&
         params.get('priority_min') === '2' &&
-        params.get('decision_state') === 'current' &&
+        params.get('decision_state') === 'rescored_neutral' &&
         params.get('created_from') === '2026-07-05' &&
         params.get('updated_to') === '2026-07-06'
       );

--- a/ezrules/frontend/src/app/app.routes.ts
+++ b/ezrules/frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { FeaturesComponent } from './features/features.component';
 import { ShadowRulesComponent } from './shadow-rules/shadow-rules.component';
 import { RolloutsComponent } from './rollouts/rollouts.component';
 import { ApiKeysComponent } from './api-keys/api-keys.component';
+import { CasesComponent } from './cases/cases.component';
 import { TestedEventsComponent } from './tested-events/tested-events.component';
 import { EventTesterComponent } from './event-tester/event-tester.component';
 import { authGuard } from './auth/auth.guard';
@@ -131,6 +132,12 @@ export const routes: Routes = [
     component: AlertsComponent,
     canActivate: [authGuard, permissionGuard],
     data: { permissionRequirement: ROUTE_PERMISSION_REQUIREMENTS.alerts }
+  },
+  {
+    path: 'cases',
+    component: CasesComponent,
+    canActivate: [authGuard, permissionGuard],
+    data: { permissionRequirement: ROUTE_PERMISSION_REQUIREMENTS.cases }
   },
   {
     path: 'management/users',

--- a/ezrules/frontend/src/app/auth/permissions.ts
+++ b/ezrules/frontend/src/app/auth/permissions.ts
@@ -24,6 +24,7 @@ export const ROUTE_PERMISSION_REQUIREMENTS = {
   rollouts: { allOf: ['view_rules'] },
   apiKeys: { allOf: ['manage_api_keys'] },
   alerts: { allOf: ['view_alerts'] },
+  cases: { allOf: ['view_cases'] },
 } as const satisfies Record<string, PermissionRequirement>;
 
 export const ACTION_PERMISSION_REQUIREMENTS = {
@@ -56,6 +57,8 @@ export const ACTION_PERMISSION_REQUIREMENTS = {
   deleteFeature: { allOf: ['delete_feature'] },
   manageApiKeys: { allOf: ['manage_api_keys'] },
   manageAlerts: { allOf: ['manage_alerts'] },
+  manageCases: { allOf: ['manage_cases'] },
+  manageIntegrations: { allOf: ['manage_integrations'] },
   submitTestEvents: { allOf: ['submit_test_events'] },
 } as const satisfies Record<string, PermissionRequirement>;
 
@@ -101,6 +104,10 @@ export const PERMISSION_LABELS: Record<string, string> = {
   manage_api_keys: 'Manage API keys',
   view_alerts: 'View alerts',
   manage_alerts: 'Manage alerts',
+  view_cases: 'View cases',
+  manage_cases: 'Manage cases',
+  view_integrations: 'View integrations',
+  manage_integrations: 'Manage integrations',
 };
 
 export function hasPermissionRequirement(

--- a/ezrules/frontend/src/app/cases/cases.component.ts
+++ b/ezrules/frontend/src/app/cases/cases.component.ts
@@ -76,8 +76,8 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
             >
               <option value="">All states</option>
               <option value="current">Current</option>
-              <option value="rescored_changed">Rescored changed</option>
-              <option value="rescored_same">Rescored same</option>
+              <option value="rescored_neutral">Rescored neutral</option>
+              <option value="rescored_non_caseable">Rescored no outcome</option>
             </select>
           </label>
           <label class="block text-sm">

--- a/ezrules/frontend/src/app/cases/cases.component.ts
+++ b/ezrules/frontend/src/app/cases/cases.component.ts
@@ -1,0 +1,253 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { SidebarComponent } from '../components/sidebar.component';
+import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services/case.service';
+
+@Component({
+  selector: 'app-cases',
+  standalone: true,
+  imports: [CommonModule, FormsModule, SidebarComponent],
+  template: `
+    <app-sidebar></app-sidebar>
+    <main class="ml-64 min-h-screen bg-gray-50">
+      <div class="px-8 py-6">
+        <div class="mb-6 flex items-center justify-between gap-4">
+          <div>
+            <h1 class="text-2xl font-bold text-gray-900">Cases</h1>
+            <p class="mt-1 text-sm text-gray-600">Review non-neutral decisions and publish case outcomes.</p>
+          </div>
+          <select
+            data-testid="case-status-filter"
+            [(ngModel)]="statusFilter"
+            (change)="loadCases()"
+            class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+          >
+            <option value="">All statuses</option>
+            <option value="open">Open</option>
+            <option value="in_review">In review</option>
+            <option value="resolved">Resolved</option>
+            <option value="closed">Closed</option>
+          </select>
+        </div>
+
+        <div *ngIf="error" class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {{ error }}
+        </div>
+        <div *ngIf="success" class="mb-4 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {{ success }}
+        </div>
+
+        <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
+          <section class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-4 py-3">
+              <h2 class="text-sm font-semibold text-gray-900">Case inbox</h2>
+            </div>
+            <div *ngIf="loading" class="p-6 text-sm text-gray-500">Loading cases...</div>
+            <div *ngIf="!loading && cases.length === 0" class="p-6 text-sm text-gray-500" data-testid="cases-empty">
+              No cases found.
+            </div>
+            <table *ngIf="!loading && cases.length > 0" class="min-w-full divide-y divide-gray-200" data-testid="cases-table">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Transaction</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Outcome</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">State</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Updated</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100 bg-white">
+                <tr
+                  *ngFor="let item of cases"
+                  (click)="selectCase(item)"
+                  class="cursor-pointer hover:bg-gray-50"
+                  [class.bg-blue-50]="selected?.id === item.id"
+                  data-testid="case-row"
+                >
+                  <td class="px-4 py-3 text-sm font-medium text-gray-900">{{ item.transaction_id }}</td>
+                  <td class="px-4 py-3 text-sm text-gray-700">{{ item.resolved_outcome || 'None' }}</td>
+                  <td class="px-4 py-3 text-sm text-gray-700">
+                    <span class="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">{{ item.status }}</span>
+                    <span *ngIf="item.decision_state !== 'current'" class="ml-2 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800">
+                      {{ item.decision_state }}
+                    </span>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-500">{{ item.updated_at | date:'short' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <aside class="space-y-6">
+            <section class="rounded-lg border border-gray-200 bg-white" data-testid="case-detail">
+              <div class="border-b border-gray-200 px-4 py-3">
+                <h2 class="text-sm font-semibold text-gray-900">Selected case</h2>
+              </div>
+              <div *ngIf="!selected" class="p-4 text-sm text-gray-500">Select a case to review.</div>
+              <div *ngIf="selected" class="space-y-4 p-4">
+                <dl class="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <dt class="text-gray-500">Case ID</dt>
+                    <dd class="font-medium text-gray-900">{{ selected.id }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-500">Evaluation</dt>
+                    <dd class="font-medium text-gray-900">{{ selected.current_evaluation_decision_id }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-500">Outcome</dt>
+                    <dd class="font-medium text-gray-900">{{ selected.resolved_outcome || 'None' }}</dd>
+                  </div>
+                  <div>
+                    <dt class="text-gray-500">Status</dt>
+                    <dd class="font-medium text-gray-900">{{ selected.status }}</dd>
+                  </div>
+                </dl>
+
+                <div
+                  *ngIf="selected.decision_state !== 'current'"
+                  class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                  data-testid="case-rescored-banner"
+                >
+                  Current score no longer matches the original case outcome.
+                </div>
+
+                <div *ngIf="selected.status !== 'resolved'" class="space-y-3">
+                  <label class="block text-sm font-medium text-gray-700" for="case-resolution-note">Resolution note</label>
+                  <textarea
+                    id="case-resolution-note"
+                    data-testid="case-resolution-note"
+                    [(ngModel)]="resolutionNote"
+                    rows="4"
+                    class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  ></textarea>
+                  <button
+                    type="button"
+                    data-testid="case-resolve-button"
+                    (click)="resolveSelectedCase()"
+                    [disabled]="saving || !resolutionNote.trim()"
+                    class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
+                  >
+                    Resolve case
+                  </button>
+                </div>
+
+                <div>
+                  <h3 class="mb-2 text-sm font-semibold text-gray-900">Timeline</h3>
+                  <ol class="space-y-2" data-testid="case-events">
+                    <li *ngFor="let event of detail?.events" class="rounded-md bg-gray-50 px-3 py-2 text-sm">
+                      <div class="font-medium text-gray-900">{{ event.event_type }}</div>
+                      <div class="text-xs text-gray-500">{{ event.occurred_at | date:'short' }}</div>
+                    </li>
+                  </ol>
+                </div>
+              </div>
+            </section>
+
+            <section class="rounded-lg border border-gray-200 bg-white">
+              <div class="border-b border-gray-200 px-4 py-3">
+                <h2 class="text-sm font-semibold text-gray-900">Recent integration events</h2>
+              </div>
+              <div class="max-h-72 overflow-y-auto p-4">
+                <div *ngIf="integrationEvents.length === 0" class="text-sm text-gray-500">No integration events.</div>
+                <div *ngFor="let event of integrationEvents" class="border-b border-gray-100 py-2 text-sm last:border-0">
+                  <div class="font-medium text-gray-900">{{ event.event_type }}</div>
+                  <div class="text-xs text-gray-500">{{ event.external_event_id }}</div>
+                </div>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </main>
+  `
+})
+export class CasesComponent implements OnInit {
+  cases: CaseItem[] = [];
+  selected: CaseItem | null = null;
+  detail: CaseDetail | null = null;
+  integrationEvents: IntegrationEvent[] = [];
+  statusFilter = '';
+  resolutionNote = '';
+  loading = true;
+  saving = false;
+  error: string | null = null;
+  success: string | null = null;
+
+  constructor(private caseService: CaseService) {}
+
+  ngOnInit(): void {
+    this.loadCases();
+    this.loadIntegrationEvents();
+  }
+
+  loadCases(): void {
+    this.loading = true;
+    this.error = null;
+    this.caseService.getCases(this.statusFilter || undefined).subscribe({
+      next: (response) => {
+        this.cases = response.cases;
+        this.loading = false;
+        if (!this.selected && this.cases.length > 0) {
+          this.selectCase(this.cases[0]);
+        }
+      },
+      error: () => {
+        this.error = 'Failed to load cases.';
+        this.loading = false;
+      }
+    });
+  }
+
+  selectCase(item: CaseItem): void {
+    this.selected = item;
+    this.resolutionNote = '';
+    this.caseService.getCase(item.id).subscribe({
+      next: (detail) => {
+        this.detail = detail;
+        this.selected = detail.case;
+      },
+      error: () => {
+        this.error = 'Failed to load case details.';
+      }
+    });
+  }
+
+  resolveSelectedCase(): void {
+    if (!this.selected || this.saving || !this.resolutionNote.trim()) {
+      return;
+    }
+    this.saving = true;
+    this.error = null;
+    this.success = null;
+    this.caseService.resolveCase(
+      this.selected.id,
+      this.resolutionNote,
+      this.selected.current_evaluation_decision_id,
+    ).subscribe({
+      next: (response) => {
+        this.success = 'Case resolved.';
+        this.saving = false;
+        this.selected = response.case;
+        this.loadCases();
+        this.selectCase(response.case);
+        this.loadIntegrationEvents();
+      },
+      error: (err) => {
+        this.error = err?.error?.detail || 'Failed to resolve case.';
+        this.saving = false;
+      }
+    });
+  }
+
+  loadIntegrationEvents(): void {
+    this.caseService.getIntegrationEvents().subscribe({
+      next: (response) => {
+        this.integrationEvents = response.events;
+      },
+      error: () => {
+        this.integrationEvents = [];
+      }
+    });
+  }
+}

--- a/ezrules/frontend/src/app/cases/cases.component.ts
+++ b/ezrules/frontend/src/app/cases/cases.component.ts
@@ -2,7 +2,8 @@ import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SidebarComponent } from '../components/sidebar.component';
-import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services/case.service';
+import { AuthService, AuthUser } from '../services/auth.service';
+import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services/case.service';
 
 @Component({
   selector: 'app-cases',
@@ -17,17 +18,43 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
             <h1 class="text-2xl font-bold text-gray-900">Cases</h1>
             <p class="mt-1 text-sm text-gray-600">Review non-neutral decisions and publish case outcomes.</p>
           </div>
-          <select
-            data-testid="case-status-filter"
-            [(ngModel)]="statusFilter"
-            (change)="loadCases()"
-            class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
-          >
-            <option value="">All statuses</option>
-            <option value="open">Open</option>
-            <option value="in_review">In review</option>
-            <option value="resolved">Resolved</option>
-          </select>
+          <div class="flex flex-wrap items-center gap-2">
+            <input
+              data-testid="case-search"
+              [(ngModel)]="searchQuery"
+              (keyup.enter)="loadCases()"
+              placeholder="Search transaction"
+              class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            />
+            <select
+              data-testid="case-status-filter"
+              [(ngModel)]="statusFilter"
+              (change)="loadCases()"
+              class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="">All statuses</option>
+              <option value="open">Open</option>
+              <option value="in_review">In review</option>
+              <option value="resolved">Resolved</option>
+            </select>
+            <select
+              data-testid="case-assignment-filter"
+              [(ngModel)]="assignedToFilter"
+              (change)="loadCases()"
+              class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="">All assignments</option>
+              <option value="me">Assigned to me</option>
+              <option value="unassigned">Unassigned</option>
+            </select>
+            <button
+              type="button"
+              (click)="loadCases()"
+              class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700"
+            >
+              Apply
+            </button>
+          </div>
         </div>
 
         <div *ngIf="error" class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -37,7 +64,7 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
           {{ success }}
         </div>
 
-        <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <div class="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1fr)_560px]">
           <section class="overflow-hidden rounded-lg border border-gray-200 bg-white">
             <div class="border-b border-gray-200 px-4 py-3">
               <h2 class="text-sm font-semibold text-gray-900">Case inbox</h2>
@@ -51,6 +78,8 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
                 <tr>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Transaction</th>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Outcome</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Assignee</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Priority</th>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">State</th>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Updated</th>
                 </tr>
@@ -65,6 +94,8 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
                 >
                   <td class="px-4 py-3 text-sm font-medium text-gray-900">{{ item.transaction_id }}</td>
                   <td class="px-4 py-3 text-sm text-gray-700">{{ item.resolved_outcome || 'None' }}</td>
+                  <td class="px-4 py-3 text-sm text-gray-700">{{ item.assigned_to_email || 'Unassigned' }}</td>
+                  <td class="px-4 py-3 text-sm text-gray-700">{{ item.priority }}</td>
                   <td class="px-4 py-3 text-sm text-gray-700">
                     <span class="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">{{ item.status }}</span>
                     <span *ngIf="item.decision_state !== 'current'" class="ml-2 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800">
@@ -90,6 +121,12 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
                     <dd class="font-medium text-gray-900">{{ selected.id }}</dd>
                   </div>
                   <div>
+                    <dt class="text-gray-500">Transaction</dt>
+                    <dd class="break-all font-medium text-gray-900" data-testid="case-detail-transaction">
+                      {{ selected.transaction_id }}
+                    </dd>
+                  </div>
+                  <div>
                     <dt class="text-gray-500">Evaluation</dt>
                     <dd class="font-medium text-gray-900">{{ selected.current_evaluation_decision_id }}</dd>
                   </div>
@@ -111,7 +148,174 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
                   Current score no longer matches the original case outcome.
                 </div>
 
+                <div *ngIf="selected.status !== 'resolved'" class="space-y-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 class="text-sm font-semibold text-gray-900">Assignment</h3>
+                      <p class="text-sm text-gray-600">{{ selected.assigned_to_email || 'Unassigned' }}</p>
+                    </div>
+                    <button
+                      type="button"
+                      data-testid="case-claim-button"
+                      (click)="claimSelectedCase()"
+                      [disabled]="saving || !currentUser || selected.assigned_to_user_id === currentUser.id"
+                      class="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
+                    >
+                      Claim
+                    </button>
+                  </div>
+                  <div class="flex gap-2">
+                    <select
+                      data-testid="case-assignee-select"
+                      [(ngModel)]="selectedAssigneeId"
+                      class="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                    >
+                      <option [ngValue]="null">Unassigned</option>
+                      <option *ngFor="let assignee of assignees" [ngValue]="assignee.id">{{ assignee.email }}</option>
+                    </select>
+                    <button
+                      type="button"
+                      data-testid="case-assign-button"
+                      (click)="assignSelectedCase(selectedAssigneeId)"
+                      [disabled]="saving"
+                      class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+
+                <div *ngIf="detail?.evaluation as evaluation" class="space-y-4">
+                  <div class="rounded-md border border-gray-200 bg-gray-50 p-3" data-testid="case-evaluation-context">
+                    <div class="mb-3 flex items-center justify-between gap-3">
+                      <h3 class="text-sm font-semibold text-gray-900">Evaluation context</h3>
+                      <span
+                        class="rounded-full px-2 py-1 text-xs font-medium"
+                        [ngClass]="evaluation.is_current ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'"
+                      >
+                        {{ evaluation.is_current ? 'Current' : 'Superseded' }}
+                      </span>
+                    </div>
+                    <dl class="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <dt class="text-gray-500">Event version</dt>
+                        <dd class="font-medium text-gray-900">{{ evaluation.event_version }}</dd>
+                      </div>
+                      <div>
+                        <dt class="text-gray-500">Event version ID</dt>
+                        <dd class="font-medium text-gray-900">{{ evaluation.event_version_id }}</dd>
+                      </div>
+                      <div>
+                        <dt class="text-gray-500">Effective</dt>
+                        <dd class="font-medium text-gray-900">{{ evaluation.effective_at | date:'short' }}</dd>
+                      </div>
+                      <div>
+                        <dt class="text-gray-500">Evaluated</dt>
+                        <dd class="font-medium text-gray-900">{{ evaluation.evaluated_at | date:'short' }}</dd>
+                      </div>
+                    </dl>
+                    <div *ngIf="outcomeCounterEntries(evaluation.outcome_counters).length > 0" class="mt-3 flex flex-wrap gap-2">
+                      <span
+                        *ngFor="let counter of outcomeCounterEntries(evaluation.outcome_counters)"
+                        class="rounded-full bg-white px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-gray-200"
+                      >
+                        {{ counter.key }}: {{ counter.value }}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div class="rounded-md border border-gray-200 bg-white" data-testid="case-triggered-rules">
+                    <div class="border-b border-gray-200 px-3 py-2">
+                      <h3 class="text-sm font-semibold text-gray-900">Triggered rules</h3>
+                    </div>
+                    <div *ngIf="evaluation.triggered_rules.length === 0" class="px-3 py-3 text-sm text-gray-500">
+                      No triggered rule details were stored for this evaluation.
+                    </div>
+                    <div *ngFor="let rule of evaluation.triggered_rules" class="border-b border-gray-100 px-3 py-3 last:border-0">
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                          <div class="truncate text-sm font-semibold text-gray-900">{{ rule.rid }}</div>
+                          <div class="text-sm text-gray-600">{{ rule.description }}</div>
+                        </div>
+                        <span class="shrink-0 rounded-full bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700">
+                          {{ rule.outcome }}
+                        </span>
+                      </div>
+                      <div *ngIf="rule.referenced_fields?.length" class="mt-2 flex flex-wrap gap-1">
+                        <span
+                          *ngFor="let field of rule.referenced_fields"
+                          class="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600"
+                        >
+                          {{ field }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="rounded-md border border-gray-200 bg-white" data-testid="case-event-payload">
+                    <div class="border-b border-gray-200 px-3 py-2">
+                      <h3 class="text-sm font-semibold text-gray-900">Event payload</h3>
+                    </div>
+                    <pre class="max-h-80 overflow-auto p-3 text-xs leading-5 text-gray-800">{{ formatJson(evaluation.event_data) }}</pre>
+                  </div>
+                </div>
+
+                <div *ngIf="selected.status !== 'resolved'" class="space-y-3 rounded-md border border-gray-200 p-3">
+                  <label class="block text-sm font-medium text-gray-700" for="case-note">Add note</label>
+                  <textarea
+                    id="case-note"
+                    data-testid="case-note"
+                    [(ngModel)]="noteText"
+                    rows="3"
+                    class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  ></textarea>
+                  <button
+                    type="button"
+                    data-testid="case-add-note-button"
+                    (click)="addNoteToSelectedCase()"
+                    [disabled]="saving || !noteText.trim()"
+                    class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:bg-gray-100"
+                  >
+                    Add note
+                  </button>
+                </div>
+
                 <div *ngIf="selected.status !== 'resolved'" class="space-y-3">
+                  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700" for="case-resolution-disposition">Disposition</label>
+                      <select
+                        id="case-resolution-disposition"
+                        data-testid="case-resolution-disposition"
+                        [(ngModel)]="resolutionDisposition"
+                        class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                      >
+                        <option value="">Select</option>
+                        <option value="confirmed_fraud">Confirmed fraud</option>
+                        <option value="false_positive">False positive</option>
+                        <option value="approved">Approved</option>
+                        <option value="rejected">Rejected</option>
+                        <option value="duplicate">Duplicate</option>
+                        <option value="unable_to_verify">Unable to verify</option>
+                        <option value="escalated">Escalated</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700" for="case-resolution-action">Action</label>
+                      <select
+                        id="case-resolution-action"
+                        data-testid="case-resolution-action"
+                        [(ngModel)]="resolutionAction"
+                        class="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                      >
+                        <option value="none">None</option>
+                        <option value="release_transaction">Release transaction</option>
+                        <option value="cancel_transaction">Cancel transaction</option>
+                        <option value="block_customer">Block customer</option>
+                        <option value="escalate_external_review">Escalate external review</option>
+                      </select>
+                    </div>
+                  </div>
                   <label class="block text-sm font-medium text-gray-700" for="case-resolution-note">Resolution note</label>
                   <textarea
                     id="case-resolution-note"
@@ -124,11 +328,17 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
                     type="button"
                     data-testid="case-resolve-button"
                     (click)="resolveSelectedCase()"
-                    [disabled]="saving || !resolutionNote.trim()"
+                    [disabled]="saving || !resolutionDisposition || !resolutionNote.trim()"
                     class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
                   >
                     Resolve case
                   </button>
+                </div>
+
+                <div *ngIf="selected.status === 'resolved'" class="rounded-md border border-green-200 bg-green-50 p-3 text-sm">
+                  <div class="font-semibold text-green-900">Resolution</div>
+                  <div class="mt-1 text-green-800">{{ selected.resolution_disposition || 'No disposition' }} / {{ selected.resolution_action || 'none' }}</div>
+                  <div *ngIf="selected.resolution_note" class="mt-2 text-green-800">{{ selected.resolution_note }}</div>
                 </div>
 
                 <div>
@@ -137,6 +347,10 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
                     <li *ngFor="let event of detail?.events" class="rounded-md bg-gray-50 px-3 py-2 text-sm">
                       <div class="font-medium text-gray-900">{{ event.event_type }}</div>
                       <div class="text-xs text-gray-500">{{ event.occurred_at | date:'short' }}</div>
+                      <div *ngIf="event.details['note']" class="mt-1 text-gray-700">{{ event.details['note'] }}</div>
+                      <div *ngIf="event.details['resolution_disposition']" class="mt-1 text-gray-700">
+                        {{ event.details['resolution_disposition'] }} / {{ event.details['resolution_action'] || 'none' }}
+                      </div>
                     </li>
                   </ol>
                 </div>
@@ -165,17 +379,42 @@ export class CasesComponent implements OnInit {
   cases: CaseItem[] = [];
   selected: CaseItem | null = null;
   detail: CaseDetail | null = null;
+  assignees: CaseAssignee[] = [];
   integrationEvents: IntegrationEvent[] = [];
+  currentUser: AuthUser | null = null;
   statusFilter = '';
+  assignedToFilter = '';
+  searchQuery = '';
+  selectedAssigneeId: number | null = null;
+  noteText = '';
+  resolutionDisposition = '';
+  resolutionAction = 'none';
   resolutionNote = '';
   loading = true;
   saving = false;
   error: string | null = null;
   success: string | null = null;
 
-  constructor(private caseService: CaseService) {}
+  constructor(private caseService: CaseService, private authService: AuthService) {}
+
+  outcomeCounterEntries(counters: Record<string, number>): Array<{ key: string; value: number }> {
+    return Object.entries(counters).map(([key, value]) => ({ key, value }));
+  }
+
+  formatJson(value: Record<string, unknown>): string {
+    return JSON.stringify(value, null, 2);
+  }
 
   ngOnInit(): void {
+    this.authService.getCurrentUser().subscribe({
+      next: (user) => {
+        this.currentUser = user;
+      },
+      error: () => {
+        this.currentUser = null;
+      }
+    });
+    this.loadAssignees();
     this.loadCases();
     this.loadIntegrationEvents();
   }
@@ -183,7 +422,11 @@ export class CasesComponent implements OnInit {
   loadCases(): void {
     this.loading = true;
     this.error = null;
-    this.caseService.getCases(this.statusFilter || undefined).subscribe({
+    this.caseService.getCases({
+      status: this.statusFilter || undefined,
+      assignedTo: this.assignedToFilter || undefined,
+      query: this.searchQuery.trim() || undefined,
+    }).subscribe({
       next: (response) => {
         this.cases = response.cases;
         this.loading = false;
@@ -200,11 +443,14 @@ export class CasesComponent implements OnInit {
 
   selectCase(item: CaseItem): void {
     this.selected = item;
-    this.resolutionNote = '';
+    this.selectedAssigneeId = item.assigned_to_user_id;
+    this.noteText = '';
+    this.resetResolutionForm();
     this.caseService.getCase(item.id).subscribe({
       next: (detail) => {
         this.detail = detail;
         this.selected = detail.case;
+        this.selectedAssigneeId = detail.case.assigned_to_user_id;
       },
       error: () => {
         this.error = 'Failed to load case details.';
@@ -212,8 +458,80 @@ export class CasesComponent implements OnInit {
     });
   }
 
+  resetResolutionForm(): void {
+    this.resolutionDisposition = '';
+    this.resolutionAction = 'none';
+    this.resolutionNote = '';
+  }
+
+  loadAssignees(): void {
+    this.caseService.getAssignees().subscribe({
+      next: (response) => {
+        this.assignees = response.users;
+      },
+      error: () => {
+        this.assignees = [];
+      }
+    });
+  }
+
+  claimSelectedCase(): void {
+    if (!this.currentUser) {
+      return;
+    }
+    this.assignSelectedCase(this.currentUser.id);
+  }
+
+  assignSelectedCase(assignedToUserId: number | null): void {
+    if (!this.selected || this.saving) {
+      return;
+    }
+    this.saving = true;
+    this.error = null;
+    this.success = null;
+    this.caseService.assignCase(this.selected.id, assignedToUserId).subscribe({
+      next: (response) => {
+        this.success = 'Case assignment updated.';
+        this.saving = false;
+        this.selected = response.case;
+        this.selectedAssigneeId = response.case.assigned_to_user_id;
+        this.loadCases();
+        this.selectCase(response.case);
+        this.loadIntegrationEvents();
+      },
+      error: (err) => {
+        this.error = err?.error?.detail || 'Failed to update case assignment.';
+        this.saving = false;
+      }
+    });
+  }
+
+  addNoteToSelectedCase(): void {
+    if (!this.selected || this.saving || !this.noteText.trim()) {
+      return;
+    }
+    this.saving = true;
+    this.error = null;
+    this.success = null;
+    this.caseService.addNote(this.selected.id, this.noteText).subscribe({
+      next: () => {
+        this.success = 'Case note added.';
+        this.saving = false;
+        this.noteText = '';
+        if (this.selected) {
+          this.selectCase(this.selected);
+        }
+        this.loadIntegrationEvents();
+      },
+      error: (err) => {
+        this.error = err?.error?.detail || 'Failed to add case note.';
+        this.saving = false;
+      }
+    });
+  }
+
   resolveSelectedCase(): void {
-    if (!this.selected || this.saving || !this.resolutionNote.trim()) {
+    if (!this.selected || this.saving || !this.resolutionDisposition || !this.resolutionNote.trim()) {
       return;
     }
     this.saving = true;
@@ -221,6 +539,8 @@ export class CasesComponent implements OnInit {
     this.success = null;
     this.caseService.resolveCase(
       this.selected.id,
+      this.resolutionDisposition,
+      this.resolutionAction,
       this.resolutionNote,
       this.selected.current_evaluation_decision_id,
     ).subscribe({

--- a/ezrules/frontend/src/app/cases/cases.component.ts
+++ b/ezrules/frontend/src/app/cases/cases.component.ts
@@ -13,12 +13,12 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
     <app-sidebar></app-sidebar>
     <main class="ml-64 min-h-screen bg-gray-50">
       <div class="px-8 py-6">
-        <div class="mb-6 flex items-center justify-between gap-4">
+        <div class="mb-4 flex items-center justify-between gap-4">
           <div>
             <h1 class="text-2xl font-bold text-gray-900">Cases</h1>
             <p class="mt-1 text-sm text-gray-600">Review non-neutral decisions and publish case outcomes.</p>
           </div>
-          <div class="flex flex-wrap items-center gap-2">
+          <div class="flex items-center gap-2">
             <input
               data-testid="case-search"
               [(ngModel)]="searchQuery"
@@ -26,33 +26,122 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
               placeholder="Search transaction"
               class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
             />
-            <select
-              data-testid="case-status-filter"
-              [(ngModel)]="statusFilter"
-              (change)="loadCases()"
-              class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
-            >
-              <option value="">All statuses</option>
-              <option value="open">Open</option>
-              <option value="in_review">In review</option>
-              <option value="resolved">Resolved</option>
-            </select>
-            <select
-              data-testid="case-assignment-filter"
-              [(ngModel)]="assignedToFilter"
-              (change)="loadCases()"
-              class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
-            >
-              <option value="">All assignments</option>
-              <option value="me">Assigned to me</option>
-              <option value="unassigned">Unassigned</option>
-            </select>
             <button
               type="button"
               (click)="loadCases()"
               class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700"
             >
               Apply
+            </button>
+          </div>
+        </div>
+
+        <div class="mb-4 flex flex-wrap items-center gap-2" role="tablist" aria-label="Case queues">
+          <button
+            *ngFor="let queue of queues"
+            type="button"
+            role="tab"
+            [attr.aria-selected]="queue.value === assignedToFilter"
+            [attr.data-testid]="'case-queue-' + queue.testId"
+            (click)="selectQueue(queue.value)"
+            class="rounded-md border px-3 py-2 text-sm font-medium"
+            [ngClass]="queue.value === assignedToFilter ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-300 bg-white text-gray-700'"
+          >
+            {{ queue.label }}
+          </button>
+        </div>
+
+        <div class="mb-6 grid grid-cols-1 gap-3 rounded-lg border border-gray-200 bg-white p-4 lg:grid-cols-4 xl:grid-cols-8">
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Status</span>
+            <select
+              data-testid="case-status-filter"
+              [(ngModel)]="statusFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="">All statuses</option>
+              <option value="open">Open</option>
+              <option value="in_review">In review</option>
+              <option value="resolved">Resolved</option>
+            </select>
+          </label>
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Decision</span>
+            <select
+              data-testid="case-decision-state-filter"
+              [(ngModel)]="decisionStateFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option value="">All states</option>
+              <option value="current">Current</option>
+              <option value="rescored_changed">Rescored changed</option>
+              <option value="rescored_same">Rescored same</option>
+            </select>
+          </label>
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Min priority</span>
+            <select
+              data-testid="case-priority-min-filter"
+              [(ngModel)]="priorityMinFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            >
+              <option [ngValue]="null">Any</option>
+              <option [ngValue]="1">1+</option>
+              <option [ngValue]="2">2+</option>
+              <option [ngValue]="3">3+</option>
+            </select>
+          </label>
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Created from</span>
+            <input
+              data-testid="case-created-from-filter"
+              type="date"
+              [(ngModel)]="createdFromFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            />
+          </label>
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Created to</span>
+            <input
+              data-testid="case-created-to-filter"
+              type="date"
+              [(ngModel)]="createdToFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            />
+          </label>
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Updated from</span>
+            <input
+              data-testid="case-updated-from-filter"
+              type="date"
+              [(ngModel)]="updatedFromFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            />
+          </label>
+          <label class="block text-sm">
+            <span class="mb-1 block font-medium text-gray-700">Updated to</span>
+            <input
+              data-testid="case-updated-to-filter"
+              type="date"
+              [(ngModel)]="updatedToFilter"
+              (change)="loadCases()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+            />
+          </label>
+          <div class="flex items-end">
+            <button
+              type="button"
+              data-testid="case-clear-filters"
+              (click)="clearFilters()"
+              class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700"
+            >
+              Clear
             </button>
           </div>
         </div>
@@ -76,7 +165,8 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
             <table *ngIf="!loading && cases.length > 0" class="min-w-full divide-y divide-gray-200" data-testid="cases-table">
               <thead class="bg-gray-50">
                 <tr>
-                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Transaction</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Case #</th>
+                  <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Transaction ID</th>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Outcome</th>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Assignee</th>
                   <th class="px-4 py-3 text-left text-xs font-semibold uppercase text-gray-500">Priority</th>
@@ -92,6 +182,7 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
                   [class.bg-blue-50]="selected?.id === item.id"
                   data-testid="case-row"
                 >
+                  <td class="px-4 py-3 text-sm font-medium text-gray-700">#{{ item.id }}</td>
                   <td class="px-4 py-3 text-sm font-medium text-gray-900">{{ item.transaction_id }}</td>
                   <td class="px-4 py-3 text-sm text-gray-700">{{ item.resolved_outcome || 'None' }}</td>
                   <td class="px-4 py-3 text-sm text-gray-700">{{ item.assigned_to_email || 'Unassigned' }}</td>
@@ -121,7 +212,7 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
                     <dd class="font-medium text-gray-900">{{ selected.id }}</dd>
                   </div>
                   <div>
-                    <dt class="text-gray-500">Transaction</dt>
+                    <dt class="text-gray-500">Transaction ID</dt>
                     <dd class="break-all font-medium text-gray-900" data-testid="case-detail-transaction">
                       {{ selected.transaction_id }}
                     </dd>
@@ -161,7 +252,7 @@ import { CaseAssignee, CaseDetail, CaseItem, CaseService, IntegrationEvent } fro
                       [disabled]="saving || !currentUser || selected.assigned_to_user_id === currentUser.id"
                       class="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-gray-300"
                     >
-                      Claim
+                      {{ currentUser && selected.assigned_to_user_id === currentUser.id ? 'Assigned to you' : 'Claim' }}
                     </button>
                   </div>
                   <div class="flex gap-2">
@@ -382,8 +473,19 @@ export class CasesComponent implements OnInit {
   assignees: CaseAssignee[] = [];
   integrationEvents: IntegrationEvent[] = [];
   currentUser: AuthUser | null = null;
+  queues = [
+    { label: 'All cases', value: '', testId: 'all' },
+    { label: 'My queue', value: 'me', testId: 'me' },
+    { label: 'Unassigned', value: 'unassigned', testId: 'unassigned' },
+  ];
   statusFilter = '';
   assignedToFilter = '';
+  decisionStateFilter = '';
+  priorityMinFilter: number | null = null;
+  createdFromFilter = '';
+  createdToFilter = '';
+  updatedFromFilter = '';
+  updatedToFilter = '';
   searchQuery = '';
   selectedAssigneeId: number | null = null;
   noteText = '';
@@ -425,7 +527,13 @@ export class CasesComponent implements OnInit {
     this.caseService.getCases({
       status: this.statusFilter || undefined,
       assignedTo: this.assignedToFilter || undefined,
+      priorityMin: this.priorityMinFilter,
+      decisionState: this.decisionStateFilter || undefined,
       query: this.searchQuery.trim() || undefined,
+      createdFrom: this.createdFromFilter || undefined,
+      createdTo: this.createdToFilter || undefined,
+      updatedFrom: this.updatedFromFilter || undefined,
+      updatedTo: this.updatedToFilter || undefined,
     }).subscribe({
       next: (response) => {
         this.cases = response.cases;
@@ -439,6 +547,27 @@ export class CasesComponent implements OnInit {
         this.loading = false;
       }
     });
+  }
+
+  selectQueue(queueValue: string): void {
+    this.assignedToFilter = queueValue;
+    if (!this.statusFilter && queueValue !== '') {
+      this.statusFilter = 'open';
+    }
+    this.loadCases();
+  }
+
+  clearFilters(): void {
+    this.statusFilter = '';
+    this.assignedToFilter = '';
+    this.decisionStateFilter = '';
+    this.priorityMinFilter = null;
+    this.createdFromFilter = '';
+    this.createdToFilter = '';
+    this.updatedFromFilter = '';
+    this.updatedToFilter = '';
+    this.searchQuery = '';
+    this.loadCases();
   }
 
   selectCase(item: CaseItem): void {

--- a/ezrules/frontend/src/app/cases/cases.component.ts
+++ b/ezrules/frontend/src/app/cases/cases.component.ts
@@ -27,7 +27,6 @@ import { CaseDetail, CaseItem, CaseService, IntegrationEvent } from '../services
             <option value="open">Open</option>
             <option value="in_review">In review</option>
             <option value="resolved">Resolved</option>
-            <option value="closed">Closed</option>
           </select>
         </div>
 

--- a/ezrules/frontend/src/app/components/sidebar.component.ts
+++ b/ezrules/frontend/src/app/components/sidebar.component.ts
@@ -120,6 +120,14 @@ import { NotificationBellComponent } from './notification-bell.component';
           <span>Alerts</span>
         </a>
 
+        <a *ngIf="canAccess(routePermissions.cases)" href="/cases" [ngClass]="linkClasses('/cases')">
+          <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M9 12h6m-6 4h6M7 4h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2z" />
+          </svg>
+          <span>Cases</span>
+        </a>
+
         <a *ngIf="canAccess(routePermissions.users)" href="/management/users" [ngClass]="linkClasses('/management/users')">
           <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />

--- a/ezrules/frontend/src/app/services/case.service.ts
+++ b/ezrules/frontend/src/app/services/case.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface CaseItem {
+  id: number;
+  transaction_id: string;
+  current_event_version_id: number;
+  current_evaluation_decision_id: number;
+  opened_by_evaluation_decision_id: number;
+  previous_evaluation_decision_id: number | null;
+  resolved_outcome: string | null;
+  previous_resolved_outcome: string | null;
+  status: string;
+  decision_state: string;
+  priority: number;
+  assigned_to_user_id: number | null;
+  resolved_by_user_id: number | null;
+  resolution_note: string | null;
+  resolution_label_id: number | null;
+  reopened_from_case_id: number | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+}
+
+export interface CaseEvent {
+  id: number;
+  case_id: number;
+  event_type: string;
+  actor_user_id: number | null;
+  source_ed_id: number | null;
+  external_event_id: string;
+  occurred_at: string;
+  details: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface CaseDetail {
+  case: CaseItem;
+  events: CaseEvent[];
+}
+
+export interface IntegrationEvent {
+  id: number;
+  external_event_id: string;
+  source_type: string;
+  source_id: number;
+  event_type: string;
+  event_version: number;
+  occurred_at: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CaseService {
+  private apiUrl = `${environment.apiUrl}/api/v2`;
+
+  constructor(private http: HttpClient) {}
+
+  getCases(status?: string): Observable<{ cases: CaseItem[]; total: number }> {
+    let params = new HttpParams().set('limit', 100);
+    if (status) {
+      params = params.set('status', status);
+    }
+    return this.http.get<{ cases: CaseItem[]; total: number }>(`${this.apiUrl}/cases`, { params });
+  }
+
+  getCase(caseId: number): Observable<CaseDetail> {
+    return this.http.get<CaseDetail>(`${this.apiUrl}/cases/${caseId}`);
+  }
+
+  resolveCase(
+    caseId: number,
+    resolutionNote: string,
+    expectedCurrentEvaluationId: number,
+  ): Observable<{ success: boolean; message: string; case: CaseItem }> {
+    return this.http.post<{ success: boolean; message: string; case: CaseItem }>(`${this.apiUrl}/cases/${caseId}/resolve`, {
+      resolution_note: resolutionNote,
+      expected_current_ed_id: expectedCurrentEvaluationId,
+    });
+  }
+
+  getIntegrationEvents(): Observable<{ events: IntegrationEvent[]; next_cursor: number | null }> {
+    return this.http.get<{ events: IntegrationEvent[]; next_cursor: number | null }>(`${this.apiUrl}/integration-events`, {
+      params: { limit: 25 },
+    });
+  }
+}

--- a/ezrules/frontend/src/app/services/case.service.ts
+++ b/ezrules/frontend/src/app/services/case.service.ts
@@ -77,7 +77,12 @@ export interface CaseFilters {
   outcome?: string;
   priorityMin?: number | null;
   decisionState?: string;
+  transactionId?: string;
   query?: string;
+  createdFrom?: string;
+  createdTo?: string;
+  updatedFrom?: string;
+  updatedTo?: string;
 }
 
 export interface CaseAssignee {
@@ -122,8 +127,23 @@ export class CaseService {
     if (filters.decisionState) {
       params = params.set('decision_state', filters.decisionState);
     }
+    if (filters.transactionId) {
+      params = params.set('transaction_id', filters.transactionId);
+    }
     if (filters.query) {
       params = params.set('q', filters.query);
+    }
+    if (filters.createdFrom) {
+      params = params.set('created_from', filters.createdFrom);
+    }
+    if (filters.createdTo) {
+      params = params.set('created_to', filters.createdTo);
+    }
+    if (filters.updatedFrom) {
+      params = params.set('updated_from', filters.updatedFrom);
+    }
+    if (filters.updatedTo) {
+      params = params.set('updated_to', filters.updatedTo);
     }
     return this.http.get<{ cases: CaseItem[]; total: number }>(`${this.apiUrl}/cases`, { params });
   }

--- a/ezrules/frontend/src/app/services/case.service.ts
+++ b/ezrules/frontend/src/app/services/case.service.ts
@@ -16,7 +16,11 @@ export interface CaseItem {
   decision_state: string;
   priority: number;
   assigned_to_user_id: number | null;
+  assigned_to_email: string | null;
   resolved_by_user_id: number | null;
+  resolved_by_email: string | null;
+  resolution_disposition: string | null;
+  resolution_action: string | null;
   resolution_note: string | null;
   resolution_label_id: number | null;
   reopened_from_case_id: number | null;
@@ -37,9 +41,48 @@ export interface CaseEvent {
   created_at: string;
 }
 
+export interface CaseTriggeredRule {
+  r_id: number;
+  rid: string;
+  description: string;
+  outcome: string;
+  metadata_source: string;
+  referenced_fields: string[] | null;
+}
+
+export interface CaseEvaluation {
+  evaluation_decision_id: number;
+  transaction_id: string;
+  event_version_id: number;
+  event_version: number;
+  effective_at: string;
+  observed_at: string;
+  evaluated_at: string;
+  is_current: boolean;
+  resolved_outcome: string | null;
+  outcome_counters: Record<string, number>;
+  event_data: Record<string, unknown>;
+  triggered_rules: CaseTriggeredRule[];
+}
+
 export interface CaseDetail {
   case: CaseItem;
   events: CaseEvent[];
+  evaluation: CaseEvaluation | null;
+}
+
+export interface CaseFilters {
+  status?: string;
+  assignedTo?: string;
+  outcome?: string;
+  priorityMin?: number | null;
+  decisionState?: string;
+  query?: string;
+}
+
+export interface CaseAssignee {
+  id: number;
+  email: string;
 }
 
 export interface IntegrationEvent {
@@ -62,24 +105,59 @@ export class CaseService {
 
   constructor(private http: HttpClient) {}
 
-  getCases(status?: string): Observable<{ cases: CaseItem[]; total: number }> {
+  getCases(filters: CaseFilters = {}): Observable<{ cases: CaseItem[]; total: number }> {
     let params = new HttpParams().set('limit', 100);
-    if (status) {
-      params = params.set('status', status);
+    if (filters.status) {
+      params = params.set('status', filters.status);
+    }
+    if (filters.assignedTo) {
+      params = params.set('assigned_to', filters.assignedTo);
+    }
+    if (filters.outcome) {
+      params = params.set('outcome', filters.outcome);
+    }
+    if (filters.priorityMin !== undefined && filters.priorityMin !== null) {
+      params = params.set('priority_min', String(filters.priorityMin));
+    }
+    if (filters.decisionState) {
+      params = params.set('decision_state', filters.decisionState);
+    }
+    if (filters.query) {
+      params = params.set('q', filters.query);
     }
     return this.http.get<{ cases: CaseItem[]; total: number }>(`${this.apiUrl}/cases`, { params });
+  }
+
+  getAssignees(): Observable<{ users: CaseAssignee[] }> {
+    return this.http.get<{ users: CaseAssignee[] }>(`${this.apiUrl}/cases/assignees`);
   }
 
   getCase(caseId: number): Observable<CaseDetail> {
     return this.http.get<CaseDetail>(`${this.apiUrl}/cases/${caseId}`);
   }
 
+  assignCase(caseId: number, assignedToUserId: number | null): Observable<{ success: boolean; message: string; case: CaseItem }> {
+    return this.http.patch<{ success: boolean; message: string; case: CaseItem }>(`${this.apiUrl}/cases/${caseId}`, {
+      assigned_to_user_id: assignedToUserId,
+    });
+  }
+
+  addNote(caseId: number, note: string): Observable<{ success: boolean; message: string; event: CaseEvent }> {
+    return this.http.post<{ success: boolean; message: string; event: CaseEvent }>(`${this.apiUrl}/cases/${caseId}/notes`, {
+      note,
+    });
+  }
+
   resolveCase(
     caseId: number,
+    resolutionDisposition: string,
+    resolutionAction: string,
     resolutionNote: string,
     expectedCurrentEvaluationId: number,
   ): Observable<{ success: boolean; message: string; case: CaseItem }> {
     return this.http.post<{ success: boolean; message: string; case: CaseItem }>(`${this.apiUrl}/cases/${caseId}/resolve`, {
+      resolution_disposition: resolutionDisposition,
+      resolution_action: resolutionAction,
       resolution_note: resolutionNote,
       expected_current_ed_id: expectedCurrentEvaluationId,
     });

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -502,6 +502,8 @@ class Case(Base):
     priority = Column(Integer, nullable=False, default=0)
     assigned_to_user_id: Mapped[int | None] = mapped_column(ForeignKey("user.id"), nullable=True)
     resolved_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    resolution_disposition = Column(String(64), nullable=True)
+    resolution_action = Column(String(64), nullable=True)
     resolution_note = Column(Text, nullable=True)
     resolution_label_id: Mapped[int | None] = mapped_column(ForeignKey("event_labels.el_id"), nullable=True)
     reopened_from_case_id: Mapped[int | None] = mapped_column(ForeignKey("cases.case_id"), nullable=True)

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -480,6 +480,139 @@ class EvaluationRuleResult(Base):
     metadata_source = Column(String(32), nullable=False, default="evaluation_snapshot")
 
 
+class Case(Base):
+    __tablename__ = "cases"
+    __table_args__ = (
+        Index("ix_cases_o_id_status_updated", "o_id", "status", "updated_at"),
+        Index("ix_cases_o_id_transaction", "o_id", "transaction_id"),
+        Index("ix_cases_o_id_current_ed", "o_id", "current_ed_id"),
+    )
+
+    case_id = Column(Integer, unique=True, primary_key=True)
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), nullable=False)
+    transaction_id = Column(String, nullable=False)
+    current_ev_id: Mapped[int] = mapped_column(ForeignKey("event_versions.ev_id"), nullable=False)
+    current_ed_id: Mapped[int] = mapped_column(ForeignKey("evaluation_decisions.ed_id"), nullable=False)
+    opened_by_ed_id: Mapped[int] = mapped_column(ForeignKey("evaluation_decisions.ed_id"), nullable=False)
+    previous_ed_id: Mapped[int | None] = mapped_column(ForeignKey("evaluation_decisions.ed_id"), nullable=True)
+    resolved_outcome = Column(String(255), nullable=True)
+    previous_resolved_outcome = Column(String(255), nullable=True)
+    status = Column(String(32), nullable=False, default="open")
+    decision_state = Column(String(32), nullable=False, default="current")
+    priority = Column(Integer, nullable=False, default=0)
+    assigned_to_user_id: Mapped[int | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    resolved_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    resolution_note = Column(Text, nullable=True)
+    resolution_label_id: Mapped[int | None] = mapped_column(ForeignKey("event_labels.el_id"), nullable=True)
+    reopened_from_case_id: Mapped[int | None] = mapped_column(ForeignKey("cases.case_id"), nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.datetime.now(datetime.UTC),
+        onupdate=lambda: datetime.datetime.now(datetime.UTC),
+        nullable=False,
+    )
+    resolved_at = Column(DateTime, nullable=True)
+
+
+class CaseEvent(Base):
+    __tablename__ = "case_events"
+    __table_args__ = (
+        Index("ix_case_events_o_id_created", "o_id", "created_at"),
+        Index("ix_case_events_case_id_created", "case_id", "created_at"),
+        UniqueConstraint("external_event_id", name="uq_case_events_external_event_id"),
+    )
+
+    case_event_id = Column(Integer, unique=True, primary_key=True)
+    case_id: Mapped[int] = mapped_column(ForeignKey("cases.case_id", ondelete="CASCADE"), nullable=False)
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), nullable=False)
+    event_type = Column(String(64), nullable=False)
+    actor_user_id: Mapped[int | None] = mapped_column(ForeignKey("user.id"), nullable=True)
+    source_ed_id: Mapped[int | None] = mapped_column(ForeignKey("evaluation_decisions.ed_id"), nullable=True)
+    external_event_id = Column(String(64), nullable=False)
+    occurred_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+    details = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+
+
+class IntegrationEvent(Base):
+    __tablename__ = "integration_events"
+    __table_args__ = (
+        Index("ix_integration_events_o_id_created", "o_id", "created_at"),
+        Index("ix_integration_events_o_id_type_created", "o_id", "event_type", "created_at"),
+        Index("ix_integration_events_o_id_source", "o_id", "source_type", "source_id"),
+        UniqueConstraint("external_event_id", name="uq_integration_events_external_event_id"),
+    )
+
+    integration_event_id = Column(Integer, unique=True, primary_key=True)
+    external_event_id = Column(String(64), nullable=False)
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), nullable=False)
+    source_type = Column(String(64), nullable=False)
+    source_id = Column(Integer, nullable=False)
+    event_type = Column(String(128), nullable=False)
+    event_version = Column(Integer, nullable=False, default=1)
+    occurred_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+    payload = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+
+
+class IntegrationSubscription(Base):
+    __tablename__ = "integration_subscriptions"
+    __table_args__ = (
+        Index("ix_integration_subscriptions_o_id_enabled", "o_id", "enabled"),
+        UniqueConstraint("o_id", "name", name="uq_integration_subscriptions_org_name"),
+    )
+
+    subscription_id = Column(Integer, unique=True, primary_key=True)
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), nullable=False)
+    name = Column(String(255), nullable=False)
+    destination_type = Column(String(64), nullable=False)
+    config = Column(JSON, nullable=False, default=dict)
+    secret_ref = Column(String(255), nullable=True)
+    event_types = Column(JSON, nullable=False, default=list)
+    enabled = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.datetime.now(datetime.UTC),
+        onupdate=lambda: datetime.datetime.now(datetime.UTC),
+        nullable=False,
+    )
+
+
+class IntegrationOutbox(Base):
+    __tablename__ = "integration_outbox"
+    __table_args__ = (
+        Index("ix_integration_outbox_status_next", "status", "next_attempt_at"),
+        Index("ix_integration_outbox_o_id_created", "o_id", "created_at"),
+        UniqueConstraint("integration_event_id", "subscription_id", name="uq_integration_outbox_event_subscription"),
+    )
+
+    delivery_id = Column(Integer, unique=True, primary_key=True)
+    o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), nullable=False)
+    integration_event_id: Mapped[int] = mapped_column(
+        ForeignKey("integration_events.integration_event_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    subscription_id: Mapped[int] = mapped_column(
+        ForeignKey("integration_subscriptions.subscription_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    destination_type = Column(String(64), nullable=False)
+    status = Column(String(32), nullable=False, default="pending")
+    attempt_count = Column(Integer, nullable=False, default=0)
+    next_attempt_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+    last_attempted_at = Column(DateTime, nullable=True)
+    last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.datetime.now(datetime.UTC),
+        onupdate=lambda: datetime.datetime.now(datetime.UTC),
+        nullable=False,
+    )
+
+
 class EventVersionLabel(Base):
     __tablename__ = "event_version_labels"
     __table_args__ = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.27.0"
+version = "1.28.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.26.0"
+version = "1.27.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -145,6 +145,17 @@ def test_neutral_decision_only_publishes_evaluation_event(session):
     assert [event.event_type for event in session.query(IntegrationEvent).all()] == ["evaluation.completed"]
 
 
+def test_neutral_decision_matching_is_case_insensitive(session):
+    _seed_case_org(session)
+    decision = _add_decision(session, outcome="release")
+
+    result = process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+
+    assert result.case_id is None
+    assert session.query(Case).count() == 0
+
+
 def test_rescore_updates_active_case_instead_of_creating_duplicate(session):
     _seed_case_org(session)
     first = _add_decision(session, outcome="HOLD", version=1, is_current=True)
@@ -263,11 +274,72 @@ def test_case_assignment_api_records_timeline_events(session):
         )
         assert unassign_response.status_code == 200
         assert unassign_response.json()["case"]["assigned_to_user_id"] is None
+        assert unassign_response.json()["case"]["status"] == "open"
 
     events = session.query(CaseEvent).order_by(CaseEvent.case_event_id).all()
     assert [event.event_type for event in events] == ["created", "assigned", "assigned"]
     assert events[-2].details["assigned_to_user_id"] == int(user.id)
     assert events[-1].details["assigned_to_user_id"] is None
+
+
+def test_case_assignment_rejects_user_from_another_org(session):
+    _org, _user, token = _seed_case_org(session)
+    other_org = Organisation(name="Other org")
+    session.add(other_org)
+    session.flush()
+    other_user = User(
+        email="other-case-manager@example.com",
+        password="unused",
+        active=True,
+        fs_uniquifier="other-case-manager@example.com",
+        o_id=int(other_org.o_id),
+    )
+    session.add(other_user)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"assigned_to_user_id": int(other_user.id)},
+        )
+
+    assert response.status_code == 422
+    assert session.query(Case).one().assigned_to_user_id is None
+
+
+def test_resolving_already_resolved_case_is_idempotent(session):
+    _org, user, _token = _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    case = session.query(Case).one()
+
+    resolve_case(
+        session,
+        o_id=1,
+        case_id=int(case.case_id),
+        actor_user_id=int(user.id),
+        resolution_note="Reviewed once.",
+        expected_current_ed_id=int(decision.ed_id),
+    )
+    resolve_case(
+        session,
+        o_id=1,
+        case_id=int(case.case_id),
+        actor_user_id=int(user.id),
+        resolution_note="Reviewed twice.",
+        expected_current_ed_id=int(decision.ed_id),
+    )
+    session.commit()
+
+    assert [event.event_type for event in session.query(CaseEvent).order_by(CaseEvent.case_event_id)] == [
+        "created",
+        "resolved",
+    ]
+    assert session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "case.resolved").count() == 1
 
 
 def test_integration_subscription_api_validates_webhook_url_and_strips_secret(session):

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -1,4 +1,5 @@
 import datetime
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -13,6 +14,7 @@ from ezrules.backend.cases import (
     process_evaluation_for_cases,
     resolve_case,
 )
+from ezrules.backend.integrations import OUTBOX_DELIVERED, dispatch_pending_outbox, publish_integration_event
 from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import (
@@ -22,6 +24,8 @@ from ezrules.models.backend_core import (
     EvaluationDecision,
     EventVersion,
     IntegrationEvent,
+    IntegrationOutbox,
+    IntegrationSubscription,
     Organisation,
     Role,
     User,
@@ -232,3 +236,128 @@ def test_cases_and_integration_events_api(session):
         assert "case.resolved" in event_types
 
     assert session.query(Case).filter(Case.resolved_by_user_id == int(user.id)).count() == 1
+
+
+def test_case_assignment_api_records_timeline_events(session):
+    _org, user, token = _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        headers = {"Authorization": f"Bearer {token}"}
+        assign_response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers=headers,
+            json={"assigned_to_user_id": int(user.id)},
+        )
+        assert assign_response.status_code == 200
+        assert assign_response.json()["case"]["assigned_to_user_id"] == int(user.id)
+        assert assign_response.json()["case"]["status"] == "in_review"
+
+        unassign_response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers=headers,
+            json={"assigned_to_user_id": None},
+        )
+        assert unassign_response.status_code == 200
+        assert unassign_response.json()["case"]["assigned_to_user_id"] is None
+
+    events = session.query(CaseEvent).order_by(CaseEvent.case_event_id).all()
+    assert [event.event_type for event in events] == ["created", "assigned", "assigned"]
+    assert events[-2].details["assigned_to_user_id"] == int(user.id)
+    assert events[-1].details["assigned_to_user_id"] is None
+
+
+def test_integration_subscription_api_validates_webhook_url_and_strips_secret(session):
+    _org, _user, token = _seed_case_org(session)
+
+    with TestClient(app) as client:
+        headers = {"Authorization": f"Bearer {token}"}
+        invalid_response = client.post(
+            "/api/v2/integration-subscriptions",
+            headers=headers,
+            json={
+                "name": "Bad webhook",
+                "destination_type": "webhook",
+                "config": {"url": "http://example.com/webhook"},
+                "event_types": ["case.resolved"],
+            },
+        )
+        assert invalid_response.status_code == 422
+
+        create_response = client.post(
+            "/api/v2/integration-subscriptions",
+            headers=headers,
+            json={
+                "name": "Case webhook",
+                "destination_type": "webhook",
+                "config": {"url": "https://example.com/webhook", "secret": "top-secret"},
+                "event_types": ["case.resolved"],
+            },
+        )
+        assert create_response.status_code == 201
+        created = create_response.json()["subscription"]
+        assert created["config"] == {"url": "https://example.com/webhook"}
+
+        update_response = client.patch(
+            f"/api/v2/integration-subscriptions/{created['id']}",
+            headers=headers,
+            json={
+                "name": "Disabled case webhook",
+                "config": {"url": "https://events.example.com/cases"},
+                "event_types": ["case.created", "case.resolved"],
+                "enabled": False,
+            },
+        )
+        assert update_response.status_code == 200
+        updated = update_response.json()["subscription"]
+        assert updated["name"] == "Disabled case webhook"
+        assert updated["enabled"] is False
+        assert updated["event_types"] == ["case.created", "case.resolved"]
+
+        list_response = client.get("/api/v2/integration-subscriptions", headers=headers)
+        assert list_response.status_code == 200
+        assert list_response.json()["subscriptions"][0]["id"] == created["id"]
+
+
+def test_outbox_dispatch_delivers_webhook_and_marks_delivery(session, monkeypatch):
+    _seed_case_org(session)
+    subscription = IntegrationSubscription(
+        o_id=1,
+        name="Case webhook",
+        destination_type="webhook",
+        config={"url": "https://example.com/webhook", "secret": "top-secret"},
+        event_types=["case.created"],
+        enabled=True,
+    )
+    session.add(subscription)
+    session.flush()
+    publish_integration_event(
+        session,
+        o_id=1,
+        source_type="case_event",
+        source_id=123,
+        event_type="case.created",
+        external_event_id="evt_test_case_created",
+        payload={"case": {"case_id": 123}},
+    )
+    session.commit()
+
+    calls = []
+
+    def fake_post(url, *, data, headers, timeout):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return SimpleNamespace(status_code=204)
+
+    monkeypatch.setattr("ezrules.backend.integrations.requests.post", fake_post)
+
+    result = dispatch_pending_outbox(session)
+
+    assert result == {"delivered": 1, "failed": 0}
+    delivery = session.query(IntegrationOutbox).one()
+    assert delivery.status == OUTBOX_DELIVERED
+    assert delivery.attempt_count == 1
+    assert calls[0]["url"] == "https://example.com/webhook"
+    assert calls[0]["headers"]["X-Ezrules-Signature"].startswith("sha256=")

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -1,0 +1,234 @@
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.cases import (
+    CASE_DECISION_RESCORED_NEUTRAL,
+    CASE_STATUS_OPEN,
+    CASE_STATUS_RESOLVED,
+    CaseConflictError,
+    process_evaluation_for_cases,
+    resolve_case,
+)
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import (
+    AllowedOutcome,
+    Case,
+    CaseEvent,
+    EvaluationDecision,
+    EventVersion,
+    IntegrationEvent,
+    Organisation,
+    Role,
+    User,
+)
+
+
+def _seed_case_org(session) -> tuple[Organisation, User, str]:
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    for severity_rank, outcome_name in enumerate(("CANCEL", "HOLD", "RELEASE"), start=1):
+        if (
+            session.query(AllowedOutcome)
+            .filter(AllowedOutcome.o_id == int(org.o_id), AllowedOutcome.outcome_name == outcome_name)
+            .first()
+            is None
+        ):
+            session.add(AllowedOutcome(outcome_name=outcome_name, severity_rank=severity_rank, o_id=int(org.o_id)))
+
+    role = Role(name="case_manager", description="Can manage cases", o_id=int(org.o_id))
+    user = User(
+        email="case-manager@example.com",
+        password="unused",
+        active=True,
+        fs_uniquifier="case-manager@example.com",
+        o_id=int(org.o_id),
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    for permission in (
+        PermissionAction.VIEW_CASES,
+        PermissionAction.MANAGE_CASES,
+        PermissionAction.VIEW_INTEGRATIONS,
+        PermissionAction.MANAGE_INTEGRATIONS,
+    ):
+        PermissionManager.grant_permission(int(role.id), permission)
+
+    token = create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[str(role.name)],
+        org_id=int(org.o_id),
+    )
+    return org, user, token
+
+
+def _add_decision(
+    session,
+    *,
+    org_id: int = 1,
+    transaction_id: str = "txn-case-1",
+    outcome: str | None = "HOLD",
+    version: int = 1,
+    is_current: bool = True,
+) -> EvaluationDecision:
+    now = datetime.datetime.now(datetime.UTC)
+    event = EventVersion(
+        o_id=org_id,
+        transaction_id=transaction_id,
+        event_version=version,
+        effective_at=now,
+        observed_at=now,
+        event_data={"transaction_id": transaction_id, "amount": 100 + version},
+        payload_hash=f"{transaction_id}-{version}",
+    )
+    session.add(event)
+    session.flush()
+    counters = {outcome: 1} if outcome else {}
+    decision = EvaluationDecision(
+        ev_id=int(event.ev_id),
+        o_id=org_id,
+        transaction_id=transaction_id,
+        event_version=version,
+        effective_at=now,
+        observed_at=now,
+        decision_type="served",
+        served=True,
+        is_current=is_current,
+        outcome_counters=counters,
+        resolved_outcome=outcome,
+        all_rule_results={"1": outcome} if outcome else {},
+        evaluated_at=now,
+    )
+    session.add(decision)
+    session.flush()
+    return decision
+
+
+def test_case_created_for_non_neutral_decision_and_integration_events(session):
+    _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD")
+
+    result = process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+
+    assert result.action == "created"
+    case = session.query(Case).one()
+    assert case.current_ed_id == decision.ed_id
+    assert case.status == CASE_STATUS_OPEN
+    assert case.resolved_outcome == "HOLD"
+    assert [event.event_type for event in session.query(CaseEvent).all()] == ["created"]
+    event_types = {event.event_type for event in session.query(IntegrationEvent).all()}
+    assert event_types == {"case.created", "evaluation.completed"}
+
+
+def test_neutral_decision_only_publishes_evaluation_event(session):
+    _seed_case_org(session)
+    decision = _add_decision(session, outcome="RELEASE")
+
+    result = process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+
+    assert result.case_id is None
+    assert session.query(Case).count() == 0
+    assert [event.event_type for event in session.query(IntegrationEvent).all()] == ["evaluation.completed"]
+
+
+def test_rescore_updates_active_case_instead_of_creating_duplicate(session):
+    _seed_case_org(session)
+    first = _add_decision(session, outcome="HOLD", version=1, is_current=True)
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(first.ed_id))
+    first.is_current = False
+    second = _add_decision(session, outcome="CANCEL", version=2, is_current=True)
+
+    result = process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(second.ed_id))
+    session.commit()
+
+    assert result.action == "rescored"
+    assert session.query(Case).count() == 1
+    case = session.query(Case).one()
+    assert case.current_ed_id == second.ed_id
+    assert case.previous_ed_id == first.ed_id
+    assert case.previous_resolved_outcome == "HOLD"
+    assert case.resolved_outcome == "CANCEL"
+    assert [event.event_type for event in session.query(CaseEvent).order_by(CaseEvent.case_event_id)] == [
+        "created",
+        "rescored",
+    ]
+
+
+def test_rescore_to_neutral_keeps_case_open_with_non_caseable_state(session):
+    _seed_case_org(session)
+    first = _add_decision(session, outcome="HOLD", version=1, is_current=True)
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(first.ed_id))
+    first.is_current = False
+    second = _add_decision(session, outcome="RELEASE", version=2, is_current=True)
+
+    result = process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(second.ed_id))
+    session.commit()
+
+    assert result.action == "rescored_non_caseable"
+    case = session.query(Case).one()
+    assert case.current_ed_id == second.ed_id
+    assert case.status == CASE_STATUS_OPEN
+    assert case.decision_state == CASE_DECISION_RESCORED_NEUTRAL
+
+
+def test_resolve_requires_current_decision_when_expected_id_is_supplied(session):
+    _org, user, _token = _seed_case_org(session)
+    first = _add_decision(session, outcome="HOLD", version=1, is_current=True)
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(first.ed_id))
+    first.is_current = False
+    second = _add_decision(session, outcome="CANCEL", version=2, is_current=True)
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(second.ed_id))
+    case = session.query(Case).one()
+
+    with pytest.raises(CaseConflictError):
+        resolve_case(
+            session,
+            o_id=1,
+            case_id=int(case.case_id),
+            actor_user_id=int(user.id),
+            resolution_note="Reviewed before score changed",
+            expected_current_ed_id=int(first.ed_id),
+        )
+
+
+def test_cases_and_integration_events_api(session):
+    _org, user, token = _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        headers = {"Authorization": f"Bearer {token}"}
+        list_response = client.get("/api/v2/cases", headers=headers)
+        assert list_response.status_code == 200
+        assert list_response.json()["cases"][0]["id"] == int(case.case_id)
+
+        resolve_response = client.post(
+            f"/api/v2/cases/{case.case_id}/resolve",
+            headers=headers,
+            json={
+                "resolution_note": "Reviewed customer history and approved closure.",
+                "expected_current_ed_id": int(decision.ed_id),
+            },
+        )
+        assert resolve_response.status_code == 200
+        assert resolve_response.json()["case"]["status"] == CASE_STATUS_RESOLVED
+
+        events_response = client.get("/api/v2/integration-events", headers=headers)
+        assert events_response.status_code == 200
+        event_types = [event["event_type"] for event in events_response.json()["events"]]
+        assert "evaluation.completed" in event_types
+        assert "case.resolved" in event_types
+
+    assert session.query(Case).filter(Case.resolved_by_user_id == int(user.id)).count() == 1

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -511,11 +511,12 @@ def test_idempotent_integration_publish_enqueues_missing_subscription_delivery(s
         source_id=123,
         event_type="case.created",
         external_event_id="evt_test_case_created",
-        payload={"case": {"case_id": 123}},
+        payload={"case": {"case_id": 456}},
     )
 
     assert result.delivery_count == 1
     assert session.query(IntegrationEvent).count() == 1
+    assert session.query(IntegrationEvent).one().payload == {"case": {"case_id": 456}}
     assert session.query(IntegrationOutbox).count() == 1
 
 

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -205,7 +205,7 @@ def test_rescore_updates_active_case_instead_of_creating_duplicate(session):
 
 
 def test_rescore_to_neutral_keeps_case_open_with_non_caseable_state(session):
-    _seed_case_org(session)
+    _org, _user, token = _seed_case_org(session)
     first = _add_decision(session, outcome="HOLD", version=1, is_current=True)
     process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(first.ed_id))
     first.is_current = False
@@ -219,6 +219,15 @@ def test_rescore_to_neutral_keeps_case_open_with_non_caseable_state(session):
     assert case.current_ed_id == second.ed_id
     assert case.status == CASE_STATUS_OPEN
     assert case.decision_state == CASE_DECISION_RESCORED_NEUTRAL
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v2/cases?decision_state=rescored_neutral",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["cases"]] == [int(case.case_id)]
 
 
 def test_resolve_requires_current_decision_when_expected_id_is_supplied(session):

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -13,6 +13,7 @@ from ezrules.backend.cases import (
     CASE_STATUS_RESOLVED,
     CaseConflictError,
     CaseValidationError,
+    enqueue_case_detection,
     process_evaluation_for_cases,
     resolve_case,
 )
@@ -177,6 +178,30 @@ def test_ignored_replay_preserves_evaluation_completed_case_id(session):
     assert session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "evaluation.completed").count() == 1
     replayed_event = session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "evaluation.completed").one()
     assert replayed_event.payload["case_id"] == int(case.case_id)
+
+
+def test_enqueue_case_detection_rolls_back_on_failure(monkeypatch):
+    calls = []
+
+    class FakeSession:
+        def commit(self):
+            calls.append("commit")
+
+        def rollback(self):
+            calls.append("rollback")
+
+    def fail_processing(db, *, o_id, evaluation_decision_id):
+        calls.append(("process", db, o_id, evaluation_decision_id))
+        raise RuntimeError("case processing failed")
+
+    fake_session = FakeSession()
+    monkeypatch.setattr("ezrules.backend.cases.db_session", fake_session)
+    monkeypatch.setattr("ezrules.backend.cases.process_evaluation_for_cases", fail_processing)
+
+    with pytest.raises(RuntimeError, match="case processing failed"):
+        enqueue_case_detection(o_id=1, evaluation_decision_id=123)
+
+    assert calls == [("process", fake_session, 1, 123), "rollback"]
 
 
 def test_neutral_decision_only_publishes_evaluation_event(session):

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -305,11 +306,132 @@ def test_cases_and_integration_events_api(session):
         assert "evaluation.completed" in event_types
         assert "case.resolved" in event_types
         resolved_event = next(event for event in integration_events if event["event_type"] == "case.resolved")
+        assert resolved_event["external_event_id"].startswith("evt_case_event_")
+        assert resolved_event["payload"]["case_id"] == int(case.case_id)
+        assert resolved_event["payload"]["transaction_id"] == "txn-case-1"
+        assert resolved_event["payload"]["case_event_type"] == "resolved"
+        assert resolved_event["payload"]["current_event_version_id"] == int(decision.ev_id)
+        assert resolved_event["payload"]["current_evaluation_decision_id"] == int(decision.ed_id)
+        assert resolved_event["payload"]["resolved_by_user_id"] == int(user.id)
+        assert resolved_event["payload"]["resolution_disposition"] == "false_positive"
+        assert resolved_event["payload"]["resolution_action"] == "release_transaction"
+        assert resolved_event["payload"]["downstream_action"] == {
+            "requested": True,
+            "action": "release_transaction",
+            "status": "requested",
+            "source": "analyst_resolution",
+            "executed_by_ezrules": False,
+        }
         assert resolved_event["payload"]["case"]["resolution_disposition"] == "false_positive"
         assert resolved_event["payload"]["case"]["resolution_action"] == "release_transaction"
         assert resolved_event["payload"]["case_event"]["details"]["resolution_disposition"] == "false_positive"
 
     assert session.query(Case).filter(Case.resolved_by_user_id == int(user.id)).count() == 1
+
+
+def test_case_resolved_event_enqueues_downstream_delivery_contract(session):
+    _org, _user, token = _seed_case_org(session)
+    subscription = IntegrationSubscription(
+        o_id=1,
+        name="Resolved case webhook",
+        destination_type="webhook",
+        config={"url": "https://example.com/webhook"},
+        event_types=["case.resolved"],
+        enabled=True,
+    )
+    session.add(subscription)
+    decision = _add_decision(session, transaction_id="txn-downstream-action", outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/api/v2/cases/{case.case_id}/resolve",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "resolution_disposition": "confirmed_fraud",
+                "resolution_action": "cancel_transaction",
+                "resolution_note": "Fraud operations confirmed account takeover.",
+                "expected_current_ed_id": int(decision.ed_id),
+            },
+        )
+
+    assert response.status_code == 200
+    resolved_event = session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "case.resolved").one()
+    delivery = session.query(IntegrationOutbox).one()
+    payload = resolved_event.payload
+    assert delivery.integration_event_id == resolved_event.integration_event_id
+    assert delivery.subscription_id == subscription.subscription_id
+    assert delivery.status == "pending"
+    assert resolved_event.external_event_id == f"evt_case_event_{resolved_event.source_id}"
+    assert payload["transaction_id"] == "txn-downstream-action"
+    assert payload["status"] == CASE_STATUS_RESOLVED
+    assert payload["resolved_outcome"] == "HOLD"
+    assert payload["resolution_disposition"] == "confirmed_fraud"
+    assert payload["resolution_action"] == "cancel_transaction"
+    assert payload["downstream_action"] == {
+        "requested": True,
+        "action": "cancel_transaction",
+        "status": "requested",
+        "source": "analyst_resolution",
+        "executed_by_ezrules": False,
+    }
+
+
+def test_case_resolved_webhook_delivery_contains_downstream_contract(session, monkeypatch):
+    _org, _user, token = _seed_case_org(session)
+    subscription = IntegrationSubscription(
+        o_id=1,
+        name="Resolved case webhook",
+        destination_type="webhook",
+        config={"url": "https://example.com/webhook"},
+        event_types=["case.resolved"],
+        enabled=True,
+    )
+    session.add(subscription)
+    decision = _add_decision(session, transaction_id="txn-webhook-action", outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/api/v2/cases/{case.case_id}/resolve",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "resolution_disposition": "false_positive",
+                "resolution_action": "release_transaction",
+                "resolution_note": "Customer verified the transfer.",
+                "expected_current_ed_id": int(decision.ed_id),
+            },
+        )
+
+    assert response.status_code == 200
+    calls = []
+
+    def fake_post(url, *, data, headers, timeout):
+        calls.append({"url": url, "data": data, "headers": headers, "timeout": timeout})
+        return SimpleNamespace(status_code=204)
+
+    monkeypatch.setattr("ezrules.backend.integrations.requests.post", fake_post)
+
+    result = dispatch_pending_outbox(session)
+
+    assert result == {"delivered": 1, "failed": 0}
+    delivered_body = json.loads(calls[0]["data"])
+    event = session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "case.resolved").one()
+    assert calls[0]["headers"]["X-Ezrules-Event-Id"] == event.external_event_id
+    assert delivered_body["event_id"] == event.external_event_id
+    assert delivered_body["event_type"] == "case.resolved"
+    assert delivered_body["payload"]["transaction_id"] == "txn-webhook-action"
+    assert delivered_body["payload"]["downstream_action"] == {
+        "requested": True,
+        "action": "release_transaction",
+        "status": "requested",
+        "source": "analyst_resolution",
+        "executed_by_ezrules": False,
+    }
 
 
 def test_case_assignment_api_records_timeline_events(session):
@@ -511,6 +633,53 @@ def test_cases_outcome_filter_is_case_insensitive(session):
     assert response.status_code == 200
     assert response.json()["total"] == 1
     assert response.json()["cases"][0]["resolved_outcome"] == "hold"
+
+
+def test_cases_support_phase_four_queue_search_filters(session):
+    _org, _user, token = _seed_case_org(session)
+    older_decision = _add_decision(session, transaction_id="txn-phase-four-old", outcome="HOLD")
+    newer_decision = _add_decision(session, transaction_id="txn-phase-four-new", outcome="CANCEL", rule_id=2)
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(older_decision.ed_id))
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(newer_decision.ed_id))
+    older_case = session.query(Case).filter(Case.transaction_id == "txn-phase-four-old").one()
+    newer_case = session.query(Case).filter(Case.transaction_id == "txn-phase-four-new").one()
+    older_case.created_at = datetime.datetime(2026, 7, 1, 9, 0, tzinfo=datetime.UTC)
+    older_case.updated_at = datetime.datetime(2026, 7, 2, 9, 0, tzinfo=datetime.UTC)
+    older_case.priority = 1
+    newer_case.created_at = datetime.datetime(2026, 7, 5, 9, 0, tzinfo=datetime.UTC)
+    newer_case.updated_at = datetime.datetime(2026, 7, 6, 9, 0, tzinfo=datetime.UTC)
+    newer_case.priority = 2
+    session.commit()
+
+    headers = {"Authorization": f"Bearer {token}"}
+    with TestClient(app) as client:
+        exact_response = client.get(
+            "/api/v2/cases?transaction_id=txn-phase-four-new",
+            headers=headers,
+        )
+        created_response = client.get(
+            "/api/v2/cases?created_from=2026-07-04&created_to=2026-07-05",
+            headers=headers,
+        )
+        updated_response = client.get(
+            "/api/v2/cases?updated_from=2026-07-06T00:00:00Z&updated_to=2026-07-06T23:59:59Z",
+            headers=headers,
+        )
+        priority_response = client.get(
+            "/api/v2/cases?q=phase-four&priority_min=2&decision_state=current",
+            headers=headers,
+        )
+        invalid_response = client.get("/api/v2/cases?created_from=not-a-date", headers=headers)
+
+    assert exact_response.status_code == 200
+    assert [item["transaction_id"] for item in exact_response.json()["cases"]] == ["txn-phase-four-new"]
+    assert created_response.status_code == 200
+    assert [item["transaction_id"] for item in created_response.json()["cases"]] == ["txn-phase-four-new"]
+    assert updated_response.status_code == 200
+    assert [item["transaction_id"] for item in updated_response.json()["cases"]] == ["txn-phase-four-new"]
+    assert priority_response.status_code == 200
+    assert [item["transaction_id"] for item in priority_response.json()["cases"]] == ["txn-phase-four-new"]
+    assert invalid_response.status_code == 422
 
 
 def test_integration_subscription_api_validates_webhook_url_and_strips_secret(session):

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -158,6 +158,27 @@ def test_case_created_for_non_neutral_decision_and_integration_events(session):
     assert event_types == {"case.created", "evaluation.completed"}
 
 
+def test_ignored_replay_preserves_evaluation_completed_case_id(session):
+    _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD", is_current=True)
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+    evaluation_event = (
+        session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "evaluation.completed").one()
+    )
+    assert evaluation_event.payload["case_id"] == int(case.case_id)
+
+    decision.is_current = False
+    result = process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+
+    assert result.action == "ignored_decision"
+    assert session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "evaluation.completed").count() == 1
+    replayed_event = session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "evaluation.completed").one()
+    assert replayed_event.payload["case_id"] == int(case.case_id)
+
+
 def test_neutral_decision_only_publishes_evaluation_event(session):
     _seed_case_org(session)
     decision = _add_decision(session, outcome="RELEASE")
@@ -564,6 +585,32 @@ def test_case_assignment_rejects_user_from_another_org(session):
             f"/api/v2/cases/{case.case_id}",
             headers={"Authorization": f"Bearer {token}"},
             json={"assigned_to_user_id": int(other_user.id)},
+        )
+
+    assert response.status_code == 422
+    assert session.query(Case).one().assigned_to_user_id is None
+
+
+def test_case_assignment_rejects_inactive_user(session):
+    _org, _user, token = _seed_case_org(session)
+    inactive_user = User(
+        email="inactive-case-manager@example.com",
+        password="unused",
+        active=False,
+        fs_uniquifier="inactive-case-manager@example.com",
+        o_id=1,
+    )
+    session.add(inactive_user)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"assigned_to_user_id": int(inactive_user.id)},
         )
 
     assert response.status_code == 422

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -274,6 +274,14 @@ def test_case_assignment_api_records_timeline_events(session):
         assert assign_response.json()["case"]["assigned_to_user_id"] == int(user.id)
         assert assign_response.json()["case"]["status"] == "in_review"
 
+        same_assign_response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers=headers,
+            json={"assigned_to_user_id": int(user.id)},
+        )
+        assert same_assign_response.status_code == 200
+        assert same_assign_response.json()["case"]["assigned_to_user_id"] == int(user.id)
+
         no_op_response = client.patch(
             f"/api/v2/cases/{case.case_id}",
             headers=headers,

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -11,10 +11,16 @@ from ezrules.backend.cases import (
     CASE_STATUS_OPEN,
     CASE_STATUS_RESOLVED,
     CaseConflictError,
+    CaseValidationError,
     process_evaluation_for_cases,
     resolve_case,
 )
-from ezrules.backend.integrations import OUTBOX_DELIVERED, dispatch_pending_outbox, publish_integration_event
+from ezrules.backend.integrations import (
+    OUTBOX_DELIVERED,
+    OUTBOX_SKIPPED,
+    dispatch_pending_outbox,
+    publish_integration_event,
+)
 from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import (
@@ -26,6 +32,7 @@ from ezrules.models.backend_core import (
     IntegrationEvent,
     IntegrationOutbox,
     IntegrationSubscription,
+    Label,
     Organisation,
     Role,
     User,
@@ -267,6 +274,14 @@ def test_case_assignment_api_records_timeline_events(session):
         assert assign_response.json()["case"]["assigned_to_user_id"] == int(user.id)
         assert assign_response.json()["case"]["status"] == "in_review"
 
+        no_op_response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers=headers,
+            json={},
+        )
+        assert no_op_response.status_code == 200
+        assert no_op_response.json()["case"]["assigned_to_user_id"] == int(user.id)
+
         unassign_response = client.patch(
             f"/api/v2/cases/{case.case_id}",
             headers=headers,
@@ -311,6 +326,31 @@ def test_case_assignment_rejects_user_from_another_org(session):
     assert session.query(Case).one().assigned_to_user_id is None
 
 
+def test_case_assignment_rejects_resolved_case(session):
+    _org, user, token = _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    case = session.query(Case).one()
+    resolve_case(
+        session,
+        o_id=1,
+        case_id=int(case.case_id),
+        actor_user_id=int(user.id),
+        resolution_note="Already reviewed.",
+    )
+    session.commit()
+
+    with TestClient(app) as client:
+        response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"assigned_to_user_id": int(user.id)},
+        )
+
+    assert response.status_code == 422
+    assert session.query(Case).one().assigned_to_user_id is None
+
+
 def test_resolving_already_resolved_case_is_idempotent(session):
     _org, user, _token = _seed_case_org(session)
     decision = _add_decision(session, outcome="HOLD")
@@ -340,6 +380,42 @@ def test_resolving_already_resolved_case_is_idempotent(session):
         "resolved",
     ]
     assert session.query(IntegrationEvent).filter(IntegrationEvent.event_type == "case.resolved").count() == 1
+
+
+def test_resolution_label_must_belong_to_case_org(session):
+    _org, user, _token = _seed_case_org(session)
+    other_org = Organisation(name="Other org")
+    session.add(other_org)
+    session.flush()
+    other_label = Label(label="Other org label", o_id=int(other_org.o_id))
+    session.add(other_label)
+    decision = _add_decision(session, outcome="HOLD")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    case = session.query(Case).one()
+
+    with pytest.raises(CaseValidationError, match="Resolution label must belong"):
+        resolve_case(
+            session,
+            o_id=1,
+            case_id=int(case.case_id),
+            actor_user_id=int(user.id),
+            resolution_note="Wrong label.",
+            resolution_label_id=int(other_label.el_id),
+        )
+
+
+def test_cases_outcome_filter_is_case_insensitive(session):
+    _org, _user, token = _seed_case_org(session)
+    decision = _add_decision(session, outcome="hold")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/cases?outcome=HOLD", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert response.json()["cases"][0]["resolved_outcome"] == "hold"
 
 
 def test_integration_subscription_api_validates_webhook_url_and_strips_secret(session):
@@ -388,10 +464,82 @@ def test_integration_subscription_api_validates_webhook_url_and_strips_secret(se
         assert updated["name"] == "Disabled case webhook"
         assert updated["enabled"] is False
         assert updated["event_types"] == ["case.created", "case.resolved"]
+        assert "secret" not in updated["config"]
+        stored_subscription = session.query(IntegrationSubscription).one()
+        assert stored_subscription.config["secret"] == "top-secret"
 
         list_response = client.get("/api/v2/integration-subscriptions", headers=headers)
         assert list_response.status_code == 200
         assert list_response.json()["subscriptions"][0]["id"] == created["id"]
+
+
+def test_idempotent_integration_publish_enqueues_missing_subscription_delivery(session):
+    _seed_case_org(session)
+    publish_integration_event(
+        session,
+        o_id=1,
+        source_type="case_event",
+        source_id=123,
+        event_type="case.created",
+        external_event_id="evt_test_case_created",
+        payload={"case": {"case_id": 123}},
+    )
+    session.flush()
+    subscription = IntegrationSubscription(
+        o_id=1,
+        name="Case webhook",
+        destination_type="webhook",
+        config={"url": "https://example.com/webhook"},
+        event_types=["case.created"],
+        enabled=True,
+    )
+    session.add(subscription)
+    session.flush()
+
+    result = publish_integration_event(
+        session,
+        o_id=1,
+        source_type="case_event",
+        source_id=123,
+        event_type="case.created",
+        external_event_id="evt_test_case_created",
+        payload={"case": {"case_id": 123}},
+    )
+
+    assert result.delivery_count == 1
+    assert session.query(IntegrationEvent).count() == 1
+    assert session.query(IntegrationOutbox).count() == 1
+
+
+def test_outbox_dispatch_skips_disabled_subscription_delivery(session):
+    _seed_case_org(session)
+    subscription = IntegrationSubscription(
+        o_id=1,
+        name="Case webhook",
+        destination_type="webhook",
+        config={"url": "https://example.com/webhook"},
+        event_types=["case.created"],
+        enabled=True,
+    )
+    session.add(subscription)
+    session.flush()
+    publish_integration_event(
+        session,
+        o_id=1,
+        source_type="case_event",
+        source_id=123,
+        event_type="case.created",
+        external_event_id="evt_test_case_created",
+        payload={"case": {"case_id": 123}},
+    )
+    subscription.enabled = False
+    session.commit()
+
+    result = dispatch_pending_outbox(session)
+
+    assert result == {"delivered": 0, "failed": 0}
+    delivery = session.query(IntegrationOutbox).one()
+    assert delivery.status == OUTBOX_SKIPPED
 
 
 def test_outbox_dispatch_delivers_webhook_and_marks_delivery(session, monkeypatch):

--- a/tests/test_case_management.py
+++ b/tests/test_case_management.py
@@ -34,6 +34,7 @@ from ezrules.models.backend_core import (
     IntegrationSubscription,
     Label,
     Organisation,
+    Rule,
     Role,
     User,
 )
@@ -89,6 +90,7 @@ def _add_decision(
     outcome: str | None = "HOLD",
     version: int = 1,
     is_current: bool = True,
+    rule_id: int = 1,
 ) -> EvaluationDecision:
     now = datetime.datetime.now(datetime.UTC)
     event = EventVersion(
@@ -115,12 +117,27 @@ def _add_decision(
         is_current=is_current,
         outcome_counters=counters,
         resolved_outcome=outcome,
-        all_rule_results={"1": outcome} if outcome else {},
+        all_rule_results={str(rule_id): outcome} if outcome else {},
         evaluated_at=now,
     )
     session.add(decision)
     session.flush()
     return decision
+
+
+def _resolve_case_for_test(
+    session, *, case: Case, actor_user_id: int, expected_current_ed_id: int | None = None
+) -> Case:
+    return resolve_case(
+        session,
+        o_id=int(case.o_id),
+        case_id=int(case.case_id),
+        actor_user_id=actor_user_id,
+        resolution_disposition="false_positive",
+        resolution_action="release_transaction",
+        resolution_note="Reviewed case.",
+        expected_current_ed_id=expected_current_ed_id,
+    )
 
 
 def test_case_created_for_non_neutral_decision_and_integration_events(session):
@@ -218,6 +235,8 @@ def test_resolve_requires_current_decision_when_expected_id_is_supplied(session)
             o_id=1,
             case_id=int(case.case_id),
             actor_user_id=int(user.id),
+            resolution_disposition="false_positive",
+            resolution_action="release_transaction",
             resolution_note="Reviewed before score changed",
             expected_current_ed_id=int(first.ed_id),
         )
@@ -225,7 +244,17 @@ def test_resolve_requires_current_decision_when_expected_id_is_supplied(session)
 
 def test_cases_and_integration_events_api(session):
     _org, user, token = _seed_case_org(session)
-    decision = _add_decision(session, outcome="HOLD")
+    rule_id = 987001
+    session.add(
+        Rule(
+            r_id=rule_id,
+            rid="premium_amount_hold",
+            logic="$amount > 100",
+            description="Premium amount hold",
+            o_id=1,
+        )
+    )
+    decision = _add_decision(session, outcome="HOLD", rule_id=rule_id)
     process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
     session.commit()
     case = session.query(Case).one()
@@ -236,22 +265,49 @@ def test_cases_and_integration_events_api(session):
         assert list_response.status_code == 200
         assert list_response.json()["cases"][0]["id"] == int(case.case_id)
 
+        detail_response = client.get(f"/api/v2/cases/{case.case_id}", headers=headers)
+        assert detail_response.status_code == 200
+        detail = detail_response.json()
+        assert detail["case"]["transaction_id"] == "txn-case-1"
+        assert detail["evaluation"]["evaluation_decision_id"] == int(decision.ed_id)
+        assert detail["evaluation"]["event_data"] == {"transaction_id": "txn-case-1", "amount": 101}
+        assert detail["evaluation"]["outcome_counters"] == {"HOLD": 1}
+        assert detail["evaluation"]["triggered_rules"] == [
+            {
+                "r_id": rule_id,
+                "rid": "premium_amount_hold",
+                "description": "Premium amount hold",
+                "outcome": "HOLD",
+                "metadata_source": "current_rule_fallback",
+                "referenced_fields": None,
+            }
+        ]
+
         resolve_response = client.post(
             f"/api/v2/cases/{case.case_id}/resolve",
             headers=headers,
             json={
+                "resolution_disposition": "false_positive",
+                "resolution_action": "release_transaction",
                 "resolution_note": "Reviewed customer history and approved closure.",
                 "expected_current_ed_id": int(decision.ed_id),
             },
         )
         assert resolve_response.status_code == 200
         assert resolve_response.json()["case"]["status"] == CASE_STATUS_RESOLVED
+        assert resolve_response.json()["case"]["resolution_disposition"] == "false_positive"
+        assert resolve_response.json()["case"]["resolution_action"] == "release_transaction"
 
         events_response = client.get("/api/v2/integration-events", headers=headers)
         assert events_response.status_code == 200
-        event_types = [event["event_type"] for event in events_response.json()["events"]]
+        integration_events = events_response.json()["events"]
+        event_types = [event["event_type"] for event in integration_events]
         assert "evaluation.completed" in event_types
         assert "case.resolved" in event_types
+        resolved_event = next(event for event in integration_events if event["event_type"] == "case.resolved")
+        assert resolved_event["payload"]["case"]["resolution_disposition"] == "false_positive"
+        assert resolved_event["payload"]["case"]["resolution_action"] == "release_transaction"
+        assert resolved_event["payload"]["case_event"]["details"]["resolution_disposition"] == "false_positive"
 
     assert session.query(Case).filter(Case.resolved_by_user_id == int(user.id)).count() == 1
 
@@ -305,6 +361,55 @@ def test_case_assignment_api_records_timeline_events(session):
     assert events[-1].details["assigned_to_user_id"] is None
 
 
+def test_case_assignees_filters_and_notes_api(session):
+    _org, user, token = _seed_case_org(session)
+    decision = _add_decision(session, outcome="HOLD", transaction_id="txn-filterable-case")
+    process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
+    session.commit()
+    case = session.query(Case).one()
+
+    with TestClient(app) as client:
+        headers = {"Authorization": f"Bearer {token}"}
+        assignees_response = client.get("/api/v2/cases/assignees", headers=headers)
+        assert assignees_response.status_code == 200
+        assert {"id": int(user.id), "email": "case-manager@example.com"} in assignees_response.json()["users"]
+
+        unassigned_response = client.get("/api/v2/cases?assigned_to=unassigned&q=filterable", headers=headers)
+        assert unassigned_response.status_code == 200
+        assert unassigned_response.json()["total"] == 1
+
+        assign_response = client.patch(
+            f"/api/v2/cases/{case.case_id}",
+            headers=headers,
+            json={"assigned_to_user_id": int(user.id)},
+        )
+        assert assign_response.status_code == 200
+        assert assign_response.json()["case"]["assigned_to_email"] == "case-manager@example.com"
+
+        assigned_to_me_response = client.get("/api/v2/cases?assigned_to=me&priority_min=1", headers=headers)
+        assert assigned_to_me_response.status_code == 200
+        assert assigned_to_me_response.json()["total"] == 1
+
+        note_response = client.post(
+            f"/api/v2/cases/{case.case_id}/notes",
+            headers=headers,
+            json={"note": "Customer confirmed the attempted transfer."},
+        )
+        assert note_response.status_code == 201
+        assert note_response.json()["event"]["event_type"] == "note"
+        assert note_response.json()["event"]["details"]["note"] == "Customer confirmed the attempted transfer."
+
+        detail_response = client.get(f"/api/v2/cases/{case.case_id}", headers=headers)
+        assert detail_response.status_code == 200
+        assert [event["event_type"] for event in detail_response.json()["events"]] == ["created", "assigned", "note"]
+
+        events_response = client.get("/api/v2/integration-events?event_type=case.note", headers=headers)
+        assert events_response.status_code == 200
+        assert events_response.json()["events"][0]["payload"]["case_event"]["details"]["note"] == (
+            "Customer confirmed the attempted transfer."
+        )
+
+
 def test_case_assignment_rejects_user_from_another_org(session):
     _org, _user, token = _seed_case_org(session)
     other_org = Organisation(name="Other org")
@@ -339,13 +444,7 @@ def test_case_assignment_rejects_resolved_case(session):
     decision = _add_decision(session, outcome="HOLD")
     process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
     case = session.query(Case).one()
-    resolve_case(
-        session,
-        o_id=1,
-        case_id=int(case.case_id),
-        actor_user_id=int(user.id),
-        resolution_note="Already reviewed.",
-    )
+    _resolve_case_for_test(session, case=case, actor_user_id=int(user.id))
     session.commit()
 
     with TestClient(app) as client:
@@ -365,22 +464,8 @@ def test_resolving_already_resolved_case_is_idempotent(session):
     process_evaluation_for_cases(session, o_id=1, evaluation_decision_id=int(decision.ed_id))
     case = session.query(Case).one()
 
-    resolve_case(
-        session,
-        o_id=1,
-        case_id=int(case.case_id),
-        actor_user_id=int(user.id),
-        resolution_note="Reviewed once.",
-        expected_current_ed_id=int(decision.ed_id),
-    )
-    resolve_case(
-        session,
-        o_id=1,
-        case_id=int(case.case_id),
-        actor_user_id=int(user.id),
-        resolution_note="Reviewed twice.",
-        expected_current_ed_id=int(decision.ed_id),
-    )
+    _resolve_case_for_test(session, case=case, actor_user_id=int(user.id), expected_current_ed_id=int(decision.ed_id))
+    _resolve_case_for_test(session, case=case, actor_user_id=int(user.id), expected_current_ed_id=int(decision.ed_id))
     session.commit()
 
     assert [event.event_type for event in session.query(CaseEvent).order_by(CaseEvent.case_event_id)] == [
@@ -407,6 +492,8 @@ def test_resolution_label_must_belong_to_case_org(session):
             o_id=1,
             case_id=int(case.case_id),
             actor_user_id=int(user.id),
+            resolution_disposition="false_positive",
+            resolution_action="release_transaction",
             resolution_note="Wrong label.",
             resolution_label_id=int(other_label.el_id),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.27.0"
+version = "1.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.26.0"
+version = "1.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- add durable case and case-event persistence for non-neutral served decisions
- add generic integration events, subscriptions, and outbox delivery support shared by evaluation and case lifecycle events
- add case management API routes, Angular Cases page, e2e coverage, docs, and v1.27.0 release notes

## Verification
- uv run poe check
- EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_54043_case_mgmt EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 uv run pytest -q tests/test_case_management.py
- npm run build -- --configuration production
- E2E_BASE_URL=http://127.0.0.1:4200 npx playwright test e2e/tests/cases.spec.ts --project=chromium --workers=1 --repeat-each=5 --no-deps
- repeated same Playwright command without resetting state
- uv run mkdocs build --strict

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the live evaluation path, new transactional case lifecycle with advisory locks, and outbound webhooks—integration consumers may act on analyst resolution intent without ezrules executing those actions.
> 
> **Overview**
> Adds **case management** for non-neutral served evaluation decisions: new persistence (`cases`, `case_events`), permissions, and `/api/v2/cases` APIs for listing/filtering, assignment, notes, and structured resolution (disposition, downstream action intent, optional `expected_current_ed_id` for 409 on rescored cases). Rescoring updates one active case per transaction and emits lifecycle integration events without changing `/evaluate` responses.
> 
> Introduces a **generic integration layer**: versioned `integration_events`, HTTPS webhook `integration_subscriptions`, transactional `integration_outbox`, cursor polling, and Celery `dispatch-integration-outbox` delivery with idempotent `external_event_id` / `downstream_action` payloads for external consumers.
> 
> **Evaluation path** now calls synchronous `enqueue_case_detection` after decisions (including duplicates), and defers feature-trace `commit` so case/integration work can fail independently. Ships an Angular **Cases** inbox (queues, filters, evaluation context), docs, and broad `test_case_management.py` coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5e407719710f66b4e23d97af3be7cdd24606ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->