### PR TITLE
Add deterministic agent tools for rule evidence

### DIFF
--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -217,6 +217,31 @@ Dashboard analytics source of truth:
 - Time buckets are anchored on `evaluation_decisions.evaluated_at`, so charts show when a decision was served rather than the event's business timestamp.
 - Label analytics and rule-quality endpoints use canonical `event_version_labels` joined to served decisions and event labels; label chart buckets are anchored on served decision time.
 
+### Agent Tools
+
+Deterministic agent tools expose bounded evidence packets for future fraud-management agents. They do not provide generic database access and they replay recent served decisions through the same rule compiler, field normalization, user-list lookup, and computed-feature resolution paths used by rule analysis.
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| `POST` | `/api/v2/agent-tools/rule-blast-radius` | Bearer + `VIEW_RULES` | Compare existing rule logic to proposed logic over recent served decisions. Returns stored/proposed outcome counts, outcome deltas, grouped changed-decision rates, representative flipped events, skipped-record counts, and warnings. |
+| `POST` | `/api/v2/agent-tools/rule-counterexamples` | Bearer + `VIEW_RULES` + `VIEW_LABELS` | Return labeled examples where a rule fired on negative labels, missed positive labels, where candidate logic fixes existing mistakes, and where candidate logic introduces regressions. |
+
+`POST /api/v2/agent-tools/rule-blast-radius` request fields:
+- `rule_id`: existing rule ID in the caller's organisation.
+- `proposed_logic`: candidate ezrules source to compare against the stored rule.
+- `lookback_days`: recent served-decision window, default `30`.
+- `group_by`: up to five event field paths used to segment changed-decision impact.
+- `sample_limit`: maximum representative flipped events returned.
+- `max_records`: cap on recent served decisions replayed.
+
+`POST /api/v2/agent-tools/rule-counterexamples` request fields:
+- `rule_id`: existing rule ID in the caller's organisation.
+- `proposed_logic`: optional candidate ezrules source for fix/regression buckets.
+- `positive_labels`: labels that should usually be caught, default `["FRAUD"]`.
+- `negative_labels`: labels that should usually not be caught, default `["NORMAL", "LEGIT", "GENUINE"]`.
+- `target_outcomes`: optional outcome names that count as actionable rule fires. When omitted, any non-null rule outcome counts as a fire.
+- `lookback_days`, `sample_limit`, and `max_records`: bounded replay controls.
+
 ### Alerts and Notifications
 
 | Method | Path | Auth | Notes |

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -219,20 +219,26 @@ Dashboard analytics source of truth:
 
 ### Agent Tools
 
-Deterministic agent tools expose bounded evidence packets for future fraud-management agents. They do not provide generic database access and they replay recent served decisions through the same rule compiler, field normalization, user-list lookup, and computed-feature resolution paths used by rule analysis.
+Deterministic agent tools expose bounded evidence packets for future fraud-management agents. They do not provide generic database access and they replay current served decisions through the same rule compiler, field normalization, user-list lookup, and computed-feature resolution paths used by rule analysis.
+
+Replay semantics:
+- Replays use current served decisions only (`is_current=true`) so superseded transaction versions do not inflate analysis counts.
+- `stored_outcome` re-executes the rule's current stored logic from the database, not the exact rule source that was active when the historical decision was originally served.
+- Blast-radius `changed_rule_outcome_*` fields measure single-rule outcome flips. They are not full resolved-decision changes across the whole ordered rule set or outcome hierarchy.
+- Replays run synchronously and default to the most recent `1,000` current served decisions. Use smaller windows for interactive use; larger caps may be slower when rules reference computed features.
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
-| `POST` | `/api/v2/agent-tools/rule-blast-radius` | Bearer + `VIEW_RULES` | Compare existing rule logic to proposed logic over recent served decisions. Returns stored/proposed outcome counts, outcome deltas, grouped changed-decision rates, representative flipped events, skipped-record counts, and warnings. |
+| `POST` | `/api/v2/agent-tools/rule-blast-radius` | Bearer + `VIEW_RULES` | Compare existing rule logic to proposed logic over recent current served decisions. Returns stored/proposed outcome counts, outcome deltas, grouped single-rule outcome flip rates, representative flipped events, skipped-record counts, and warnings. |
 | `POST` | `/api/v2/agent-tools/rule-counterexamples` | Bearer + `VIEW_RULES` + `VIEW_LABELS` | Return labeled examples where a rule fired on negative labels, missed positive labels, where candidate logic fixes existing mistakes, and where candidate logic introduces regressions. |
 
 `POST /api/v2/agent-tools/rule-blast-radius` request fields:
 - `rule_id`: existing rule ID in the caller's organisation.
 - `proposed_logic`: candidate ezrules source to compare against the stored rule.
 - `lookback_days`: recent served-decision window, default `30`.
-- `group_by`: up to five event field paths used to segment changed-decision impact.
+- `group_by`: up to five event field paths used to segment single-rule outcome flip impact.
 - `sample_limit`: maximum representative flipped events returned.
-- `max_records`: cap on recent served decisions replayed.
+- `max_records`: cap on recent served decisions replayed, default `1,000`.
 
 `POST /api/v2/agent-tools/rule-counterexamples` request fields:
 - `rule_id`: existing rule ID in the caller's organisation.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -3,7 +3,7 @@
 ## v1.27.0
 
 * **Deterministic agent tools API**: Added `/api/v2/agent-tools` endpoints that let future fraud-management agents request bounded, permission-gated evidence instead of broad database access.
-* **Rule blast-radius analysis**: Added `POST /api/v2/agent-tools/rule-blast-radius` to compare proposed rule logic against recent served decisions, including outcome deltas, grouped changed-decision rates, representative flipped events, and replay warnings.
+* **Rule blast-radius analysis**: Added `POST /api/v2/agent-tools/rule-blast-radius` to compare proposed rule logic against recent served decisions, including outcome deltas, grouped single-rule outcome flip rates, representative flipped events, and replay warnings.
 * **Rule counterexample mining**: Added `POST /api/v2/agent-tools/rule-counterexamples` to return labeled false-positive, missed-positive, candidate-fix, and candidate-regression examples for rule review workflows.
 
 ## v1.26.0

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.27.0
+
+* **Deterministic agent tools API**: Added `/api/v2/agent-tools` endpoints that let future fraud-management agents request bounded, permission-gated evidence instead of broad database access.
+* **Rule blast-radius analysis**: Added `POST /api/v2/agent-tools/rule-blast-radius` to compare proposed rule logic against recent served decisions, including outcome deltas, grouped changed-decision rates, representative flipped events, and replay warnings.
+* **Rule counterexample mining**: Added `POST /api/v2/agent-tools/rule-counterexamples` to return labeled false-positive, missed-positive, candidate-fix, and candidate-regression examples for rule review workflows.
+
 ## v1.26.0
 
 * **Recent rule triggers**: Rule detail pages now show recent served transactions where the rule produced an outcome, with a fixed-size **Load more** flow for reviewing additional trigger history without leaving the page.

--- a/ezrules/backend/agent_tools.py
+++ b/ezrules/backend/agent_tools.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy.orm import aliased
-
 from ezrules.backend.features import FeatureResolutionError, FeatureResolver
 from ezrules.backend.utils import load_cast_configs
 from ezrules.core.field_paths import get_field_value
@@ -26,6 +24,7 @@ DEFAULT_POSITIVE_LABELS = ("FRAUD",)
 
 @dataclass(slots=True)
 class AgentToolRecord:
+    event_version_id: int
     transaction_id: str
     event_version: int
     evaluation_decision_id: int
@@ -57,6 +56,12 @@ class ReplayResult:
 
 def _lookback_start(lookback_days: int) -> datetime:
     return datetime.now(UTC) - timedelta(days=lookback_days)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _safe_outcome(value: Any) -> str | None:
@@ -124,26 +129,21 @@ def _load_recent_records(
     lookback_days: int,
     max_records: int,
 ) -> list[AgentToolRecord]:
-    label_alias = aliased(Label)
     rows = (
         db.query(
+            EventVersion.ev_id,
             EventVersion.transaction_id,
             EventVersion.event_version,
             EventVersion.event_data,
             EventVersion.effective_at,
             EvaluationDecision.ed_id,
             EvaluationDecision.evaluated_at,
-            label_alias.label,
         )
         .join(EvaluationDecision, EvaluationDecision.ev_id == EventVersion.ev_id)
-        .outerjoin(
-            EventVersionLabel,
-            (EventVersionLabel.ev_id == EventVersion.ev_id) & (EventVersionLabel.o_id == org_id),
-        )
-        .outerjoin(label_alias, (label_alias.el_id == EventVersionLabel.el_id) & (label_alias.o_id == org_id))
         .filter(
             EvaluationDecision.o_id == org_id,
             EvaluationDecision.served.is_(True),
+            EvaluationDecision.is_current.is_(True),
             EvaluationDecision.decision_type == "served",
             EvaluationDecision.evaluated_at >= _lookback_start(lookback_days),
         )
@@ -152,15 +152,34 @@ def _load_recent_records(
         .all()
     )
 
+    ev_ids = [int(row.ev_id) for row in rows]
+    labels_by_ev_id: dict[int, str] = {}
+    if ev_ids:
+        label_rows = (
+            db.query(EventVersionLabel.ev_id, EventVersionLabel.assigned_at, EventVersionLabel.evl_id, Label.label)
+            .join(Label, (Label.el_id == EventVersionLabel.el_id) & (Label.o_id == org_id))
+            .filter(EventVersionLabel.o_id == org_id, EventVersionLabel.ev_id.in_(ev_ids))
+            .order_by(
+                EventVersionLabel.ev_id.asc(),
+                EventVersionLabel.assigned_at.desc(),
+                EventVersionLabel.evl_id.desc(),
+            )
+            .all()
+        )
+        for label_row in label_rows:
+            ev_id = int(label_row.ev_id)
+            labels_by_ev_id.setdefault(ev_id, str(label_row.label))
+
     return [
         AgentToolRecord(
+            event_version_id=int(row.ev_id),
             transaction_id=str(row.transaction_id),
             event_version=int(row.event_version),
             evaluation_decision_id=int(row.ed_id),
             event_data=dict(row.event_data or {}),
-            effective_at=row.effective_at if row.effective_at.tzinfo else row.effective_at.replace(tzinfo=UTC),
-            evaluated_at=row.evaluated_at if row.evaluated_at.tzinfo else row.evaluated_at.replace(tzinfo=UTC),
-            label_name=str(row.label) if row.label else None,
+            effective_at=_as_utc(row.effective_at),
+            evaluated_at=_as_utc(row.evaluated_at),
+            label_name=labels_by_ev_id.get(int(row.ev_id)),
         )
         for row in rows
     ]
@@ -316,7 +335,7 @@ def build_blast_radius(
             {
                 "group": dict(item.group_values),
                 "total_records": 0,
-                "changed_decision_count": 0,
+                "changed_rule_outcome_count": 0,
                 "stored_result": Counter(),
                 "proposed_result": Counter(),
             },
@@ -325,7 +344,7 @@ def build_blast_radius(
         group["stored_result"][_count_key(item.stored_outcome)] += 1
         group["proposed_result"][_count_key(item.proposed_outcome)] += 1
         if _count_key(item.stored_outcome) != _count_key(item.proposed_outcome):
-            group["changed_decision_count"] += 1
+            group["changed_rule_outcome_count"] += 1
 
     group_deltas = []
     for group in group_counters.values():
@@ -335,8 +354,8 @@ def build_blast_radius(
             {
                 "group": group["group"],
                 "total_records": group["total_records"],
-                "changed_decision_count": group["changed_decision_count"],
-                "changed_decision_rate": round(group["changed_decision_count"] / group["total_records"], 4)
+                "changed_rule_outcome_count": group["changed_rule_outcome_count"],
+                "changed_rule_outcome_rate": round(group["changed_rule_outcome_count"] / group["total_records"], 4)
                 if group["total_records"]
                 else 0.0,
                 "stored_result": _sorted_counts(stored_result),
@@ -344,7 +363,7 @@ def build_blast_radius(
                 "outcome_delta": _outcome_delta(stored_result, proposed_result),
             }
         )
-    group_deltas.sort(key=lambda row: (row["changed_decision_count"], row["total_records"]), reverse=True)
+    group_deltas.sort(key=lambda row: (row["changed_rule_outcome_count"], row["total_records"]), reverse=True)
 
     return {
         "rule_id": rule_id,
@@ -355,8 +374,10 @@ def build_blast_radius(
         "stored_result": _sorted_counts(replay.stored_counts),
         "proposed_result": _sorted_counts(replay.proposed_counts),
         "outcome_delta": _outcome_delta(replay.stored_counts, replay.proposed_counts),
-        "changed_decision_count": len(changed),
-        "changed_decision_rate": round(len(changed) / replay.eligible_records, 4) if replay.eligible_records else 0.0,
+        "changed_rule_outcome_count": len(changed),
+        "changed_rule_outcome_rate": round(len(changed) / replay.eligible_records, 4)
+        if replay.eligible_records
+        else 0.0,
         "group_deltas": group_deltas,
         "flipped_events": [_evidence_row(item) for item in changed[:sample_limit]],
         "warnings": replay.warnings,

--- a/ezrules/backend/agent_tools.py
+++ b/ezrules/backend/agent_tools.py
@@ -1,0 +1,481 @@
+"""Deterministic analysis helpers exposed through agent-tool API routes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy.orm import aliased
+
+from ezrules.backend.features import FeatureResolutionError, FeatureResolver
+from ezrules.backend.utils import load_cast_configs
+from ezrules.core.field_paths import get_field_value
+from ezrules.core.rule import MissingFieldLookupError, MissingStatLookupError, Rule, RuleFactory
+from ezrules.core.type_casting import CastError, RequiredFieldError, find_missing_fields, normalize_event
+from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.models.backend_core import EvaluationDecision, EventVersion, EventVersionLabel, Label
+from ezrules.models.backend_core import Rule as RuleModel
+
+NO_OUTCOME = "NO_OUTCOME"
+DEFAULT_NEGATIVE_LABELS = ("NORMAL", "LEGIT", "GENUINE")
+DEFAULT_POSITIVE_LABELS = ("FRAUD",)
+
+
+@dataclass(slots=True)
+class AgentToolRecord:
+    transaction_id: str
+    event_version: int
+    evaluation_decision_id: int
+    event_data: dict[str, Any]
+    effective_at: datetime
+    evaluated_at: datetime
+    label_name: str | None
+
+
+@dataclass(slots=True)
+class ReplayEvaluation:
+    record: AgentToolRecord
+    stored_outcome: str | None
+    proposed_outcome: str | None
+    group_values: dict[str, Any]
+    event_data_snippet: dict[str, Any]
+
+
+@dataclass(slots=True)
+class ReplayResult:
+    total_records: int
+    eligible_records: int
+    skipped_records: int
+    stored_counts: Counter[str]
+    proposed_counts: Counter[str]
+    evaluations: list[ReplayEvaluation]
+    warnings: list[str]
+
+
+def _lookback_start(lookback_days: int) -> datetime:
+    return datetime.now(UTC) - timedelta(days=lookback_days)
+
+
+def _safe_outcome(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _count_key(outcome: str | None) -> str:
+    return outcome if outcome is not None else NO_OUTCOME
+
+
+def _sorted_counts(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _outcome_delta(stored: Counter[str], proposed: Counter[str]) -> dict[str, int]:
+    keys = sorted(set(stored) | set(proposed))
+    return {key: proposed[key] - stored[key] for key in keys if proposed[key] != stored[key]}
+
+
+def _field_value_or_none(event_data: dict[str, Any], field_path: str) -> Any:
+    try:
+        return get_field_value(event_data, field_path)
+    except KeyError:
+        return None
+
+
+def _event_snippet(event_data: dict[str, Any], field_paths: Iterable[str]) -> dict[str, Any]:
+    snippet: dict[str, Any] = {}
+    for field_path in sorted(set(field_paths)):
+        snippet[field_path] = _field_value_or_none(event_data, field_path)
+    if snippet:
+        return snippet
+
+    for key in sorted(event_data)[:8]:
+        value = event_data[key]
+        if isinstance(value, dict | list):
+            continue
+        snippet[str(key)] = value
+    return snippet
+
+
+def _load_rule(db: Any, *, org_id: int, rule_id: int) -> RuleModel | None:
+    return db.query(RuleModel).filter(RuleModel.r_id == rule_id, RuleModel.o_id == org_id).first()
+
+
+def _compile_rules(
+    db: Any,
+    *,
+    org_id: int,
+    rule_model: RuleModel,
+    proposed_logic: str | None,
+) -> tuple[Rule, Rule | None]:
+    list_provider = PersistentUserListManager(db_session=db, o_id=org_id)
+    stored_rule = RuleFactory.from_json(rule_model.__dict__, list_values_provider=list_provider)
+    proposed_rule = None
+    if proposed_logic is not None:
+        proposed_rule = Rule(rid="", logic=proposed_logic, list_values_provider=list_provider)
+    return stored_rule, proposed_rule
+
+
+def _load_recent_records(
+    db: Any,
+    *,
+    org_id: int,
+    lookback_days: int,
+    max_records: int,
+) -> list[AgentToolRecord]:
+    label_alias = aliased(Label)
+    rows = (
+        db.query(
+            EventVersion.transaction_id,
+            EventVersion.event_version,
+            EventVersion.event_data,
+            EventVersion.effective_at,
+            EvaluationDecision.ed_id,
+            EvaluationDecision.evaluated_at,
+            label_alias.label,
+        )
+        .join(EvaluationDecision, EvaluationDecision.ev_id == EventVersion.ev_id)
+        .outerjoin(
+            EventVersionLabel,
+            (EventVersionLabel.ev_id == EventVersion.ev_id) & (EventVersionLabel.o_id == org_id),
+        )
+        .outerjoin(label_alias, (label_alias.el_id == EventVersionLabel.el_id) & (label_alias.o_id == org_id))
+        .filter(
+            EvaluationDecision.o_id == org_id,
+            EvaluationDecision.served.is_(True),
+            EvaluationDecision.decision_type == "served",
+            EvaluationDecision.evaluated_at >= _lookback_start(lookback_days),
+        )
+        .order_by(EvaluationDecision.evaluated_at.desc(), EvaluationDecision.ed_id.desc())
+        .limit(max_records)
+        .all()
+    )
+
+    return [
+        AgentToolRecord(
+            transaction_id=str(row.transaction_id),
+            event_version=int(row.event_version),
+            evaluation_decision_id=int(row.ed_id),
+            event_data=dict(row.event_data or {}),
+            effective_at=row.effective_at if row.effective_at.tzinfo else row.effective_at.replace(tzinfo=UTC),
+            evaluated_at=row.evaluated_at if row.evaluated_at.tzinfo else row.evaluated_at.replace(tzinfo=UTC),
+            label_name=str(row.label) if row.label else None,
+        )
+        for row in rows
+    ]
+
+
+def replay_rule_change(
+    db: Any,
+    *,
+    org_id: int,
+    rule_model: RuleModel,
+    proposed_logic: str | None,
+    lookback_days: int,
+    group_by: list[str],
+    max_records: int,
+) -> ReplayResult:
+    stored_rule, proposed_rule = _compile_rules(
+        db,
+        org_id=org_id,
+        rule_model=rule_model,
+        proposed_logic=proposed_logic,
+    )
+    comparison_rule = proposed_rule or stored_rule
+    referenced_fields = sorted(stored_rule.get_rule_params() | comparison_rule.get_rule_params() | set(group_by))
+    stat_paths = stored_rule.get_rule_stats() | comparison_rule.get_rule_stats()
+    configs = load_cast_configs(db, org_id)
+    feature_resolver = FeatureResolver(db, org_id) if stat_paths else None
+
+    records = _load_recent_records(db, org_id=org_id, lookback_days=lookback_days, max_records=max_records)
+    warnings: list[str] = []
+    if len(records) == max_records:
+        warnings.append(f"Analysis was capped at the most recent {max_records} served decision(s).")
+
+    skipped_records = 0
+    stored_counts: Counter[str] = Counter()
+    proposed_counts: Counter[str] = Counter()
+    evaluations: list[ReplayEvaluation] = []
+    missing_field_counts: Counter[str] = Counter()
+    normalization_failures: Counter[str] = Counter()
+    stat_failures: Counter[str] = Counter()
+
+    for record in records:
+        raw_event = dict(record.event_data)
+        missing_fields = find_missing_fields(raw_event, referenced_fields)
+        if missing_fields:
+            skipped_records += 1
+            missing_field_counts.update(missing_fields)
+            continue
+
+        try:
+            normalized_event = normalize_event(raw_event, configs)
+        except (CastError, RequiredFieldError) as exc:
+            skipped_records += 1
+            normalization_failures[str(exc)] += 1
+            continue
+
+        stats: dict[str, Any] | None = None
+        if stat_paths:
+            try:
+                assert feature_resolver is not None
+                stats, _ = feature_resolver.resolve_with_traces(normalized_event, record.effective_at, stat_paths)
+            except FeatureResolutionError as exc:
+                skipped_records += 1
+                stat_failures[str(exc)] += 1
+                continue
+
+        try:
+            stored_outcome = _safe_outcome(stored_rule(normalized_event, stats))
+            proposed_outcome = _safe_outcome(comparison_rule(normalized_event, stats))
+        except MissingFieldLookupError as exc:
+            skipped_records += 1
+            missing_field_counts[exc.field_name] += 1
+            continue
+        except MissingStatLookupError as exc:
+            skipped_records += 1
+            stat_failures[exc.stat_path] += 1
+            continue
+
+        stored_counts[_count_key(stored_outcome)] += 1
+        proposed_counts[_count_key(proposed_outcome)] += 1
+        group_values = {field_path: _field_value_or_none(normalized_event, field_path) for field_path in group_by}
+        evaluations.append(
+            ReplayEvaluation(
+                record=record,
+                stored_outcome=stored_outcome,
+                proposed_outcome=proposed_outcome,
+                group_values=group_values,
+                event_data_snippet=_event_snippet(normalized_event, referenced_fields),
+            )
+        )
+
+    if missing_field_counts:
+        warnings.append(
+            "Records missing referenced fields were skipped: "
+            + ", ".join(f"{field} ({missing_field_counts[field]})" for field in sorted(missing_field_counts))
+            + "."
+        )
+    if normalization_failures:
+        warnings.extend(
+            f"Records excluded by normalization rules: {message} ({count})."
+            for message, count in sorted(normalization_failures.items())
+        )
+    if stat_failures:
+        warnings.append(
+            "Records with unavailable computed stats were skipped: "
+            + ", ".join(f"{reason} ({stat_failures[reason]})" for reason in sorted(stat_failures))
+            + "."
+        )
+
+    return ReplayResult(
+        total_records=len(records),
+        eligible_records=len(evaluations),
+        skipped_records=skipped_records,
+        stored_counts=stored_counts,
+        proposed_counts=proposed_counts,
+        evaluations=evaluations,
+        warnings=warnings,
+    )
+
+
+def build_blast_radius(
+    db: Any,
+    *,
+    org_id: int,
+    rule_id: int,
+    proposed_logic: str,
+    lookback_days: int,
+    group_by: list[str],
+    sample_limit: int,
+    max_records: int,
+) -> dict[str, Any] | None:
+    rule_model = _load_rule(db, org_id=org_id, rule_id=rule_id)
+    if rule_model is None:
+        return None
+
+    replay = replay_rule_change(
+        db,
+        org_id=org_id,
+        rule_model=rule_model,
+        proposed_logic=proposed_logic,
+        lookback_days=lookback_days,
+        group_by=group_by,
+        max_records=max_records,
+    )
+    changed = [
+        item for item in replay.evaluations if _count_key(item.stored_outcome) != _count_key(item.proposed_outcome)
+    ]
+
+    group_counters: dict[tuple[tuple[str, str], ...], dict[str, Any]] = {}
+    for item in replay.evaluations:
+        group_key = tuple(sorted((key, str(value)) for key, value in item.group_values.items()))
+        group = group_counters.setdefault(
+            group_key,
+            {
+                "group": dict(item.group_values),
+                "total_records": 0,
+                "changed_decision_count": 0,
+                "stored_result": Counter(),
+                "proposed_result": Counter(),
+            },
+        )
+        group["total_records"] += 1
+        group["stored_result"][_count_key(item.stored_outcome)] += 1
+        group["proposed_result"][_count_key(item.proposed_outcome)] += 1
+        if _count_key(item.stored_outcome) != _count_key(item.proposed_outcome):
+            group["changed_decision_count"] += 1
+
+    group_deltas = []
+    for group in group_counters.values():
+        stored_result = group["stored_result"]
+        proposed_result = group["proposed_result"]
+        group_deltas.append(
+            {
+                "group": group["group"],
+                "total_records": group["total_records"],
+                "changed_decision_count": group["changed_decision_count"],
+                "changed_decision_rate": round(group["changed_decision_count"] / group["total_records"], 4)
+                if group["total_records"]
+                else 0.0,
+                "stored_result": _sorted_counts(stored_result),
+                "proposed_result": _sorted_counts(proposed_result),
+                "outcome_delta": _outcome_delta(stored_result, proposed_result),
+            }
+        )
+    group_deltas.sort(key=lambda row: (row["changed_decision_count"], row["total_records"]), reverse=True)
+
+    return {
+        "rule_id": rule_id,
+        "lookback_days": lookback_days,
+        "total_records": replay.total_records,
+        "eligible_records": replay.eligible_records,
+        "skipped_records": replay.skipped_records,
+        "stored_result": _sorted_counts(replay.stored_counts),
+        "proposed_result": _sorted_counts(replay.proposed_counts),
+        "outcome_delta": _outcome_delta(replay.stored_counts, replay.proposed_counts),
+        "changed_decision_count": len(changed),
+        "changed_decision_rate": round(len(changed) / replay.eligible_records, 4) if replay.eligible_records else 0.0,
+        "group_deltas": group_deltas,
+        "flipped_events": [_evidence_row(item) for item in changed[:sample_limit]],
+        "warnings": replay.warnings,
+    }
+
+
+def _outcome_is_actionable(outcome: str | None, target_outcomes: set[str] | None) -> bool:
+    if outcome is None:
+        return False
+    return target_outcomes is None or outcome in target_outcomes
+
+
+def _is_wrong(
+    *,
+    label_name: str | None,
+    outcome: str | None,
+    positive_labels: set[str],
+    negative_labels: set[str],
+    target_outcomes: set[str] | None,
+) -> bool:
+    if label_name is None:
+        return False
+    fired = _outcome_is_actionable(outcome, target_outcomes)
+    if label_name in positive_labels:
+        return not fired
+    if label_name in negative_labels:
+        return fired
+    return False
+
+
+def _evidence_row(item: ReplayEvaluation) -> dict[str, Any]:
+    return {
+        "transaction_id": item.record.transaction_id,
+        "event_version": item.record.event_version,
+        "evaluation_decision_id": item.record.evaluation_decision_id,
+        "label_name": item.record.label_name,
+        "stored_outcome": item.stored_outcome,
+        "proposed_outcome": item.proposed_outcome,
+        "group": item.group_values,
+        "event_data": item.event_data_snippet,
+    }
+
+
+def build_rule_counterexamples(
+    db: Any,
+    *,
+    org_id: int,
+    rule_id: int,
+    proposed_logic: str | None,
+    lookback_days: int,
+    positive_labels: list[str],
+    negative_labels: list[str],
+    target_outcomes: list[str] | None,
+    sample_limit: int,
+    max_records: int,
+) -> dict[str, Any] | None:
+    rule_model = _load_rule(db, org_id=org_id, rule_id=rule_id)
+    if rule_model is None:
+        return None
+
+    replay = replay_rule_change(
+        db,
+        org_id=org_id,
+        rule_model=rule_model,
+        proposed_logic=proposed_logic,
+        lookback_days=lookback_days,
+        group_by=[],
+        max_records=max_records,
+    )
+    positive_label_set = set(positive_labels or DEFAULT_POSITIVE_LABELS)
+    negative_label_set = set(negative_labels or DEFAULT_NEGATIVE_LABELS)
+    target_outcome_set = set(target_outcomes) if target_outcomes else None
+
+    buckets: dict[str, list[dict[str, Any]]] = {
+        "fired_but_negative": [],
+        "missed_positive": [],
+        "candidate_fixes_existing": [],
+        "candidate_introduces_new_errors": [],
+    }
+
+    for item in replay.evaluations:
+        label_name = item.record.label_name
+        if label_name is None:
+            continue
+
+        stored_wrong = _is_wrong(
+            label_name=label_name,
+            outcome=item.stored_outcome,
+            positive_labels=positive_label_set,
+            negative_labels=negative_label_set,
+            target_outcomes=target_outcome_set,
+        )
+        proposed_wrong = _is_wrong(
+            label_name=label_name,
+            outcome=item.proposed_outcome,
+            positive_labels=positive_label_set,
+            negative_labels=negative_label_set,
+            target_outcomes=target_outcome_set,
+        )
+
+        fired = _outcome_is_actionable(item.stored_outcome, target_outcome_set)
+        if label_name in negative_label_set and fired and len(buckets["fired_but_negative"]) < sample_limit:
+            buckets["fired_but_negative"].append(_evidence_row(item))
+        if label_name in positive_label_set and not fired and len(buckets["missed_positive"]) < sample_limit:
+            buckets["missed_positive"].append(_evidence_row(item))
+        if stored_wrong and not proposed_wrong and len(buckets["candidate_fixes_existing"]) < sample_limit:
+            buckets["candidate_fixes_existing"].append(_evidence_row(item))
+        if not stored_wrong and proposed_wrong and len(buckets["candidate_introduces_new_errors"]) < sample_limit:
+            buckets["candidate_introduces_new_errors"].append(_evidence_row(item))
+
+    return {
+        "rule_id": rule_id,
+        "lookback_days": lookback_days,
+        "total_records": replay.total_records,
+        "eligible_records": replay.eligible_records,
+        "skipped_records": replay.skipped_records,
+        "positive_labels": sorted(positive_label_set),
+        "negative_labels": sorted(negative_label_set),
+        "target_outcomes": sorted(target_outcome_set) if target_outcome_set is not None else None,
+        "buckets": buckets,
+        "warnings": replay.warnings,
+    }

--- a/ezrules/backend/agent_tools.py
+++ b/ezrules/backend/agent_tools.py
@@ -18,8 +18,6 @@ from ezrules.models.backend_core import EvaluationDecision, EventVersion, EventV
 from ezrules.models.backend_core import Rule as RuleModel
 
 NO_OUTCOME = "NO_OUTCOME"
-DEFAULT_NEGATIVE_LABELS = ("NORMAL", "LEGIT", "GENUINE")
-DEFAULT_POSITIVE_LABELS = ("FRAUD",)
 
 
 @dataclass(slots=True)
@@ -256,6 +254,11 @@ def replay_rule_change(
             skipped_records += 1
             stat_failures[exc.stat_path] += 1
             continue
+        except KeyError as exc:
+            skipped_records += 1
+            missing_key = exc.args[0] if exc.args else "runtime_key_error"
+            missing_field_counts[str(missing_key)] += 1
+            continue
 
         stored_counts[_count_key(stored_outcome)] += 1
         proposed_counts[_count_key(proposed_outcome)] += 1
@@ -379,7 +382,7 @@ def build_blast_radius(
         if replay.eligible_records
         else 0.0,
         "group_deltas": group_deltas,
-        "flipped_events": [_evidence_row(item) for item in changed[:sample_limit]],
+        "flipped_events": [_evidence_row(item, include_label=False) for item in changed[:sample_limit]],
         "warnings": replay.warnings,
     }
 
@@ -408,17 +411,19 @@ def _is_wrong(
     return False
 
 
-def _evidence_row(item: ReplayEvaluation) -> dict[str, Any]:
-    return {
+def _evidence_row(item: ReplayEvaluation, *, include_label: bool) -> dict[str, Any]:
+    row = {
         "transaction_id": item.record.transaction_id,
         "event_version": item.record.event_version,
         "evaluation_decision_id": item.record.evaluation_decision_id,
-        "label_name": item.record.label_name,
         "stored_outcome": item.stored_outcome,
         "proposed_outcome": item.proposed_outcome,
         "group": item.group_values,
         "event_data": item.event_data_snippet,
     }
+    if include_label:
+        row["label_name"] = item.record.label_name
+    return row
 
 
 def build_rule_counterexamples(
@@ -447,8 +452,8 @@ def build_rule_counterexamples(
         group_by=[],
         max_records=max_records,
     )
-    positive_label_set = set(positive_labels or DEFAULT_POSITIVE_LABELS)
-    negative_label_set = set(negative_labels or DEFAULT_NEGATIVE_LABELS)
+    positive_label_set = set(positive_labels)
+    negative_label_set = set(negative_labels)
     target_outcome_set = set(target_outcomes) if target_outcomes else None
 
     buckets: dict[str, list[dict[str, Any]]] = {
@@ -480,13 +485,13 @@ def build_rule_counterexamples(
 
         fired = _outcome_is_actionable(item.stored_outcome, target_outcome_set)
         if label_name in negative_label_set and fired and len(buckets["fired_but_negative"]) < sample_limit:
-            buckets["fired_but_negative"].append(_evidence_row(item))
+            buckets["fired_but_negative"].append(_evidence_row(item, include_label=True))
         if label_name in positive_label_set and not fired and len(buckets["missed_positive"]) < sample_limit:
-            buckets["missed_positive"].append(_evidence_row(item))
+            buckets["missed_positive"].append(_evidence_row(item, include_label=True))
         if stored_wrong and not proposed_wrong and len(buckets["candidate_fixes_existing"]) < sample_limit:
-            buckets["candidate_fixes_existing"].append(_evidence_row(item))
+            buckets["candidate_fixes_existing"].append(_evidence_row(item, include_label=True))
         if not stored_wrong and proposed_wrong and len(buckets["candidate_introduces_new_errors"]) < sample_limit:
-            buckets["candidate_introduces_new_errors"].append(_evidence_row(item))
+            buckets["candidate_introduces_new_errors"].append(_evidence_row(item, include_label=True))
 
     return {
         "rule_id": rule_id,

--- a/ezrules/backend/api_v2/main.py
+++ b/ezrules/backend/api_v2/main.py
@@ -19,6 +19,7 @@ from ezrules.backend.api_v2.auth.dependencies import (
     get_org_id_for_api_key,
 )
 from ezrules.backend.api_v2.routes import (
+    agent_tools,
     alerts,
     analytics,
     api_keys,
@@ -189,3 +190,6 @@ app.include_router(api_keys.router)
 
 # Runtime settings routes: /api/v2/settings/*
 app.include_router(settings.router)
+
+# Deterministic agent tool routes: /api/v2/agent-tools/*
+app.include_router(agent_tools.router)

--- a/ezrules/backend/api_v2/routes/agent_tools.py
+++ b/ezrules/backend/api_v2/routes/agent_tools.py
@@ -1,0 +1,85 @@
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ezrules.backend.agent_tools import build_blast_radius, build_rule_counterexamples
+from ezrules.backend.api_v2.auth.dependencies import (
+    get_current_active_user,
+    get_current_org_id,
+    get_db,
+    require_permission,
+)
+from ezrules.backend.api_v2.schemas.agent_tools import (
+    RuleBlastRadiusRequest,
+    RuleBlastRadiusResponse,
+    RuleCounterexamplesRequest,
+    RuleCounterexamplesResponse,
+)
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.core.rule import Rule
+from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.models.backend_core import User
+
+router = APIRouter(prefix="/api/v2/agent-tools", tags=["Agent Tools"])
+
+
+def _validate_rule_logic(db: Any, org_id: int, logic: str) -> None:
+    try:
+        Rule(rid="", logic=logic, list_values_provider=PersistentUserListManager(db, org_id))
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid proposed rule logic: {exc!s}",
+        ) from exc
+
+
+@router.post("/rule-blast-radius", response_model=RuleBlastRadiusResponse)
+def simulate_rule_blast_radius(
+    request: RuleBlastRadiusRequest,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_RULES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> RuleBlastRadiusResponse:
+    _validate_rule_logic(db, current_org_id, request.proposed_logic)
+    payload = build_blast_radius(
+        db,
+        org_id=current_org_id,
+        rule_id=request.rule_id,
+        proposed_logic=request.proposed_logic,
+        lookback_days=request.lookback_days,
+        group_by=request.group_by,
+        sample_limit=request.sample_limit,
+        max_records=request.max_records,
+    )
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+    return RuleBlastRadiusResponse.model_validate(payload)
+
+
+@router.post("/rule-counterexamples", response_model=RuleCounterexamplesResponse)
+def find_rule_counterexamples(
+    request: RuleCounterexamplesRequest,
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_RULES)),
+    __: None = Depends(require_permission(PermissionAction.VIEW_LABELS)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> RuleCounterexamplesResponse:
+    if request.proposed_logic is not None:
+        _validate_rule_logic(db, current_org_id, request.proposed_logic)
+    payload = build_rule_counterexamples(
+        db,
+        org_id=current_org_id,
+        rule_id=request.rule_id,
+        proposed_logic=request.proposed_logic,
+        lookback_days=request.lookback_days,
+        positive_labels=request.positive_labels,
+        negative_labels=request.negative_labels,
+        target_outcomes=request.target_outcomes,
+        sample_limit=request.sample_limit,
+        max_records=request.max_records,
+    )
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
+    return RuleCounterexamplesResponse.model_validate(payload)

--- a/ezrules/backend/api_v2/schemas/agent_tools.py
+++ b/ezrules/backend/api_v2/schemas/agent_tools.py
@@ -17,8 +17,8 @@ class AgentToolEvidenceEvent(BaseModel):
 class AgentToolGroupDelta(BaseModel):
     group: dict[str, Any]
     total_records: int
-    changed_decision_count: int
-    changed_decision_rate: float
+    changed_rule_outcome_count: int
+    changed_rule_outcome_rate: float
     stored_result: dict[str, int]
     proposed_result: dict[str, int]
     outcome_delta: dict[str, int]
@@ -30,7 +30,7 @@ class RuleBlastRadiusRequest(BaseModel):
     lookback_days: int = Field(default=30, ge=1, le=365)
     group_by: list[str] = Field(default_factory=list, max_length=5)
     sample_limit: int = Field(default=20, ge=1, le=100)
-    max_records: int = Field(default=10_000, ge=1, le=100_000)
+    max_records: int = Field(default=1_000, ge=1, le=100_000)
 
 
 class RuleBlastRadiusResponse(BaseModel):
@@ -42,8 +42,8 @@ class RuleBlastRadiusResponse(BaseModel):
     stored_result: dict[str, int]
     proposed_result: dict[str, int]
     outcome_delta: dict[str, int]
-    changed_decision_count: int
-    changed_decision_rate: float
+    changed_rule_outcome_count: int
+    changed_rule_outcome_rate: float
     group_deltas: list[AgentToolGroupDelta]
     flipped_events: list[AgentToolEvidenceEvent]
     warnings: list[str] = Field(default_factory=list)
@@ -60,7 +60,7 @@ class RuleCounterexamplesRequest(BaseModel):
         description="Optional outcome names that count as an actionable rule fire",
     )
     sample_limit: int = Field(default=20, ge=1, le=100)
-    max_records: int = Field(default=10_000, ge=1, le=100_000)
+    max_records: int = Field(default=1_000, ge=1, le=100_000)
 
 
 class RuleCounterexampleBuckets(BaseModel):

--- a/ezrules/backend/api_v2/schemas/agent_tools.py
+++ b/ezrules/backend/api_v2/schemas/agent_tools.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AgentToolEvidenceEvent(BaseModel):
+    transaction_id: str
+    event_version: int
+    evaluation_decision_id: int
+    label_name: str | None = None
+    stored_outcome: str | None = None
+    proposed_outcome: str | None = None
+    group: dict[str, Any] = Field(default_factory=dict)
+    event_data: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentToolGroupDelta(BaseModel):
+    group: dict[str, Any]
+    total_records: int
+    changed_decision_count: int
+    changed_decision_rate: float
+    stored_result: dict[str, int]
+    proposed_result: dict[str, int]
+    outcome_delta: dict[str, int]
+
+
+class RuleBlastRadiusRequest(BaseModel):
+    rule_id: int = Field(..., description="Existing rule ID to compare against")
+    proposed_logic: str = Field(..., min_length=1, description="Candidate rule logic")
+    lookback_days: int = Field(default=30, ge=1, le=365)
+    group_by: list[str] = Field(default_factory=list, max_length=5)
+    sample_limit: int = Field(default=20, ge=1, le=100)
+    max_records: int = Field(default=10_000, ge=1, le=100_000)
+
+
+class RuleBlastRadiusResponse(BaseModel):
+    rule_id: int
+    lookback_days: int
+    total_records: int
+    eligible_records: int
+    skipped_records: int
+    stored_result: dict[str, int]
+    proposed_result: dict[str, int]
+    outcome_delta: dict[str, int]
+    changed_decision_count: int
+    changed_decision_rate: float
+    group_deltas: list[AgentToolGroupDelta]
+    flipped_events: list[AgentToolEvidenceEvent]
+    warnings: list[str] = Field(default_factory=list)
+
+
+class RuleCounterexamplesRequest(BaseModel):
+    rule_id: int = Field(..., description="Existing rule ID to inspect")
+    proposed_logic: str | None = Field(default=None, description="Optional candidate logic for fix/regression buckets")
+    lookback_days: int = Field(default=30, ge=1, le=365)
+    positive_labels: list[str] = Field(default_factory=lambda: ["FRAUD"])
+    negative_labels: list[str] = Field(default_factory=lambda: ["NORMAL", "LEGIT", "GENUINE"])
+    target_outcomes: list[str] | None = Field(
+        default=None,
+        description="Optional outcome names that count as an actionable rule fire",
+    )
+    sample_limit: int = Field(default=20, ge=1, le=100)
+    max_records: int = Field(default=10_000, ge=1, le=100_000)
+
+
+class RuleCounterexampleBuckets(BaseModel):
+    fired_but_negative: list[AgentToolEvidenceEvent]
+    missed_positive: list[AgentToolEvidenceEvent]
+    candidate_fixes_existing: list[AgentToolEvidenceEvent]
+    candidate_introduces_new_errors: list[AgentToolEvidenceEvent]
+
+
+class RuleCounterexamplesResponse(BaseModel):
+    rule_id: int
+    lookback_days: int
+    total_records: int
+    eligible_records: int
+    skipped_records: int
+    positive_labels: list[str]
+    negative_labels: list[str]
+    target_outcomes: list[str] | None = None
+    buckets: RuleCounterexampleBuckets
+    warnings: list[str] = Field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.26.0"
+version = "1.27.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_api_v2_agent_tools.py
+++ b/tests/test_api_v2_agent_tools.py
@@ -1,0 +1,180 @@
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import Label, Organisation, Role, User
+from ezrules.models.backend_core import Rule as RuleModel
+from tests.canonical_helpers import add_served_decision
+
+
+@pytest.fixture(scope="function")
+def agent_tools_client(session):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    role = Role(
+        name="agent_tools_viewer",
+        description="Can use deterministic agent analysis tools",
+        o_id=int(org.o_id),
+    )
+    user = User(
+        email="agent-tools@example.com",
+        password="agent-tools-pass",
+        active=True,
+        fs_uniquifier="agent-tools@example.com",
+        o_id=int(org.o_id),
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    PermissionManager.grant_permission(role.id, PermissionAction.VIEW_RULES)
+    PermissionManager.grant_permission(role.id, PermissionAction.VIEW_LABELS)
+
+    token = create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[item.name for item in user.roles],
+        org_id=int(user.o_id),
+    )
+
+    with TestClient(app) as client:
+        client.test_data = {"token": token, "session": session, "org": org}  # type: ignore[attr-defined]
+        yield client
+
+
+@pytest.fixture(scope="function")
+def agent_tools_fixture(session):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    fraud_label = Label(label="FRAUD", o_id=int(org.o_id))
+    normal_label = Label(label="NORMAL", o_id=int(org.o_id))
+    session.add_all([fraud_label, normal_label])
+    session.commit()
+
+    rule = RuleModel(
+        rid="agent_tools_threshold",
+        logic="if $amount > 100:\n\treturn !HOLD",
+        description="Threshold rule for agent tool analysis",
+        o_id=int(org.o_id),
+    )
+    session.add(rule)
+    session.commit()
+
+    now = datetime.datetime.now(datetime.UTC)
+    records = [
+        ("agent_evt_1", 200, "US", fraud_label),
+        ("agent_evt_2", 130, "US", normal_label),
+        ("agent_evt_3", 80, "GB", normal_label),
+        ("agent_evt_4", 170, "GB", fraud_label),
+        ("agent_evt_5", 120, "GB", fraud_label),
+        ("agent_evt_6", 60, "US", fraud_label),
+    ]
+    for index, (transaction_id, amount, country, label) in enumerate(records):
+        add_served_decision(
+            session,
+            org_id=int(org.o_id),
+            transaction_id=transaction_id,
+            event_data={"amount": amount, "country": country},
+            evaluated_at=now - datetime.timedelta(minutes=index),
+            rule_results={int(rule.r_id): "HOLD"} if amount > 100 else {},
+            resolved_outcome="HOLD" if amount > 100 else None,
+            label=label,
+        )
+    session.commit()
+    return {"rule": rule}
+
+
+def test_rule_blast_radius_returns_grouped_flips(agent_tools_client, agent_tools_fixture):
+    token = agent_tools_client.test_data["token"]
+    rule = agent_tools_fixture["rule"]
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": "if $amount > 150:\n\treturn !HOLD",
+            "group_by": ["country"],
+            "sample_limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["eligible_records"] == 6
+    assert data["skipped_records"] == 0
+    assert data["stored_result"] == {"HOLD": 4, "NO_OUTCOME": 2}
+    assert data["proposed_result"] == {"HOLD": 2, "NO_OUTCOME": 4}
+    assert data["outcome_delta"] == {"HOLD": -2, "NO_OUTCOME": 2}
+    assert data["changed_decision_count"] == 2
+    assert data["changed_decision_rate"] == pytest.approx(0.3333, abs=1e-4)
+    assert {event["transaction_id"] for event in data["flipped_events"]} == {"agent_evt_2", "agent_evt_5"}
+
+    groups = {row["group"]["country"]: row for row in data["group_deltas"]}
+    assert groups["US"]["changed_decision_count"] == 1
+    assert groups["GB"]["changed_decision_count"] == 1
+
+
+def test_rule_counterexamples_returns_fix_and_regression_buckets(agent_tools_client, agent_tools_fixture):
+    token = agent_tools_client.test_data["token"]
+    rule = agent_tools_fixture["rule"]
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-counterexamples",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": "if $amount > 150:\n\treturn !HOLD",
+            "positive_labels": ["FRAUD"],
+            "negative_labels": ["NORMAL"],
+            "target_outcomes": ["HOLD"],
+            "sample_limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    buckets = response.json()["buckets"]
+    assert {event["transaction_id"] for event in buckets["fired_but_negative"]} == {"agent_evt_2"}
+    assert {event["transaction_id"] for event in buckets["missed_positive"]} == {"agent_evt_6"}
+    assert {event["transaction_id"] for event in buckets["candidate_fixes_existing"]} == {"agent_evt_2"}
+    assert {event["transaction_id"] for event in buckets["candidate_introduces_new_errors"]} == {"agent_evt_5"}
+
+
+def test_agent_tools_require_label_permission_for_counterexamples(session, agent_tools_fixture):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    role = Role(name="agent_tools_rule_only", description="Can view rules only", o_id=int(org.o_id))
+    user = User(
+        email="agent-tools-rule-only@example.com",
+        password="agent-tools-pass",
+        active=True,
+        fs_uniquifier="agent-tools-rule-only@example.com",
+        o_id=int(org.o_id),
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    PermissionManager.grant_permission(role.id, PermissionAction.VIEW_RULES)
+
+    token = create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[item.name for item in user.roles],
+        org_id=int(user.o_id),
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/agent-tools/rule-counterexamples",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"rule_id": int(agent_tools_fixture["rule"].r_id)},
+        )
+
+    assert response.status_code == 403

--- a/tests/test_api_v2_agent_tools.py
+++ b/tests/test_api_v2_agent_tools.py
@@ -111,13 +111,13 @@ def test_rule_blast_radius_returns_grouped_flips(agent_tools_client, agent_tools
     assert data["stored_result"] == {"HOLD": 4, "NO_OUTCOME": 2}
     assert data["proposed_result"] == {"HOLD": 2, "NO_OUTCOME": 4}
     assert data["outcome_delta"] == {"HOLD": -2, "NO_OUTCOME": 2}
-    assert data["changed_decision_count"] == 2
-    assert data["changed_decision_rate"] == pytest.approx(0.3333, abs=1e-4)
+    assert data["changed_rule_outcome_count"] == 2
+    assert data["changed_rule_outcome_rate"] == pytest.approx(0.3333, abs=1e-4)
     assert {event["transaction_id"] for event in data["flipped_events"]} == {"agent_evt_2", "agent_evt_5"}
 
     groups = {row["group"]["country"]: row for row in data["group_deltas"]}
-    assert groups["US"]["changed_decision_count"] == 1
-    assert groups["GB"]["changed_decision_count"] == 1
+    assert groups["US"]["changed_rule_outcome_count"] == 1
+    assert groups["GB"]["changed_rule_outcome_count"] == 1
 
 
 def test_rule_counterexamples_returns_fix_and_regression_buckets(agent_tools_client, agent_tools_fixture):
@@ -178,3 +178,115 @@ def test_agent_tools_require_label_permission_for_counterexamples(session, agent
         )
 
     assert response.status_code == 403
+
+
+def test_rule_blast_radius_ignores_superseded_transaction_versions(
+    session,
+    agent_tools_client,
+    agent_tools_fixture,
+):
+    token = agent_tools_client.test_data["token"]
+    org = agent_tools_client.test_data["org"]
+    rule = agent_tools_fixture["rule"]
+    normal_label = session.query(Label).filter(Label.o_id == int(org.o_id), Label.label == "NORMAL").one()
+    now = datetime.datetime.now(datetime.UTC)
+
+    add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="agent_rescore",
+        event_data={"amount": 130, "country": "US"},
+        evaluated_at=now - datetime.timedelta(minutes=20),
+        rule_results={int(rule.r_id): "HOLD"},
+        resolved_outcome="HOLD",
+        label=normal_label,
+    )
+    add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="agent_rescore",
+        event_data={"amount": 80, "country": "US"},
+        evaluated_at=now - datetime.timedelta(minutes=1),
+        rule_results={},
+        resolved_outcome=None,
+        label=normal_label,
+    )
+    session.commit()
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": "if $amount > 150:\n\treturn !HOLD",
+            "sample_limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["eligible_records"] == 7
+    assert data["changed_rule_outcome_count"] == 2
+    assert {event["transaction_id"] for event in data["flipped_events"]} == {"agent_evt_2", "agent_evt_5"}
+
+
+def test_rule_blast_radius_returns_404_when_rule_not_found(agent_tools_client):
+    token = agent_tools_client.test_data["token"]
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": 999_999,
+            "proposed_logic": "return !HOLD",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Rule not found"
+
+
+def test_rule_blast_radius_rejects_invalid_proposed_logic(agent_tools_client, agent_tools_fixture):
+    token = agent_tools_client.test_data["token"]
+    rule = agent_tools_fixture["rule"]
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": "if $amount >",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Invalid proposed rule logic" in response.json()["detail"]
+
+
+def test_rule_blast_radius_handles_empty_replay_window(session, agent_tools_client):
+    token = agent_tools_client.test_data["token"]
+    org = agent_tools_client.test_data["org"]
+    rule = RuleModel(
+        rid="agent_tools_empty_window",
+        logic="if $amount > 100:\n\treturn !HOLD",
+        description="Rule without recent decisions",
+        o_id=int(org.o_id),
+    )
+    session.add(rule)
+    session.commit()
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": "if $amount > 150:\n\treturn !HOLD",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_records"] == 0
+    assert data["eligible_records"] == 0
+    assert data["changed_rule_outcome_count"] == 0
+    assert data["flipped_events"] == []

--- a/tests/test_api_v2_agent_tools.py
+++ b/tests/test_api_v2_agent_tools.py
@@ -171,12 +171,24 @@ def test_agent_tools_require_label_permission_for_counterexamples(session, agent
     )
 
     with TestClient(app) as client:
+        blast_response = client.post(
+            "/api/v2/agent-tools/rule-blast-radius",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "rule_id": int(agent_tools_fixture["rule"].r_id),
+                "proposed_logic": "if $amount > 150:\n\treturn !HOLD",
+                "sample_limit": 10,
+            },
+        )
         response = client.post(
             "/api/v2/agent-tools/rule-counterexamples",
             headers={"Authorization": f"Bearer {token}"},
             json={"rule_id": int(agent_tools_fixture["rule"].r_id)},
         )
 
+    assert blast_response.status_code == 200
+    assert blast_response.json()["flipped_events"]
+    assert all(event["label_name"] is None for event in blast_response.json()["flipped_events"])
     assert response.status_code == 403
 
 
@@ -290,3 +302,68 @@ def test_rule_blast_radius_handles_empty_replay_window(session, agent_tools_clie
     assert data["eligible_records"] == 0
     assert data["changed_rule_outcome_count"] == 0
     assert data["flipped_events"] == []
+
+
+def test_rule_blast_radius_skips_runtime_key_errors(session, agent_tools_client):
+    token = agent_tools_client.test_data["token"]
+    org = agent_tools_client.test_data["org"]
+    rule = RuleModel(
+        rid="agent_tools_runtime_key_error",
+        logic='if t["missing"]:\n\treturn !HOLD',
+        description="Rule with dynamic missing-key access",
+        o_id=int(org.o_id),
+    )
+    session.add(rule)
+    session.commit()
+    add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="agent_missing_key",
+        event_data={"amount": 200},
+        rule_results={},
+        resolved_outcome=None,
+    )
+    session.commit()
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": 'if t["missing"]:\n\treturn !HOLD',
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_records"] == 1
+    assert data["eligible_records"] == 0
+    assert data["skipped_records"] == 1
+    assert data["warnings"] == ["Records missing referenced fields were skipped: missing (1)."]
+
+
+def test_rule_counterexamples_respects_empty_label_sets(agent_tools_client, agent_tools_fixture):
+    token = agent_tools_client.test_data["token"]
+    rule = agent_tools_fixture["rule"]
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-counterexamples",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "positive_labels": [],
+            "negative_labels": [],
+            "sample_limit": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["positive_labels"] == []
+    assert data["negative_labels"] == []
+    assert data["buckets"] == {
+        "fired_but_negative": [],
+        "missed_positive": [],
+        "candidate_fixes_existing": [],
+        "candidate_introduces_new_errors": [],
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.26.0"
+version = "1.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Add deterministic /api/v2/agent-tools endpoints for rule blast-radius analysis and labeled counterexample mining
- Reuse existing rule compilation, normalization, labels, feature resolution, and served-decision ledgers
- Document the new API surface and bump the release line to v1.27.0

## Local verification
- EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_0ef9_agent_tools EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 uv run pytest -q tests/test_api_v2_agent_tools.py
- EZRULES_DB_ENDPOINT=postgresql://postgres:root@localhost:5432/tests_e2e_0ef9_agent_tools EZRULES_TESTING=true EZRULES_APP_SECRET=test-secret EZRULES_ORG_ID=1 uv run poe check
- uv run mkdocs build --strict

## Notes
- README screenshots/GIFs reviewed; no UI surface changed, so no image updates were needed.
- estimate_rule_param_gain is intentionally left for the next milestone because its metric contract is more design-sensitive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Synchronous replays over up to 100k decisions can load the API and DB; counterexamples expose labeled transaction snippets to callers with VIEW_RULES/VIEW_LABELS.
> 
> **Overview**
> Adds **v1.27.0** `/api/v2/agent-tools` endpoints so agents can pull bounded rule evidence instead of open DB access.
> 
> **`POST /rule-blast-radius`** replays recent **current served** decisions (default 1,000 / 30 days), re-runs **stored vs proposed** logic through the same compile/normalize/user-list/feature paths as live analysis, and returns outcome deltas, optional `group_by` flip rates, sample flipped events, skip counts, and warnings. **`POST /rule-counterexamples`** (also **`VIEW_LABELS`**) buckets labeled traffic into false positives, missed positives, candidate fixes, and candidate regressions, with optional proposed logic for fix/regression buckets.
> 
> New `ezrules/backend/agent_tools.py` implements the replay engine; routes validate proposed logic before execution. Docs and release notes describe replay semantics (e.g. stored logic is today’s DB version, flips are single-rule only). API tests cover permissions, superseded versions, empty windows, and skip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b422bf0247ce10722256699346f79ecc300b2135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->