### PR TITLE
Preserve user-role permission boundary during onboarding

### DIFF
--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -341,8 +341,8 @@ AI authoring settings notes:
 |---|---|---|---|
 | `GET` | `/api/v2/users` | Bearer + permission | List users in the caller's org |
 | `GET` | `/api/v2/users/{user_id}` | Bearer + permission | Get user details in the caller's org |
-| `POST` | `/api/v2/users` | Bearer + permission | Create user in the caller's org |
-| `POST` | `/api/v2/users/invite` | Bearer + permission | Invite user into the caller's org and send activation link |
+| `POST` | `/api/v2/users` | Bearer + `CREATE_USER` | Create user in the caller's org |
+| `POST` | `/api/v2/users/invite` | Bearer + `CREATE_USER` | Invite user into the caller's org and send activation link |
 | `PUT` | `/api/v2/users/{user_id}` | Bearer + permission | Update user in the caller's org |
 | `DELETE` | `/api/v2/users/{user_id}` | Bearer + permission | Delete user in the caller's org |
 | `POST` | `/api/v2/users/{user_id}/roles` | Bearer + permission | Assign role to user in the caller's org (cross-org role IDs return `404`) |
@@ -355,6 +355,8 @@ AI authoring settings notes:
 | `DELETE` | `/api/v2/roles/{role_id}` | Bearer + permission | Delete role from the caller's org |
 | `GET` | `/api/v2/roles/{role_id}/permissions` | Bearer + permission | Get role permissions in the caller's org |
 | `PUT` | `/api/v2/roles/{role_id}/permissions` | Bearer + permission | Update role permissions in the caller's org |
+
+User creation and invitation do not accept initial role assignments. Assign roles after the account exists with `POST /api/v2/users/{user_id}/roles`, which requires `MANAGE_USER_ROLES`.
 
 ### User Lists
 

--- a/docs/user-guide/admin-guide.md
+++ b/docs/user-guide/admin-guide.md
@@ -54,7 +54,7 @@ uv run ezrules bootstrap-org --name your-org --admin-email admin@example.com --a
 
 1. Open **Security** for user management
 2. Open **Settings** for role/permission management
-3. Use **Invite User** for standard onboarding (email + optional role)
+3. Use **Invite User** for standard onboarding, then assign roles through the dedicated role controls
 4. Apply least-privilege role assignments
 
 ### API endpoints

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,9 @@
 # What's New
 
+## v1.28.1
+
+* **User role assignment permission boundary**: Creating or inviting users no longer accepts `role_ids`; callers must create or invite the account first and then use the dedicated role-assignment endpoint with `MANAGE_USER_ROLES`.
+
 ## v1.28.0
 
 * **Case management inbox**: Non-neutral live evaluation decisions now create durable case work items linked to the canonical evaluation ledger, with a new **Cases** page for reviewing and resolving cases.

--- a/ezrules/backend/api_v2/routes/users.py
+++ b/ezrules/backend/api_v2/routes/users.py
@@ -198,19 +198,6 @@ def create_user(
         o_id=current_org_id,
     )
 
-    # Assign roles if provided
-    if user_data.role_ids:
-        roles = db.query(Role).filter(Role.o_id == current_org_id, Role.id.in_(user_data.role_ids)).all()
-        if len(roles) != len(user_data.role_ids):
-            found_ids = {r.id for r in roles}
-            missing_ids = [rid for rid in user_data.role_ids if rid not in found_ids]
-            return UserMutationResponse(
-                success=False,
-                message="Some roles not found",
-                error=f"Role IDs not found: {missing_ids}",
-            )
-        new_user.roles = roles
-
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
@@ -252,6 +239,7 @@ def invite_user(
     Creates an inactive user when needed and sends a one-time invite email.
     """
     email = str(invite_data.email).strip().lower()
+
     existing_user = db.query(User).filter(User.email == email).first()
 
     if existing_user and int(existing_user.o_id) != current_org_id:
@@ -281,20 +269,6 @@ def invite_user(
         db.flush()
     else:
         target_user.active = False
-
-    if invite_data.role_ids:
-        roles = db.query(Role).filter(Role.o_id == current_org_id, Role.id.in_(invite_data.role_ids)).all()
-        if len(roles) != len(invite_data.role_ids):
-            found_ids = {int(r.id) for r in roles}
-            missing_ids = [rid for rid in invite_data.role_ids if rid not in found_ids]
-            return UserInviteResponse(
-                success=False,
-                message="Some roles not found",
-                error=f"Role IDs not found: {missing_ids}",
-            )
-        for role in roles:
-            if role not in target_user.roles:
-                target_user.roles.append(role)
 
     now = now_utc_naive()
     db.query(Invitation).filter(

--- a/ezrules/backend/api_v2/schemas/users.py
+++ b/ezrules/backend/api_v2/schemas/users.py
@@ -7,7 +7,7 @@ Pydantic automatically validates incoming data and serializes outgoing data.
 
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 # =============================================================================
 # REQUEST SCHEMAS
@@ -19,33 +19,31 @@ class UserCreate(BaseModel):
 
     email: EmailStr = Field(..., description="User's email address")
     password: str = Field(..., min_length=6, description="User's password (min 6 characters)")
-    role_ids: list[int] | None = Field(default=None, description="Optional list of role IDs to assign")
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
             "example": {
                 "email": "newuser@example.com",
                 "password": "securepassword123",
-                "role_ids": [1, 2],
             }
-        }
-    }
+        },
+    )
 
 
 class UserInvite(BaseModel):
     """Schema for inviting a new user."""
 
     email: EmailStr = Field(..., description="User's email address")
-    role_ids: list[int] | None = Field(default=None, description="Optional list of role IDs to assign")
 
-    model_config = {
-        "json_schema_extra": {
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
             "example": {
                 "email": "newuser@example.com",
-                "role_ids": [1, 2],
             }
-        }
-    }
+        },
+    )
 
 
 class UserUpdate(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.0"
+version = "1.28.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_api_v2_user_role_creation_permissions.py
+++ b/tests/test_api_v2_user_role_creation_permissions.py
@@ -1,0 +1,114 @@
+"""Regression coverage for keeping role assignment out of onboarding flows."""
+
+import bcrypt
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.api_v2.routes import users as users_routes
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import Invitation, Role, User
+
+
+def _create_user_management_token(session, *, email: str, permissions: list[PermissionAction]) -> str:
+    hashed_password = bcrypt.hashpw("permissionpass".encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    role = Role(name=f"role_{email.split('@')[0]}", description="Scoped user management role", o_id=1)
+    user = User(
+        email=email,
+        password=hashed_password,
+        active=True,
+        fs_uniquifier=email,
+        o_id=1,
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    for permission in permissions:
+        PermissionManager.grant_permission(int(role.id), permission)
+
+    return create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[str(role.name)],
+        org_id=int(user.o_id),
+    )
+
+
+def test_create_user_rejects_role_ids_field(session):
+    """Account creation must not accept initial role assignments."""
+    token = _create_user_management_token(
+        session,
+        email="create-only@example.com",
+        permissions=[PermissionAction.CREATE_USER],
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/users",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "email": "blocked-create@example.com",
+                "password": "password123",
+                "role_ids": [1],
+            },
+        )
+
+    assert response.status_code == 422
+    assert session.query(User).filter(User.email == "blocked-create@example.com").first() is None
+
+
+def test_create_user_without_role_ids_allowed_with_create_user_only(session):
+    """CREATE_USER remains sufficient for creating an account without assigning roles."""
+    token = _create_user_management_token(
+        session,
+        email="create-only-without-roles@example.com",
+        permissions=[PermissionAction.CREATE_USER],
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/users",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "email": "allowed-create@example.com",
+                "password": "password123",
+            },
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["success"] is True
+    assert data["user"]["email"] == "allowed-create@example.com"
+    assert data["user"]["roles"] == []
+
+
+def test_invite_user_rejects_role_ids_field(session, monkeypatch):
+    """Invitations must not accept initial role assignments."""
+    token = _create_user_management_token(
+        session,
+        email="invite-create-only@example.com",
+        permissions=[PermissionAction.CREATE_USER],
+    )
+
+    def fail_if_email_sent(email: str, raw_token: str) -> None:
+        raise AssertionError("invite email should not be sent")
+
+    monkeypatch.setattr(users_routes, "send_invitation_email", fail_if_email_sent)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/users/invite",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "email": "blocked-invite@example.com",
+                "role_ids": [1],
+            },
+        )
+
+    assert response.status_code == 422
+    assert session.query(User).filter(User.email == "blocked-invite@example.com").first() is None
+    assert session.query(Invitation).filter(Invitation.email == "blocked-invite@example.com").first() is None

--- a/tests/test_api_v2_users.py
+++ b/tests/test_api_v2_users.py
@@ -226,9 +226,10 @@ class TestCreateUser:
         assert data["user"]["email"] == "newuser@example.com"
         assert data["user"]["active"] is True
 
-    def test_create_user_with_roles(self, users_test_client, sample_role):
-        """Should create user with assigned roles."""
+    def test_create_user_rejects_role_ids(self, users_test_client, sample_role):
+        """Role assignment must use the dedicated role-assignment endpoint."""
         token = users_test_client.test_data["token"]
+        session = users_test_client.test_data["session"]
 
         response = users_test_client.post(
             "/api/v2/users",
@@ -240,11 +241,8 @@ class TestCreateUser:
             },
         )
 
-        assert response.status_code == 201
-        data = response.json()
-        assert data["success"] is True
-        assert len(data["user"]["roles"]) == 1
-        assert data["user"]["roles"][0]["name"] == "test_role"
+        assert response.status_code == 422
+        assert session.query(User).filter(User.email == "withroles@example.com").first() is None
 
     def test_create_user_duplicate_email(self, users_test_client, sample_user):
         """Should return error for duplicate email."""
@@ -294,9 +292,10 @@ class TestCreateUser:
 
         assert response.status_code == 422
 
-    def test_create_user_invalid_role_id(self, users_test_client):
-        """Should return error for non-existent role ID."""
+    def test_create_user_rejects_invalid_role_ids_field(self, users_test_client):
+        """Unknown role IDs are not processed by the create-user endpoint."""
         token = users_test_client.test_data["token"]
+        session = users_test_client.test_data["session"]
 
         response = users_test_client.post(
             "/api/v2/users",
@@ -308,10 +307,8 @@ class TestCreateUser:
             },
         )
 
-        assert response.status_code == 201
-        data = response.json()
-        assert data["success"] is False
-        assert "not found" in data["error"]
+        assert response.status_code == 422
+        assert session.query(User).filter(User.email == "invalidrole@example.com").first() is None
 
 
 class TestInviteUser:

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Remove initial role assignment from user create/invite flows entirely; these request bodies no longer accept role_ids.
- Keep CREATE_USER scoped to account creation/onboarding only.
- Require role grants to use the dedicated /api/v2/users/{user_id}/roles endpoint guarded by MANAGE_USER_ROLES.
- Add regression coverage for rejected create/invite role_ids payloads and keep the create-without-roles path covered.
- Keep v1.28.1 release notes and API/admin docs aligned with the clean-slate contract.

## Verification
- uv run poe check
- Local pytest not run per repository policy; GitHub Actions PR checks are the test source of truth.

Asana: https://app.asana.com/1/106415343104513/project/1211443964065287/task/1213897153566596

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for integrations that set roles during create/invite; improves least-privilege by separating account provisioning from role assignment.
> 
> **Overview**
> **User onboarding no longer accepts `role_ids`.** `POST /api/v2/users` and `POST /api/v2/users/invite` only take email/password (or email for invite); `UserCreate` and `UserInvite` use `extra="forbid"`, so payloads that include `role_ids` fail with **422** and no user or invitation is created. Role assignment is removed from the create/invite handlers—callers must use `POST /api/v2/users/{user_id}/roles` with **`MANAGE_USER_ROLES`**.
> 
> **`CREATE_USER` alone** is still enough to create or invite accounts with empty roles. Docs (manager API, admin guide, what's new) and version **1.28.1** reflect the contract; tests assert rejection of `role_ids` and successful create without roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5531c57b3fca3c094748ce5be8959107d14661ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->