### PR TITLE
Harden refresh token session storage

### DIFF
--- a/alembic/versions/20260707_0034_hash_refresh_sessions.py
+++ b/alembic/versions/20260707_0034_hash_refresh_sessions.py
@@ -1,0 +1,58 @@
+"""Hash stored refresh session tokens.
+
+Revision ID: 20260707_0034
+Revises: 20260630_0033
+Create Date: 2026-07-07
+"""
+
+from __future__ import annotations
+
+import hashlib
+import string
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260707_0034"
+down_revision: str | None = "20260630_0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sha256_hex(value: str) -> bool:
+    return len(value) == 64 and all(char in string.hexdigits for char in value)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    session_rows = connection.execute(sa.text("SELECT id, refresh_token FROM user_session")).mappings().all()
+
+    for row in session_rows:
+        raw_value = row["refresh_token"]
+        if _is_sha256_hex(raw_value):
+            continue
+        token_hash = hashlib.sha256(raw_value.encode("utf-8")).hexdigest()
+        connection.execute(
+            sa.text("UPDATE user_session SET refresh_token = :token_hash WHERE id = :session_id"),
+            {"token_hash": token_hash, "session_id": row["id"]},
+        )
+
+    op.alter_column(
+        "user_session",
+        "refresh_token",
+        existing_type=sa.String(length=2048),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "user_session",
+        "refresh_token",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=2048),
+        existing_nullable=False,
+    )

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -41,7 +41,15 @@ curl -X POST http://localhost:8888/api/v2/auth/login \
 
 ### Session revocation (logout)
 
-Refresh tokens are tracked server-side in the `user_session` table. To revoke a session:
+Refresh tokens are tracked server-side in the `user_session` table as SHA-256 hashes. Browser logins also receive the refresh token in an HttpOnly `ezrules_refresh_token` cookie, so browser logout can revoke the session without exposing the refresh token to JavaScript:
+
+```bash
+curl -X POST http://localhost:8888/api/v2/auth/logout \
+  -H "Authorization: Bearer <access_token>" \
+  --cookie "ezrules_refresh_token=<refresh_token>"
+```
+
+API clients can still revoke a session by sending the refresh token in the request body:
 
 ```bash
 curl -X POST http://localhost:8888/api/v2/auth/logout \
@@ -50,11 +58,11 @@ curl -X POST http://localhost:8888/api/v2/auth/logout \
   -d '{"refresh_token": "<refresh_token>"}'
 ```
 
-After a successful logout, the refresh token is deleted from the database and any subsequent attempt to use it returns `401`. Access tokens remain valid until their 30-minute expiry (stateless JWTs cannot be revoked).
+After a successful logout, the refresh token hash is deleted from the database and any subsequent attempt to use that refresh token returns `401`. Access tokens remain valid until their 30-minute expiry (stateless JWTs cannot be revoked).
 
 ### Refresh token rotation
 
-Each call to `POST /api/v2/auth/refresh` deletes the submitted refresh token and issues a new one. A refresh token can only be used once. Presenting a previously-used or revoked refresh token returns `401 Session not found or already revoked`.
+Each call to `POST /api/v2/auth/refresh` deletes the stored hash for the submitted refresh token and issues a new one. Browser clients can refresh by sending the HttpOnly cookie; API clients can continue sending `{"refresh_token": "<refresh_token>"}`. A refresh token can only be used once. Presenting a previously-used or revoked refresh token returns `401 Session not found or already revoked`.
 
 ## Endpoint Map
 
@@ -66,8 +74,8 @@ Each call to `POST /api/v2/auth/refresh` deletes the submitted refresh token and
 | `POST` | `/api/v2/auth/accept-invite` | No | Accept invitation token and set password |
 | `POST` | `/api/v2/auth/forgot-password` | No | Send password reset email (always generic response) |
 | `POST` | `/api/v2/auth/reset-password` | No | Reset password using one-time token |
-| `POST` | `/api/v2/auth/refresh` | No (refresh token in body) | Exchanges refresh token (rotation — one-time use) |
-| `POST` | `/api/v2/auth/logout` | Bearer + refresh token in body | Revokes refresh token server-side |
+| `POST` | `/api/v2/auth/refresh` | No (refresh cookie or body) | Exchanges refresh token (rotation — one-time use) |
+| `POST` | `/api/v2/auth/logout` | Bearer + refresh cookie or body | Revokes refresh token server-side |
 | `GET` | `/api/v2/auth/me` | Bearer | Current user profile, including effective permission names |
 
 ### Rules

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -41,26 +41,18 @@ curl -X POST http://localhost:8888/api/v2/auth/login \
 
 ### Session revocation (logout)
 
-Refresh tokens are tracked server-side in the `user_session` table as SHA-256 hashes. Browser logins also receive the refresh token in an HttpOnly `ezrules_refresh_token` cookie, so browser logout can revoke the session without exposing the refresh token to JavaScript:
+Refresh tokens are tracked server-side in the `user_session` table as SHA-256 hashes. Logins receive the refresh token only in an HttpOnly `ezrules_refresh_token` cookie, so logout can revoke the session without exposing the refresh token to JavaScript:
 
 ```bash
 curl -X POST http://localhost:8888/api/v2/auth/logout \
   --cookie "ezrules_refresh_token=<refresh_token>"
 ```
 
-API clients can still revoke a session by sending the refresh token in the request body:
-
-```bash
-curl -X POST http://localhost:8888/api/v2/auth/logout \
-  -H "Content-Type: application/json" \
-  -d '{"refresh_token": "<refresh_token>"}'
-```
-
 After a successful logout, the refresh token hash is deleted from the database and any subsequent attempt to use that refresh token returns `401`. Access tokens remain valid until their 30-minute expiry (stateless JWTs cannot be revoked).
 
 ### Refresh token rotation
 
-Each call to `POST /api/v2/auth/refresh` deletes the stored hash for the submitted refresh token and issues a new one. Browser clients can refresh by sending the HttpOnly cookie; API clients can continue sending `{"refresh_token": "<refresh_token>"}`. A refresh token can only be used once. Presenting a previously-used or revoked refresh token returns `401 Session not found or already revoked`.
+Each call to `POST /api/v2/auth/refresh` deletes the stored hash for the refresh token in the HttpOnly cookie and sets a new refresh cookie. Refresh tokens are not returned in JSON response bodies and cannot be supplied in request bodies. A refresh token can only be used once. Presenting a previously-used or revoked refresh token returns `401 Session not found or already revoked`.
 
 ## Endpoint Map
 
@@ -72,8 +64,8 @@ Each call to `POST /api/v2/auth/refresh` deletes the stored hash for the submitt
 | `POST` | `/api/v2/auth/accept-invite` | No | Accept invitation token and set password |
 | `POST` | `/api/v2/auth/forgot-password` | No | Send password reset email (always generic response) |
 | `POST` | `/api/v2/auth/reset-password` | No | Reset password using one-time token |
-| `POST` | `/api/v2/auth/refresh` | No (refresh cookie or body) | Exchanges refresh token (rotation — one-time use) |
-| `POST` | `/api/v2/auth/logout` | Refresh cookie or body | Revokes refresh token server-side |
+| `POST` | `/api/v2/auth/refresh` | Refresh cookie | Exchanges refresh token (rotation — one-time use) |
+| `POST` | `/api/v2/auth/logout` | Refresh cookie | Revokes refresh token server-side |
 | `GET` | `/api/v2/auth/me` | Bearer | Current user profile, including effective permission names |
 
 ### Rules

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -45,7 +45,6 @@ Refresh tokens are tracked server-side in the `user_session` table as SHA-256 ha
 
 ```bash
 curl -X POST http://localhost:8888/api/v2/auth/logout \
-  -H "Authorization: Bearer <access_token>" \
   --cookie "ezrules_refresh_token=<refresh_token>"
 ```
 
@@ -53,7 +52,6 @@ API clients can still revoke a session by sending the refresh token in the reque
 
 ```bash
 curl -X POST http://localhost:8888/api/v2/auth/logout \
-  -H "Authorization: Bearer <access_token>" \
   -H "Content-Type: application/json" \
   -d '{"refresh_token": "<refresh_token>"}'
 ```
@@ -75,7 +73,7 @@ Each call to `POST /api/v2/auth/refresh` deletes the stored hash for the submitt
 | `POST` | `/api/v2/auth/forgot-password` | No | Send password reset email (always generic response) |
 | `POST` | `/api/v2/auth/reset-password` | No | Reset password using one-time token |
 | `POST` | `/api/v2/auth/refresh` | No (refresh cookie or body) | Exchanges refresh token (rotation — one-time use) |
-| `POST` | `/api/v2/auth/logout` | Bearer + refresh cookie or body | Revokes refresh token server-side |
+| `POST` | `/api/v2/auth/logout` | Refresh cookie or body | Revokes refresh token server-side |
 | `GET` | `/api/v2/auth/me` | Bearer | Current user profile, including effective permission names |
 
 ### Rules

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -4,8 +4,8 @@
 
 * **Hashed refresh sessions**: Refresh token sessions are now stored as SHA-256 hashes in `user_session`, including a migration that hashes any existing plaintext session rows during upgrade.
 * **HttpOnly browser refresh cookie**: Browser login and refresh flows now set the long-lived refresh token in an HttpOnly cookie and no longer persist it in frontend `localStorage`.
-* **Compatible refresh API**: API clients can still send refresh tokens in request bodies, while browser refresh/logout can use the cookie-backed flow.
-* **Refresh-token logout hardening**: Logout now revokes directly from the refresh token or HttpOnly cookie, so expired access tokens and empty JSON request bodies do not leave browser refresh sessions active.
+* **Cookie-only refresh API**: Refresh tokens are no longer returned in JSON response bodies or accepted in request bodies; refresh and logout now use only the HttpOnly cookie.
+* **Refresh-token logout hardening**: Logout now revokes directly from the HttpOnly refresh cookie, so expired access tokens do not leave browser refresh sessions active.
 
 ## v1.28.0
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.27.1
+
+* **Hashed refresh sessions**: Refresh token sessions are now stored as SHA-256 hashes in `user_session`, including a migration that hashes any existing plaintext session rows during upgrade.
+* **HttpOnly browser refresh cookie**: Browser login and refresh flows now set the long-lived refresh token in an HttpOnly cookie and no longer persist it in frontend `localStorage`.
+* **Compatible refresh API**: API clients can still send refresh tokens in request bodies, while browser refresh/logout can use the cookie-backed flow.
+
 ## v1.27.0
 
 * **Deterministic agent tools API**: Added `/api/v2/agent-tools` endpoints that let future fraud-management agents request bounded, permission-gated evidence instead of broad database access.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,12 @@
 # What's New
 
+## v1.28.1
+
+* **Hashed refresh sessions**: Refresh token sessions are now stored as SHA-256 hashes in `user_session`, including a migration that hashes any existing plaintext session rows during upgrade.
+* **HttpOnly browser refresh cookie**: Browser login and refresh flows now set the long-lived refresh token in an HttpOnly cookie and no longer persist it in frontend `localStorage`.
+* **Compatible refresh API**: API clients can still send refresh tokens in request bodies, while browser refresh/logout can use the cookie-backed flow.
+* **Refresh-token logout hardening**: Logout now revokes directly from the refresh token or HttpOnly cookie, so expired access tokens and empty JSON request bodies do not leave browser refresh sessions active.
+
 ## v1.28.0
 
 * **Case management inbox**: Non-neutral live evaluation decisions now create durable case work items linked to the canonical evaluation ledger, with a new **Cases** page for reviewing and resolving cases.
@@ -9,9 +16,6 @@
 * **Rescoring-aware case lifecycle**: Rescored transactions update the active case with old/new decision references, while resolved cases remain auditable and later case-worthy scores create a new linked case.
 * **Generic integration events**: Evaluation completion and case lifecycle actions now write versioned integration events with a transactional outbox so external systems can poll or receive pushed delivery without changing the `/evaluate` response contract.
 * **Case and integration permissions**: Upgrades now seed the new case/integration permissions for existing admin roles, and webhook subscriptions validate HTTPS destinations before events enter the outbox.
-* **Hashed refresh sessions**: Refresh token sessions are now stored as SHA-256 hashes in `user_session`, including a migration that hashes any existing plaintext session rows during upgrade.
-* **HttpOnly browser refresh cookie**: Browser login and refresh flows now set the long-lived refresh token in an HttpOnly cookie and no longer persist it in frontend `localStorage`.
-* **Compatible refresh API**: API clients can still send refresh tokens in request bodies, while browser refresh/logout can use the cookie-backed flow.
 
 ## v1.27.0
 

--- a/ezrules/backend/api_v2/auth/schemas.py
+++ b/ezrules/backend/api_v2/auth/schemas.py
@@ -53,7 +53,7 @@ class RefreshRequest(BaseModel):
     instead rely on the HttpOnly refresh cookie set during login.
     """
 
-    refresh_token: str
+    refresh_token: str | None = None
 
 
 class AcceptInviteRequest(BaseModel):

--- a/ezrules/backend/api_v2/auth/schemas.py
+++ b/ezrules/backend/api_v2/auth/schemas.py
@@ -48,8 +48,9 @@ class RefreshRequest(BaseModel):
         "refresh_token": "eyJhbGciOiJIUzI1NiIs..."
     }
 
-    This is used when the access token expires and the client
-    wants a new one without re-entering their password.
+    This is used by API clients when the access token expires and the client
+    wants a new one without re-entering their password. Browser clients can
+    instead rely on the HttpOnly refresh cookie set during login.
     """
 
     refresh_token: str
@@ -93,9 +94,9 @@ class TokenResponse(BaseModel):
     }
 
     The client will:
-    1. Store both tokens (localStorage, memory, etc.)
+    1. Store the access token
     2. Send access_token in Authorization header: "Bearer eyJ..."
-    3. When access_token expires, use refresh_token to get a new pair
+    3. When access_token expires, use the refresh_token or HttpOnly refresh cookie to get a new pair
     """
 
     access_token: str

--- a/ezrules/backend/api_v2/auth/schemas.py
+++ b/ezrules/backend/api_v2/auth/schemas.py
@@ -39,23 +39,6 @@ class LoginRequest(BaseModel):
     password: str
 
 
-class RefreshRequest(BaseModel):
-    """
-    Refresh token request payload.
-
-    Example JSON:
-    {
-        "refresh_token": "eyJhbGciOiJIUzI1NiIs..."
-    }
-
-    This is used by API clients when the access token expires and the client
-    wants a new one without re-entering their password. Browser clients can
-    instead rely on the HttpOnly refresh cookie set during login.
-    """
-
-    refresh_token: str | None = None
-
-
 class AcceptInviteRequest(BaseModel):
     """Accept-invite payload."""
 
@@ -88,7 +71,6 @@ class TokenResponse(BaseModel):
     Example response:
     {
         "access_token": "eyJhbGciOiJIUzI1NiIs...",
-        "refresh_token": "eyJhbGciOiJIUzI1NiIs...",
         "token_type": "bearer",
         "expires_in": 1800
     }
@@ -96,11 +78,10 @@ class TokenResponse(BaseModel):
     The client will:
     1. Store the access token
     2. Send access_token in Authorization header: "Bearer eyJ..."
-    3. When access_token expires, use the refresh_token or HttpOnly refresh cookie to get a new pair
+    3. When access_token expires, use the HttpOnly refresh cookie to get a new access token
     """
 
     access_token: str
-    refresh_token: str
     token_type: str = "bearer"  # Always "bearer" for JWT
     expires_in: int  # Seconds until access_token expires
 

--- a/ezrules/backend/api_v2/routes/auth.py
+++ b/ezrules/backend/api_v2/routes/auth.py
@@ -552,16 +552,13 @@ def logout(
     response: Response,
     body: RefreshRequest | None = Body(default=None),
     db: Any = Depends(get_db),
-    current_user: User = Depends(get_current_active_user_strict),
 ):
     """
     Revoke the current refresh token server-side.
 
     **How to use:**
 
-    1. Include your access token in the Authorization header:
-       `Authorization: Bearer <access_token>`
-    2. Browser clients can use the HttpOnly refresh cookie. API clients can
+    1. Browser clients can use the HttpOnly refresh cookie. API clients can
        send the refresh token in the request body:
        `{"refresh_token": "<refresh_token>"}`
 
@@ -569,16 +566,29 @@ def logout(
     cannot be used again. The client should also clear local access-token state.
     """
     raw_refresh_token = _refresh_token_from_request(body, http_request)
+    if raw_refresh_token is None:
+        _clear_refresh_token_cookie(response)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-    # Delete the session row scoped to this user (prevents cross-user deletion)
-    if raw_refresh_token is not None:
-        db.query(UserSession).filter(
-            UserSession.refresh_token == hash_token(raw_refresh_token),
-            UserSession.user_id == int(current_user.id),
-        ).delete()
+    payload = decode_token(raw_refresh_token)
+    if payload is None or payload.token_type != "refresh":
+        _clear_refresh_token_cookie(response)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-    # Lazy cleanup of expired sessions for this user
-    _cleanup_expired_sessions(db, int(current_user.id))
+    db.query(UserSession).filter(
+        UserSession.refresh_token == hash_token(raw_refresh_token),
+        UserSession.user_id == payload.user_id,
+    ).delete()
+
+    _cleanup_expired_sessions(db, payload.user_id)
     db.commit()
     _clear_refresh_token_cookie(response)
 

--- a/ezrules/backend/api_v2/routes/auth.py
+++ b/ezrules/backend/api_v2/routes/auth.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 
@@ -49,6 +49,9 @@ from ezrules.settings import app_settings
 # All routes here will be under /api/v2/auth/...
 router = APIRouter(prefix="/api/v2/auth", tags=["Authentication"])
 logger = logging.getLogger(__name__)
+
+REFRESH_TOKEN_COOKIE_NAME = "ezrules_refresh_token"
+REFRESH_TOKEN_COOKIE_PATH = "/api/v2/auth"
 
 
 # =============================================================================
@@ -82,7 +85,7 @@ def hash_password(password: str) -> str:
 
 
 def hash_token(token: str) -> str:
-    """Hash a one-time token for secure storage."""
+    """Hash a bearer or one-time token for secure storage."""
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
@@ -120,6 +123,46 @@ def _cleanup_expired_sessions(db: Any, user_id: int) -> None:
     ).delete()
 
 
+def _refresh_cookie_secure() -> bool:
+    """Use secure refresh cookies whenever the configured app URL is HTTPS."""
+    return app_settings.APP_BASE_URL.lower().startswith("https://")
+
+
+def _set_refresh_token_cookie(response: Response, refresh_token: str) -> None:
+    response.set_cookie(
+        key=REFRESH_TOKEN_COOKIE_NAME,
+        value=refresh_token,
+        max_age=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        httponly=True,
+        secure=_refresh_cookie_secure(),
+        samesite="lax",
+        path=REFRESH_TOKEN_COOKIE_PATH,
+    )
+
+
+def _clear_refresh_token_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=REFRESH_TOKEN_COOKIE_NAME,
+        httponly=True,
+        secure=_refresh_cookie_secure(),
+        samesite="lax",
+        path=REFRESH_TOKEN_COOKIE_PATH,
+    )
+
+
+def _refresh_token_from_request(body: RefreshRequest | None, request: Request) -> str | None:
+    if body is not None and body.refresh_token:
+        return body.refresh_token
+    return request.cookies.get(REFRESH_TOKEN_COOKIE_NAME)
+
+
+def _store_refresh_session(db: Any, user_id: int, refresh_token: str, expires_at: datetime) -> None:
+    refresh_token_hash = hash_token(refresh_token)
+    db.query(UserSession).filter(UserSession.refresh_token == refresh_token_hash).delete()
+    db.flush()
+    db.add(UserSession(user_id=user_id, refresh_token=refresh_token_hash, expires_at=expires_at))
+
+
 # =============================================================================
 # LOGIN ENDPOINT
 # =============================================================================
@@ -133,6 +176,7 @@ def _cleanup_expired_sessions(db: Any, user_id: int) -> None:
     },
 )
 def login(
+    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: Any = Depends(get_db),
 ):
@@ -150,6 +194,8 @@ def login(
     2. On success, you get back:
        - access_token: Use this in Authorization header for API calls
        - refresh_token: Use this to get new access tokens
+       - HttpOnly refresh cookie: Browser clients can refresh without storing
+         the refresh token in JavaScript-accessible storage
        - expires_in: Seconds until access_token expires
 
     3. For subsequent API calls, include the header:
@@ -204,10 +250,9 @@ def login(
     # edge cases where the same JWT can be generated within the same second).
     _cleanup_expired_sessions(db, int(user.id))
     expires_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    db.query(UserSession).filter(UserSession.refresh_token == refresh_token).delete()
-    db.flush()
-    db.add(UserSession(user_id=int(user.id), refresh_token=refresh_token, expires_at=expires_at))
+    _store_refresh_session(db, int(user.id), refresh_token, expires_at)
     db.commit()
+    _set_refresh_token_cookie(response, refresh_token)
 
     return TokenResponse(
         access_token=access_token,
@@ -372,7 +417,9 @@ def reset_password(
     },
 )
 def refresh_token(
-    request: RefreshRequest,
+    http_request: Request,
+    response: Response,
+    body: RefreshRequest | None = Body(default=None),
     db: Any = Depends(get_db),
 ):
     """
@@ -386,7 +433,8 @@ def refresh_token(
 
     **How it works:**
 
-    1. Send your refresh_token in the request body
+    1. Send your refresh_token in the request body, or use the HttpOnly
+       refresh cookie set during browser login
     2. If valid, you get back a fresh pair of tokens
     3. The old refresh token is immediately invalidated (rotation)
 
@@ -396,8 +444,16 @@ def refresh_token(
     If an admin deactivates a user, their refresh tokens stop working.
     Each refresh token can only be used once (rotation).
     """
+    raw_refresh_token = _refresh_token_from_request(body, http_request)
+    if raw_refresh_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     # Decode the refresh token
-    payload = decode_token(request.refresh_token)
+    payload = decode_token(raw_refresh_token)
     if payload is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -430,7 +486,15 @@ def refresh_token(
         )
 
     # Verify the session exists in the database (wasn't revoked via logout)
-    session_row = db.query(UserSession).filter(UserSession.refresh_token == request.refresh_token).first()
+    refresh_token_hash = hash_token(raw_refresh_token)
+    session_row = (
+        db.query(UserSession)
+        .filter(
+            UserSession.refresh_token == refresh_token_hash,
+            UserSession.user_id == payload.user_id,
+        )
+        .first()
+    )
     if session_row is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -459,10 +523,9 @@ def refresh_token(
 
     # Record the new session, guarding against clock-precision duplicates.
     expires_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    db.query(UserSession).filter(UserSession.refresh_token == new_refresh_token).delete()
-    db.flush()
-    db.add(UserSession(user_id=int(user.id), refresh_token=new_refresh_token, expires_at=expires_at))
+    _store_refresh_session(db, int(user.id), new_refresh_token, expires_at)
     db.commit()
+    _set_refresh_token_cookie(response, new_refresh_token)
 
     return TokenResponse(
         access_token=access_token,
@@ -485,7 +548,9 @@ def refresh_token(
     },
 )
 def logout(
-    request: RefreshRequest,
+    http_request: Request,
+    response: Response,
+    body: RefreshRequest | None = Body(default=None),
     db: Any = Depends(get_db),
     current_user: User = Depends(get_current_active_user_strict),
 ):
@@ -496,21 +561,26 @@ def logout(
 
     1. Include your access token in the Authorization header:
        `Authorization: Bearer <access_token>`
-    2. Send the refresh token in the request body:
+    2. Browser clients can use the HttpOnly refresh cookie. API clients can
+       send the refresh token in the request body:
        `{"refresh_token": "<refresh_token>"}`
 
     After this call the refresh token is deleted from the database and
-    cannot be used again. The client should also clear its local storage.
+    cannot be used again. The client should also clear local access-token state.
     """
+    raw_refresh_token = _refresh_token_from_request(body, http_request)
+
     # Delete the session row scoped to this user (prevents cross-user deletion)
-    db.query(UserSession).filter(
-        UserSession.refresh_token == request.refresh_token,
-        UserSession.user_id == int(current_user.id),
-    ).delete()
+    if raw_refresh_token is not None:
+        db.query(UserSession).filter(
+            UserSession.refresh_token == hash_token(raw_refresh_token),
+            UserSession.user_id == int(current_user.id),
+        ).delete()
 
     # Lazy cleanup of expired sessions for this user
     _cleanup_expired_sessions(db, int(current_user.id))
     db.commit()
+    _clear_refresh_token_cookie(response)
 
     return {"message": "Logged out successfully"}
 

--- a/ezrules/backend/api_v2/routes/auth.py
+++ b/ezrules/backend/api_v2/routes/auth.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import bcrypt
-from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 
@@ -34,7 +34,6 @@ from ezrules.backend.api_v2.auth.schemas import (
     AcceptInviteRequest,
     ForgotPasswordRequest,
     MessageResponse,
-    RefreshRequest,
     ResetPasswordRequest,
     RoleResponse,
     TokenResponse,
@@ -150,9 +149,7 @@ def _clear_refresh_token_cookie(response: Response) -> None:
     )
 
 
-def _refresh_token_from_request(body: RefreshRequest | None, request: Request) -> str | None:
-    if body is not None and body.refresh_token:
-        return body.refresh_token
+def _refresh_token_from_cookie(request: Request) -> str | None:
     return request.cookies.get(REFRESH_TOKEN_COOKIE_NAME)
 
 
@@ -183,7 +180,8 @@ def login(
     """
     Authenticate user and return JWT tokens.
 
-    This endpoint accepts credentials and returns an access token + refresh token.
+    This endpoint accepts credentials, returns an access token, and sets the
+    refresh token in an HttpOnly cookie.
 
     **How to use:**
 
@@ -193,9 +191,8 @@ def login(
 
     2. On success, you get back:
        - access_token: Use this in Authorization header for API calls
-       - refresh_token: Use this to get new access tokens
-       - HttpOnly refresh cookie: Browser clients can refresh without storing
-         the refresh token in JavaScript-accessible storage
+       - HttpOnly refresh cookie: Refresh/logout use this cookie without exposing
+         the refresh token to JavaScript-accessible storage
        - expires_in: Seconds until access_token expires
 
     3. For subsequent API calls, include the header:
@@ -256,7 +253,6 @@ def login(
 
     return TokenResponse(
         access_token=access_token,
-        refresh_token=refresh_token,
         token_type="bearer",
         expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Convert to seconds
     )
@@ -419,7 +415,6 @@ def reset_password(
 def refresh_token(
     http_request: Request,
     response: Response,
-    body: RefreshRequest | None = Body(default=None),
     db: Any = Depends(get_db),
 ):
     """
@@ -433,9 +428,8 @@ def refresh_token(
 
     **How it works:**
 
-    1. Send your refresh_token in the request body, or use the HttpOnly
-       refresh cookie set during browser login
-    2. If valid, you get back a fresh pair of tokens
+    1. Send the HttpOnly refresh cookie set during login
+    2. If valid, you get back a fresh access token and a rotated refresh cookie
     3. The old refresh token is immediately invalidated (rotation)
 
     **Security note:**
@@ -444,7 +438,7 @@ def refresh_token(
     If an admin deactivates a user, their refresh tokens stop working.
     Each refresh token can only be used once (rotation).
     """
-    raw_refresh_token = _refresh_token_from_request(body, http_request)
+    raw_refresh_token = _refresh_token_from_cookie(http_request)
     if raw_refresh_token is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -529,7 +523,6 @@ def refresh_token(
 
     return TokenResponse(
         access_token=access_token,
-        refresh_token=new_refresh_token,
         token_type="bearer",
         expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     )
@@ -550,7 +543,6 @@ def refresh_token(
 def logout(
     http_request: Request,
     response: Response,
-    body: RefreshRequest | None = Body(default=None),
     db: Any = Depends(get_db),
 ):
     """
@@ -558,14 +550,12 @@ def logout(
 
     **How to use:**
 
-    1. Browser clients can use the HttpOnly refresh cookie. API clients can
-       send the refresh token in the request body:
-       `{"refresh_token": "<refresh_token>"}`
+    1. Send the HttpOnly refresh cookie set during login or refresh.
 
     After this call the refresh token is deleted from the database and
     cannot be used again. The client should also clear local access-token state.
     """
-    raw_refresh_token = _refresh_token_from_request(body, http_request)
+    raw_refresh_token = _refresh_token_from_cookie(http_request)
     if raw_refresh_token is None:
         _clear_refresh_token_cookie(response)
         raise HTTPException(

--- a/ezrules/frontend/e2e/auth.setup.ts
+++ b/ezrules/frontend/e2e/auth.setup.ts
@@ -1,8 +1,8 @@
 import { test as setup } from '@playwright/test';
 
 /**
- * Global setup that logs in once and saves the auth state (localStorage tokens)
- * to a file. All test projects depend on this setup so they start authenticated.
+ * Global setup that logs in once and saves the auth state to a file.
+ * All test projects depend on this setup so they start authenticated.
  */
 setup('authenticate', async ({ page }) => {
   // Navigate to login page
@@ -16,6 +16,6 @@ setup('authenticate', async ({ page }) => {
   // Wait for redirect to dashboard after login
   await page.waitForURL(/.*dashboard/, { timeout: 30000 });
 
-  // Save the authenticated state (localStorage with tokens)
+  // Save the authenticated state (access token plus refresh cookie)
   await page.context().storageState({ path: 'e2e/.auth/user.json' });
 });

--- a/ezrules/frontend/e2e/tests/features.spec.ts
+++ b/ezrules/frontend/e2e/tests/features.spec.ts
@@ -92,7 +92,6 @@ test.describe('Features Page', () => {
 
     await page.addInitScript(() => {
       localStorage.setItem('ezrules_access_token', 'ui-test-access-token');
-      localStorage.setItem('ezrules_refresh_token', 'ui-test-refresh-token');
     });
 
     await mockFeaturePageApi(page, {

--- a/ezrules/frontend/e2e/tests/tested-events-graph.spec.ts
+++ b/ezrules/frontend/e2e/tests/tested-events-graph.spec.ts
@@ -12,7 +12,6 @@ function json(route: Route, body: unknown, status = 200) {
 async function mockTestedEventGraphApi(page: Page, onGraphRequest: () => void) {
   await page.addInitScript(() => {
     localStorage.setItem('ezrules_access_token', 'ui-test-access-token');
-    localStorage.setItem('ezrules_refresh_token', 'ui-test-refresh-token');
   });
 
   await page.route('**/api/v2/auth/me', async (route) => {

--- a/ezrules/frontend/src/app/services/auth.service.ts
+++ b/ezrules/frontend/src/app/services/auth.service.ts
@@ -31,7 +31,7 @@ export interface MessageResponse {
 export class AuthService {
   private readonly AUTH_URL = `${environment.apiUrl}/api/v2/auth`;
   private readonly ACCESS_TOKEN_KEY = 'ezrules_access_token';
-  private readonly REFRESH_TOKEN_KEY = 'ezrules_refresh_token';
+  private readonly LEGACY_REFRESH_TOKEN_KEY = 'ezrules_refresh_token';
 
   private loggedIn = new BehaviorSubject<boolean>(this.hasToken());
   private currentUser = new BehaviorSubject<AuthUser | null>(null);
@@ -46,10 +46,6 @@ export class AuthService {
 
   getAccessToken(): string | null {
     return localStorage.getItem(this.ACCESS_TOKEN_KEY);
-  }
-
-  getRefreshToken(): string | null {
-    return localStorage.getItem(this.REFRESH_TOKEN_KEY);
   }
 
   getCurrentUserSnapshot(): AuthUser | null {
@@ -67,11 +63,12 @@ export class AuthService {
     formData.set('password', password);
 
     return this.http.post<TokenResponse>(`${this.AUTH_URL}/login`, formData.toString(), {
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      withCredentials: true
     }).pipe(
       tap(response => {
         localStorage.setItem(this.ACCESS_TOKEN_KEY, response.access_token);
-        localStorage.setItem(this.REFRESH_TOKEN_KEY, response.refresh_token);
+        localStorage.removeItem(this.LEGACY_REFRESH_TOKEN_KEY);
         this.setCurrentUser(null);
         this.currentUserRequest$ = null;
         this.loggedIn.next(true);
@@ -85,17 +82,10 @@ export class AuthService {
   }
 
   refresh(): Observable<TokenResponse> {
-    const refreshToken = this.getRefreshToken();
-    if (!refreshToken) {
-      return throwError(() => new Error('No refresh token'));
-    }
-
-    return this.http.post<TokenResponse>(`${this.AUTH_URL}/refresh`, {
-      refresh_token: refreshToken
-    }).pipe(
+    return this.http.post<TokenResponse>(`${this.AUTH_URL}/refresh`, null, { withCredentials: true }).pipe(
       tap(response => {
         localStorage.setItem(this.ACCESS_TOKEN_KEY, response.access_token);
-        localStorage.setItem(this.REFRESH_TOKEN_KEY, response.refresh_token);
+        localStorage.removeItem(this.LEGACY_REFRESH_TOKEN_KEY);
         this.currentUserRequest$ = null;
         this.loggedIn.next(true);
       }),
@@ -107,15 +97,15 @@ export class AuthService {
   }
 
   logout(): void {
-    const refreshToken = this.getRefreshToken();
-    if (refreshToken) {
+    const accessToken = this.getAccessToken();
+    if (accessToken) {
       // Fire and forget — clear local state regardless of outcome
-      this.http.post(`${this.AUTH_URL}/logout`, { refresh_token: refreshToken }).subscribe({
+      this.http.post(`${this.AUTH_URL}/logout`, null, { withCredentials: true }).subscribe({
         error: () => {} // Ignore errors — local cleanup always happens
       });
     }
     localStorage.removeItem(this.ACCESS_TOKEN_KEY);
-    localStorage.removeItem(this.REFRESH_TOKEN_KEY);
+    localStorage.removeItem(this.LEGACY_REFRESH_TOKEN_KEY);
     this.setCurrentUser(null);
     this.currentUserRequest$ = null;
     this.loggedIn.next(false);

--- a/ezrules/frontend/src/app/services/auth.service.ts
+++ b/ezrules/frontend/src/app/services/auth.service.ts
@@ -7,7 +7,6 @@ import { environment } from '../../environments/environment';
 
 export interface TokenResponse {
   access_token: string;
-  refresh_token: string;
   token_type: string;
   expires_in: number;
 }
@@ -31,7 +30,6 @@ export interface MessageResponse {
 export class AuthService {
   private readonly AUTH_URL = `${environment.apiUrl}/api/v2/auth`;
   private readonly ACCESS_TOKEN_KEY = 'ezrules_access_token';
-  private readonly LEGACY_REFRESH_TOKEN_KEY = 'ezrules_refresh_token';
 
   private loggedIn = new BehaviorSubject<boolean>(this.hasToken());
   private currentUser = new BehaviorSubject<AuthUser | null>(null);
@@ -68,7 +66,6 @@ export class AuthService {
     }).pipe(
       tap(response => {
         localStorage.setItem(this.ACCESS_TOKEN_KEY, response.access_token);
-        localStorage.removeItem(this.LEGACY_REFRESH_TOKEN_KEY);
         this.setCurrentUser(null);
         this.currentUserRequest$ = null;
         this.loggedIn.next(true);
@@ -85,7 +82,6 @@ export class AuthService {
     return this.http.post<TokenResponse>(`${this.AUTH_URL}/refresh`, null, { withCredentials: true }).pipe(
       tap(response => {
         localStorage.setItem(this.ACCESS_TOKEN_KEY, response.access_token);
-        localStorage.removeItem(this.LEGACY_REFRESH_TOKEN_KEY);
         this.currentUserRequest$ = null;
         this.loggedIn.next(true);
       }),
@@ -105,7 +101,6 @@ export class AuthService {
       });
     }
     localStorage.removeItem(this.ACCESS_TOKEN_KEY);
-    localStorage.removeItem(this.LEGACY_REFRESH_TOKEN_KEY);
     this.setCurrentUser(null);
     this.currentUserRequest$ = null;
     this.loggedIn.next(false);

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -1140,7 +1140,7 @@ class UserSession(Base):
 
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False, index=True)
-    refresh_token = Column(String(2048), nullable=False, unique=True)
+    refresh_token = Column(String(64), nullable=False, unique=True)
     expires_at = Column(DateTime, nullable=False)
     created_at = Column(DateTime, default=datetime.datetime.utcnow)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.27.0"
+version = "1.27.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.0"
+version = "1.28.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_api_v2_auth.py
+++ b/tests/test_api_v2_auth.py
@@ -27,6 +27,10 @@ from ezrules.backend.api_v2.routes import auth as auth_routes
 from ezrules.models.backend_core import Invitation, Organisation, PasswordResetToken, Role, User, UserSession
 
 
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
 @pytest.fixture(scope="function")
 def api_client(session):
     """
@@ -452,7 +456,7 @@ class TestInviteAndPasswordResetEndpoints:
         session.add(
             UserSession(
                 user_id=int(user.id),
-                refresh_token="test_refresh_token_to_revoke",
+                refresh_token=_hash_token("test_refresh_token_to_revoke"),
                 expires_at=now + timedelta(days=1),
             )
         )
@@ -567,7 +571,7 @@ class TestSessionTracking:
     """Tests for server-side refresh token session tracking (UserSession table)."""
 
     def test_login_creates_session(self, api_client, session):
-        """Login should insert a UserSession row for the issued refresh token."""
+        """Login should insert a UserSession row with a hash of the issued refresh token."""
         response = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
@@ -576,10 +580,26 @@ class TestSessionTracking:
         tokens = response.json()
 
         session.expire_all()
-        session_row = session.query(UserSession).filter(UserSession.refresh_token == tokens["refresh_token"]).first()
+        session_row = (
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
+        )
         assert session_row is not None
+        assert session_row.refresh_token != tokens["refresh_token"]
         assert session_row.expires_at is not None
         assert session_row.user_id is not None
+
+    def test_login_sets_http_only_refresh_cookie(self, api_client, session):
+        """Browser logins should receive a refresh cookie that JavaScript cannot read."""
+        response = api_client.post(
+            "/api/v2/auth/login",
+            data={"username": "testuser@example.com", "password": "testpassword123"},
+        )
+        assert response.status_code == 200
+
+        set_cookie = response.headers.get("set-cookie", "")
+        assert "ezrules_refresh_token=" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=lax" in set_cookie
 
     def test_refresh_rotation_deletes_old_and_creates_new_session(self, api_client, session):
         """Refresh should delete the consumed session and insert a new one."""
@@ -599,14 +619,43 @@ class TestSessionTracking:
 
         session.expire_all()
         # Old session must be gone
-        old_session = session.query(UserSession).filter(UserSession.refresh_token == old_refresh_token).first()
+        old_session = (
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(old_refresh_token)).first()
+        )
         assert old_session is None
 
         # New session must exist
         new_session = (
-            session.query(UserSession).filter(UserSession.refresh_token == new_tokens["refresh_token"]).first()
+            session.query(UserSession)
+            .filter(UserSession.refresh_token == _hash_token(new_tokens["refresh_token"]))
+            .first()
         )
         assert new_session is not None
+
+    def test_refresh_accepts_http_only_cookie(self, api_client, session):
+        """Browser refresh can rotate the token from the cookie without a JSON body."""
+        login_response = api_client.post(
+            "/api/v2/auth/login",
+            data={"username": "testuser@example.com", "password": "testpassword123"},
+        )
+        assert login_response.status_code == 200
+        original_refresh_token = login_response.json()["refresh_token"]
+
+        refresh_response = api_client.post("/api/v2/auth/refresh")
+        assert refresh_response.status_code == 200
+        new_tokens = refresh_response.json()
+
+        session.expire_all()
+        assert (
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(original_refresh_token)).first()
+            is None
+        )
+        assert (
+            session.query(UserSession)
+            .filter(UserSession.refresh_token == _hash_token(new_tokens["refresh_token"]))
+            .first()
+            is not None
+        )
 
     def test_refresh_token_can_only_be_used_once(self, api_client, session):
         """A refresh token should be invalid after it has been used once (rotation)."""
@@ -639,7 +688,7 @@ class TestSessionTracking:
         tokens = login_response.json()
 
         # Manually revoke the session directly in the database
-        session.query(UserSession).filter(UserSession.refresh_token == tokens["refresh_token"]).delete()
+        session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).delete()
         session.commit()
 
         response = api_client.post(
@@ -675,8 +724,31 @@ class TestLogoutEndpoint:
         assert logout_response.json()["message"] == "Logged out successfully"
 
         session.expire_all()
-        session_row = session.query(UserSession).filter(UserSession.refresh_token == tokens["refresh_token"]).first()
+        session_row = (
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
+        )
         assert session_row is None
+
+    def test_logout_accepts_http_only_cookie(self, api_client, session):
+        """Browser logout can revoke the session using the refresh cookie."""
+        login_response = api_client.post(
+            "/api/v2/auth/login",
+            data={"username": "testuser@example.com", "password": "testpassword123"},
+        )
+        tokens = login_response.json()
+
+        logout_response = api_client.post(
+            "/api/v2/auth/logout",
+            headers={"Authorization": f"Bearer {tokens['access_token']}"},
+        )
+        assert logout_response.status_code == 200
+
+        session.expire_all()
+        assert (
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
+            is None
+        )
+        assert "ezrules_refresh_token=" in logout_response.headers.get("set-cookie", "")
 
     def test_refresh_after_logout_returns_401(self, api_client, session):
         """After logout, using the old refresh token should return 401."""

--- a/tests/test_api_v2_auth.py
+++ b/tests/test_api_v2_auth.py
@@ -11,6 +11,7 @@ These tests verify:
 import hashlib
 import uuid
 from datetime import UTC, datetime, timedelta
+from http.cookies import SimpleCookie
 
 import bcrypt
 import pytest
@@ -29,6 +30,17 @@ from ezrules.models.backend_core import Invitation, Organisation, PasswordResetT
 
 def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _refresh_token_from_set_cookie(response) -> str:
+    cookies = SimpleCookie()
+    cookies.load(response.headers["set-cookie"])
+    return cookies[auth_routes.REFRESH_TOKEN_COOKIE_NAME].value
+
+
+def _replace_refresh_cookie(client: TestClient, refresh_token: str) -> None:
+    client.cookies.clear()
+    client.cookies.set(auth_routes.REFRESH_TOKEN_COOKIE_NAME, refresh_token)
 
 
 @pytest.fixture(scope="function")
@@ -177,7 +189,7 @@ class TestLoginEndpoint:
     """Tests for POST /api/v2/auth/login."""
 
     def test_login_valid_credentials(self, api_client, session):
-        """Login with valid credentials should return tokens."""
+        """Login with valid credentials should return an access token and refresh cookie."""
         response = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
@@ -187,7 +199,7 @@ class TestLoginEndpoint:
         data = response.json()
 
         assert "access_token" in data
-        assert "refresh_token" in data
+        assert "refresh_token" not in data
         assert data["token_type"] == "bearer"
         assert data["expires_in"] == ACCESS_TOKEN_EXPIRE_MINUTES * 60
 
@@ -196,6 +208,10 @@ class TestLoginEndpoint:
         assert payload is not None
         assert payload.email == "testuser@example.com"
         assert payload.token_type == "access"
+
+        refresh_payload = decode_token(_refresh_token_from_set_cookie(response))
+        assert refresh_payload is not None
+        assert refresh_payload.token_type == "refresh"
 
     def test_login_invalid_password(self, api_client, session):
         """Login with wrong password should return 401."""
@@ -272,42 +288,38 @@ class TestRefreshEndpoint:
     """Tests for POST /api/v2/auth/refresh."""
 
     def test_refresh_valid_token(self, api_client, session):
-        """Refresh with valid token should return new tokens."""
+        """Refresh with valid cookie should return a new access token."""
         # First, login to get tokens
         login_response = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        original_tokens = login_response.json()
+        assert login_response.status_code == 200
 
         # Now refresh
-        refresh_response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": original_tokens["refresh_token"]},
-        )
+        refresh_response = api_client.post("/api/v2/auth/refresh")
 
         assert refresh_response.status_code == 200
         new_tokens = refresh_response.json()
 
         assert "access_token" in new_tokens
-        assert "refresh_token" in new_tokens
+        assert "refresh_token" not in new_tokens
         assert new_tokens["token_type"] == "bearer"
+        assert _refresh_token_from_set_cookie(refresh_response)
         # Verify the new access token is valid and contains correct data
         payload = decode_token(new_tokens["access_token"])
         assert payload is not None
         assert payload.email == "testuser@example.com"
 
     def test_refresh_invalid_token(self, api_client, session):
-        """Refresh with invalid token should return 401."""
-        response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": "invalid.token.here"},
-        )
+        """Refresh with invalid cookie should return 401."""
+        _replace_refresh_cookie(api_client, "invalid.token.here")
+        response = api_client.post("/api/v2/auth/refresh")
 
         assert response.status_code == 401
 
     def test_refresh_with_access_token(self, api_client, session):
-        """Refresh with access token (wrong type) should return 401."""
+        """Refresh with an access token cookie (wrong type) should return 401."""
         # Login to get tokens
         login_response = api_client.post(
             "/api/v2/auth/login",
@@ -315,11 +327,9 @@ class TestRefreshEndpoint:
         )
         tokens = login_response.json()
 
-        # Try to refresh using the access token (should fail)
-        response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": tokens["access_token"]},  # Wrong token type!
-        )
+        # Try to refresh using the access token as the refresh cookie (should fail)
+        _replace_refresh_cookie(api_client, tokens["access_token"])
+        response = api_client.post("/api/v2/auth/refresh")
 
         assert response.status_code == 401
         assert "Invalid token type" in response.json()["detail"]
@@ -530,12 +540,12 @@ class TestMeEndpoint:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens = login_response.json()
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
         # Try to use refresh token for /me (should fail)
         response = api_client.get(
             "/api/v2/auth/me",
-            headers={"Authorization": f"Bearer {tokens['refresh_token']}"},
+            headers={"Authorization": f"Bearer {refresh_token}"},
         )
 
         assert response.status_code == 401
@@ -577,14 +587,12 @@ class TestSessionTracking:
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
         assert response.status_code == 200
-        tokens = response.json()
+        refresh_token = _refresh_token_from_set_cookie(response)
 
         session.expire_all()
-        session_row = (
-            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
-        )
+        session_row = session.query(UserSession).filter(UserSession.refresh_token == _hash_token(refresh_token)).first()
         assert session_row is not None
-        assert session_row.refresh_token != tokens["refresh_token"]
+        assert session_row.refresh_token != refresh_token
         assert session_row.expires_at is not None
         assert session_row.user_id is not None
 
@@ -607,15 +615,11 @@ class TestSessionTracking:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        original_tokens = login_response.json()
-        old_refresh_token = original_tokens["refresh_token"]
+        old_refresh_token = _refresh_token_from_set_cookie(login_response)
 
-        refresh_response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": old_refresh_token},
-        )
+        refresh_response = api_client.post("/api/v2/auth/refresh")
         assert refresh_response.status_code == 200
-        new_tokens = refresh_response.json()
+        new_refresh_token = _refresh_token_from_set_cookie(refresh_response)
 
         session.expire_all()
         # Old session must be gone
@@ -626,9 +630,7 @@ class TestSessionTracking:
 
         # New session must exist
         new_session = (
-            session.query(UserSession)
-            .filter(UserSession.refresh_token == _hash_token(new_tokens["refresh_token"]))
-            .first()
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(new_refresh_token)).first()
         )
         assert new_session is not None
 
@@ -639,11 +641,11 @@ class TestSessionTracking:
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
         assert login_response.status_code == 200
-        original_refresh_token = login_response.json()["refresh_token"]
+        original_refresh_token = _refresh_token_from_set_cookie(login_response)
 
         refresh_response = api_client.post("/api/v2/auth/refresh")
         assert refresh_response.status_code == 200
-        new_tokens = refresh_response.json()
+        new_refresh_token = _refresh_token_from_set_cookie(refresh_response)
 
         session.expire_all()
         assert (
@@ -651,23 +653,22 @@ class TestSessionTracking:
             is None
         )
         assert (
-            session.query(UserSession)
-            .filter(UserSession.refresh_token == _hash_token(new_tokens["refresh_token"]))
-            .first()
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(new_refresh_token)).first()
             is not None
         )
 
-    def test_refresh_accepts_cookie_with_empty_json_body(self, api_client, session):
-        """Cookie refresh should still work when a client sends an empty JSON object."""
+    def test_refresh_rejects_request_body_refresh_token(self, api_client, session):
+        """Refresh tokens are accepted only from the HttpOnly cookie, not request JSON."""
         login_response = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
         assert login_response.status_code == 200
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
-        refresh_response = api_client.post("/api/v2/auth/refresh", json={})
-        assert refresh_response.status_code == 200
-        assert "refresh_token" in refresh_response.json()
+        api_client.cookies.clear()
+        refresh_response = api_client.post("/api/v2/auth/refresh", json={"refresh_token": refresh_token})
+        assert refresh_response.status_code == 401
 
     def test_refresh_token_can_only_be_used_once(self, api_client, session):
         """A refresh token should be invalid after it has been used once (rotation)."""
@@ -675,20 +676,15 @@ class TestSessionTracking:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        original_refresh_token = login_response.json()["refresh_token"]
+        original_refresh_token = _refresh_token_from_set_cookie(login_response)
 
         # First use — succeeds and rotates the token
-        first_refresh = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": original_refresh_token},
-        )
+        first_refresh = api_client.post("/api/v2/auth/refresh")
         assert first_refresh.status_code == 200
 
         # Second use of the same (now-deleted) token — must be rejected
-        second_refresh = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": original_refresh_token},
-        )
+        _replace_refresh_cookie(api_client, original_refresh_token)
+        second_refresh = api_client.post("/api/v2/auth/refresh")
         assert second_refresh.status_code == 401
 
     def test_refresh_revoked_session_returns_401(self, api_client, session):
@@ -697,16 +693,13 @@ class TestSessionTracking:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens = login_response.json()
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
         # Manually revoke the session directly in the database
-        session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).delete()
+        session.query(UserSession).filter(UserSession.refresh_token == _hash_token(refresh_token)).delete()
         session.commit()
 
-        response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": tokens["refresh_token"]},
-        )
+        response = api_client.post("/api/v2/auth/refresh")
         assert response.status_code == 401
         assert "revoked" in response.json()["detail"].lower()
 
@@ -725,19 +718,14 @@ class TestLogoutEndpoint:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens = login_response.json()
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
-        logout_response = api_client.post(
-            "/api/v2/auth/logout",
-            json={"refresh_token": tokens["refresh_token"]},
-        )
+        logout_response = api_client.post("/api/v2/auth/logout")
         assert logout_response.status_code == 200
         assert logout_response.json()["message"] == "Logged out successfully"
 
         session.expire_all()
-        session_row = (
-            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
-        )
+        session_row = session.query(UserSession).filter(UserSession.refresh_token == _hash_token(refresh_token)).first()
         assert session_row is None
 
     def test_logout_accepts_http_only_cookie(self, api_client, session):
@@ -746,33 +734,33 @@ class TestLogoutEndpoint:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens = login_response.json()
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
         logout_response = api_client.post("/api/v2/auth/logout")
         assert logout_response.status_code == 200
 
         session.expire_all()
         assert (
-            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
-            is None
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(refresh_token)).first() is None
         )
         assert "ezrules_refresh_token=" in logout_response.headers.get("set-cookie", "")
 
-    def test_logout_accepts_cookie_with_empty_json_body(self, api_client, session):
-        """Cookie logout should still work when a client sends an empty JSON object."""
+    def test_logout_rejects_request_body_refresh_token(self, api_client, session):
+        """Logout tokens are accepted only from the HttpOnly cookie, not request JSON."""
         login_response = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens = login_response.json()
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
-        logout_response = api_client.post("/api/v2/auth/logout", json={})
-        assert logout_response.status_code == 200
+        api_client.cookies.clear()
+        logout_response = api_client.post("/api/v2/auth/logout", json={"refresh_token": refresh_token})
+        assert logout_response.status_code == 401
 
         session.expire_all()
         assert (
-            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
-            is None
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(refresh_token)).first()
+            is not None
         )
 
     def test_refresh_after_logout_returns_401(self, api_client, session):
@@ -781,17 +769,12 @@ class TestLogoutEndpoint:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens = login_response.json()
+        refresh_token = _refresh_token_from_set_cookie(login_response)
 
-        api_client.post(
-            "/api/v2/auth/logout",
-            json={"refresh_token": tokens["refresh_token"]},
-        )
+        api_client.post("/api/v2/auth/logout")
 
-        response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": tokens["refresh_token"]},
-        )
+        _replace_refresh_cookie(api_client, refresh_token)
+        response = api_client.post("/api/v2/auth/refresh")
         assert response.status_code == 401
 
     def test_logout_without_refresh_token_returns_401(self, api_client, session):
@@ -800,11 +783,9 @@ class TestLogoutEndpoint:
         assert response.status_code == 401
 
     def test_logout_with_invalid_refresh_token_returns_401(self, api_client, session):
-        """Logout with an invalid refresh token should be rejected."""
-        response = api_client.post(
-            "/api/v2/auth/logout",
-            json={"refresh_token": "sometoken"},
-        )
+        """Logout with an invalid refresh cookie should be rejected."""
+        _replace_refresh_cookie(api_client, "sometoken")
+        response = api_client.post("/api/v2/auth/logout")
         assert response.status_code == 401
 
     def test_logout_does_not_affect_other_sessions(self, api_client, session):
@@ -813,23 +794,19 @@ class TestLogoutEndpoint:
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens1 = login1.json()
+        refresh_token1 = _refresh_token_from_set_cookie(login1)
 
         login2 = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
-        tokens2 = login2.json()
+        refresh_token2 = _refresh_token_from_set_cookie(login2)
 
         # Logout the first session only
-        api_client.post(
-            "/api/v2/auth/logout",
-            json={"refresh_token": tokens1["refresh_token"]},
-        )
+        _replace_refresh_cookie(api_client, refresh_token1)
+        api_client.post("/api/v2/auth/logout")
 
         # Second session should still be usable
-        refresh_response = api_client.post(
-            "/api/v2/auth/refresh",
-            json={"refresh_token": tokens2["refresh_token"]},
-        )
+        _replace_refresh_cookie(api_client, refresh_token2)
+        refresh_response = api_client.post("/api/v2/auth/refresh")
         assert refresh_response.status_code == 200

--- a/tests/test_api_v2_auth.py
+++ b/tests/test_api_v2_auth.py
@@ -657,6 +657,18 @@ class TestSessionTracking:
             is not None
         )
 
+    def test_refresh_accepts_cookie_with_empty_json_body(self, api_client, session):
+        """Cookie refresh should still work when a client sends an empty JSON object."""
+        login_response = api_client.post(
+            "/api/v2/auth/login",
+            data={"username": "testuser@example.com", "password": "testpassword123"},
+        )
+        assert login_response.status_code == 200
+
+        refresh_response = api_client.post("/api/v2/auth/refresh", json={})
+        assert refresh_response.status_code == 200
+        assert "refresh_token" in refresh_response.json()
+
     def test_refresh_token_can_only_be_used_once(self, api_client, session):
         """A refresh token should be invalid after it has been used once (rotation)."""
         login_response = api_client.post(
@@ -718,7 +730,6 @@ class TestLogoutEndpoint:
         logout_response = api_client.post(
             "/api/v2/auth/logout",
             json={"refresh_token": tokens["refresh_token"]},
-            headers={"Authorization": f"Bearer {tokens['access_token']}"},
         )
         assert logout_response.status_code == 200
         assert logout_response.json()["message"] == "Logged out successfully"
@@ -730,17 +741,14 @@ class TestLogoutEndpoint:
         assert session_row is None
 
     def test_logout_accepts_http_only_cookie(self, api_client, session):
-        """Browser logout can revoke the session using the refresh cookie."""
+        """Browser logout can revoke the session using only the refresh cookie."""
         login_response = api_client.post(
             "/api/v2/auth/login",
             data={"username": "testuser@example.com", "password": "testpassword123"},
         )
         tokens = login_response.json()
 
-        logout_response = api_client.post(
-            "/api/v2/auth/logout",
-            headers={"Authorization": f"Bearer {tokens['access_token']}"},
-        )
+        logout_response = api_client.post("/api/v2/auth/logout")
         assert logout_response.status_code == 200
 
         session.expire_all()
@@ -749,6 +757,23 @@ class TestLogoutEndpoint:
             is None
         )
         assert "ezrules_refresh_token=" in logout_response.headers.get("set-cookie", "")
+
+    def test_logout_accepts_cookie_with_empty_json_body(self, api_client, session):
+        """Cookie logout should still work when a client sends an empty JSON object."""
+        login_response = api_client.post(
+            "/api/v2/auth/login",
+            data={"username": "testuser@example.com", "password": "testpassword123"},
+        )
+        tokens = login_response.json()
+
+        logout_response = api_client.post("/api/v2/auth/logout", json={})
+        assert logout_response.status_code == 200
+
+        session.expire_all()
+        assert (
+            session.query(UserSession).filter(UserSession.refresh_token == _hash_token(tokens["refresh_token"])).first()
+            is None
+        )
 
     def test_refresh_after_logout_returns_401(self, api_client, session):
         """After logout, using the old refresh token should return 401."""
@@ -761,7 +786,6 @@ class TestLogoutEndpoint:
         api_client.post(
             "/api/v2/auth/logout",
             json={"refresh_token": tokens["refresh_token"]},
-            headers={"Authorization": f"Bearer {tokens['access_token']}"},
         )
 
         response = api_client.post(
@@ -770,8 +794,13 @@ class TestLogoutEndpoint:
         )
         assert response.status_code == 401
 
-    def test_logout_without_access_token_returns_401(self, api_client, session):
-        """Logout with no Bearer token should be rejected."""
+    def test_logout_without_refresh_token_returns_401(self, api_client, session):
+        """Logout with no refresh token or cookie should be rejected."""
+        response = api_client.post("/api/v2/auth/logout")
+        assert response.status_code == 401
+
+    def test_logout_with_invalid_refresh_token_returns_401(self, api_client, session):
+        """Logout with an invalid refresh token should be rejected."""
         response = api_client.post(
             "/api/v2/auth/logout",
             json={"refresh_token": "sometoken"},
@@ -796,7 +825,6 @@ class TestLogoutEndpoint:
         api_client.post(
             "/api/v2/auth/logout",
             json={"refresh_token": tokens1["refresh_token"]},
-            headers={"Authorization": f"Bearer {tokens1['access_token']}"},
         )
 
         # Second session should still be usable

--- a/tests/test_api_v2_users.py
+++ b/tests/test_api_v2_users.py
@@ -8,12 +8,13 @@ These tests verify:
 - Self-deletion/deactivation prevention
 """
 
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
 import bcrypt
 import pytest
 from fastapi.testclient import TestClient
-from datetime import UTC, datetime, timedelta
-import hashlib
-import uuid
 
 from ezrules.backend.api_v2.auth.jwt import create_access_token
 from ezrules.backend.api_v2.main import app
@@ -561,7 +562,7 @@ class TestDeleteUser:
         session.add(
             UserSession(
                 user_id=int(sample_user.id),
-                refresh_token="refresh-token-for-delete-test",
+                refresh_token=hashlib.sha256(b"refresh-token-for-delete-test").hexdigest(),
                 expires_at=now + timedelta(days=1),
             )
         )

--- a/tests/test_api_v2_users_session_revocation.py
+++ b/tests/test_api_v2_users_session_revocation.py
@@ -89,17 +89,17 @@ def test_admin_password_change_revokes_existing_refresh_sessions(user_admin_clie
         [
             UserSession(
                 user_id=managed_user_id,
-                refresh_token="managed-refresh-token-1",
+                refresh_token="a" * 64,
                 expires_at=session_expires_at,
             ),
             UserSession(
                 user_id=managed_user_id,
-                refresh_token="managed-refresh-token-2",
+                refresh_token="b" * 64,
                 expires_at=session_expires_at,
             ),
             UserSession(
                 user_id=admin_user_id,
-                refresh_token="admin-refresh-token",
+                refresh_token="c" * 64,
                 expires_at=session_expires_at,
             ),
         ]

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.27.0"
+version = "1.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Store refresh session rows as SHA-256 token hashes and add an Alembic migration that hashes existing plaintext rows.
- Move refresh/logout to an HttpOnly `ezrules_refresh_token` cookie only: refresh tokens are no longer returned in JSON responses or accepted in request bodies.
- Stop persisting refresh tokens in Angular `localStorage` and update auth docs/release notes for v1.28.1.

## Verification

- `uv run poe check`

## Not run

- Local pytest/Playwright suites, per project policy; GitHub Actions should provide the full hosted verification.

Asana: https://app.asana.com/1/106415343104513/project/1211443964065287/task/1213897230613642

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking authentication contract change (cookie-only refresh/logout, no JSON refresh token) plus a data migration on `user_session`; misconfigured CORS/cookies or non-browser API clients will fail refresh until they adopt cookies.
> 
> **Overview**
> **Refresh sessions are stored as SHA-256 hashes** instead of raw JWTs, with an Alembic upgrade that rewrites existing `user_session` rows and narrows `refresh_token` to 64 characters.
> 
> **Browser and API auth flows move refresh tokens off JSON and `localStorage`:** login/refresh return only an access token in the body and set or rotate an HttpOnly `ezrules_refresh_token` cookie (path `/api/v2/auth`, `SameSite=lax`, `Secure` when `APP_BASE_URL` is HTTPS). `POST /refresh` and `POST /logout` read the cookie only—`RefreshRequest` is removed and logout no longer requires a Bearer access token, so sessions can be revoked when the access token is already expired.
> 
> The Angular `AuthService` keeps the access token in `localStorage`, uses `withCredentials` on login/refresh/logout, and drops refresh-token body handling. Docs, release notes (v1.28.1), and tests/e2e mocks are updated for the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a2e2b1dacc3ac7c4d754cea3664b0b9f1d55ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->