### PR TITLE
Protect notification channel configs

### DIFF
--- a/alembic/versions/20260707_0036_encrypt_notification_channel_configs.py
+++ b/alembic/versions/20260707_0036_encrypt_notification_channel_configs.py
@@ -5,16 +5,14 @@ Revises: 20260706_0035
 Create Date: 2026-07-07
 """
 
-import json
 from collections.abc import Sequence
-from typing import Any
 
 import sqlalchemy as sa
 
 from alembic import op
 from ezrules.core.notification_channel_config import (
-    decrypt_notification_channel_config_unvalidated,
-    encrypt_notification_channel_config_unvalidated,
+    decrypt_notification_channel_config,
+    encrypt_notification_channel_config,
 )
 
 revision: str = "20260707_0036"
@@ -29,9 +27,7 @@ def upgrade() -> None:
     connection = op.get_bind()
     rows = connection.execute(sa.text("SELECT nc_id, channel_type, config FROM notification_channels")).mappings()
     for row in rows:
-        encrypted_config = encrypt_notification_channel_config_unvalidated(
-            _coerce_json_config(row["config"]),
-        )
+        encrypted_config = encrypt_notification_channel_config(str(row["channel_type"]), row["config"])
         connection.execute(
             sa.text("UPDATE notification_channels SET config_encrypted = :config_encrypted WHERE nc_id = :nc_id"),
             {"config_encrypted": encrypted_config, "nc_id": row["nc_id"]},
@@ -52,21 +48,8 @@ def downgrade() -> None:
         sa.text("SELECT nc_id, channel_type, config_encrypted FROM notification_channels")
     ).mappings()
     for row in rows:
-        config = decrypt_notification_channel_config_unvalidated(row["config_encrypted"])
+        config = decrypt_notification_channel_config(str(row["channel_type"]), row["config_encrypted"])
         connection.execute(update_config, {"config": config, "nc_id": row["nc_id"]})
 
     op.alter_column("notification_channels", "config", nullable=False)
     op.drop_column("notification_channels", "config_encrypted")
-
-
-def _coerce_json_config(raw_config: Any) -> Any:
-    if raw_config is None:
-        return {}
-    if isinstance(raw_config, dict | list | int | float | bool):
-        return raw_config
-    if isinstance(raw_config, str):
-        try:
-            return json.loads(raw_config)
-        except json.JSONDecodeError:
-            return raw_config
-    raise ValueError("notification_channels.config must contain JSON-serializable data")

--- a/alembic/versions/20260707_0036_encrypt_notification_channel_configs.py
+++ b/alembic/versions/20260707_0036_encrypt_notification_channel_configs.py
@@ -1,0 +1,72 @@
+"""Encrypt notification channel configs.
+
+Revision ID: 20260707_0036
+Revises: 20260706_0035
+Create Date: 2026-07-07
+"""
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+
+from alembic import op
+from ezrules.core.notification_channel_config import (
+    decrypt_notification_channel_config,
+    encrypt_notification_channel_config,
+)
+
+revision: str = "20260707_0036"
+down_revision: str | None = "20260706_0035"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("notification_channels", sa.Column("config_encrypted", sa.Text(), nullable=True))
+
+    connection = op.get_bind()
+    rows = connection.execute(sa.text("SELECT nc_id, channel_type, config FROM notification_channels")).mappings()
+    for row in rows:
+        encrypted_config = encrypt_notification_channel_config(
+            str(row["channel_type"]),
+            _coerce_json_config(row["config"]),
+        )
+        connection.execute(
+            sa.text("UPDATE notification_channels SET config_encrypted = :config_encrypted WHERE nc_id = :nc_id"),
+            {"config_encrypted": encrypted_config, "nc_id": row["nc_id"]},
+        )
+
+    op.alter_column("notification_channels", "config_encrypted", nullable=False)
+    op.drop_column("notification_channels", "config")
+
+
+def downgrade() -> None:
+    op.add_column("notification_channels", sa.Column("config", sa.JSON(), nullable=True))
+
+    connection = op.get_bind()
+    update_config = sa.text("UPDATE notification_channels SET config = :config WHERE nc_id = :nc_id").bindparams(
+        sa.bindparam("config", type_=sa.JSON())
+    )
+    rows = connection.execute(
+        sa.text("SELECT nc_id, channel_type, config_encrypted FROM notification_channels")
+    ).mappings()
+    for row in rows:
+        config = decrypt_notification_channel_config(str(row["channel_type"]), row["config_encrypted"])
+        connection.execute(update_config, {"config": config, "nc_id": row["nc_id"]})
+
+    op.alter_column("notification_channels", "config", nullable=False)
+    op.drop_column("notification_channels", "config_encrypted")
+
+
+def _coerce_json_config(raw_config: Any) -> dict[str, Any]:
+    if raw_config is None:
+        return {}
+    if isinstance(raw_config, dict):
+        return raw_config
+    if isinstance(raw_config, str):
+        decoded = json.loads(raw_config)
+        if isinstance(decoded, dict):
+            return decoded
+    raise ValueError("notification_channels.config must contain a JSON object")

--- a/alembic/versions/20260707_0036_encrypt_notification_channel_configs.py
+++ b/alembic/versions/20260707_0036_encrypt_notification_channel_configs.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 
 from alembic import op
 from ezrules.core.notification_channel_config import (
-    decrypt_notification_channel_config,
-    encrypt_notification_channel_config,
+    decrypt_notification_channel_config_unvalidated,
+    encrypt_notification_channel_config_unvalidated,
 )
 
 revision: str = "20260707_0036"
@@ -29,8 +29,7 @@ def upgrade() -> None:
     connection = op.get_bind()
     rows = connection.execute(sa.text("SELECT nc_id, channel_type, config FROM notification_channels")).mappings()
     for row in rows:
-        encrypted_config = encrypt_notification_channel_config(
-            str(row["channel_type"]),
+        encrypted_config = encrypt_notification_channel_config_unvalidated(
             _coerce_json_config(row["config"]),
         )
         connection.execute(
@@ -53,20 +52,21 @@ def downgrade() -> None:
         sa.text("SELECT nc_id, channel_type, config_encrypted FROM notification_channels")
     ).mappings()
     for row in rows:
-        config = decrypt_notification_channel_config(str(row["channel_type"]), row["config_encrypted"])
+        config = decrypt_notification_channel_config_unvalidated(row["config_encrypted"])
         connection.execute(update_config, {"config": config, "nc_id": row["nc_id"]})
 
     op.alter_column("notification_channels", "config", nullable=False)
     op.drop_column("notification_channels", "config_encrypted")
 
 
-def _coerce_json_config(raw_config: Any) -> dict[str, Any]:
+def _coerce_json_config(raw_config: Any) -> Any:
     if raw_config is None:
         return {}
-    if isinstance(raw_config, dict):
+    if isinstance(raw_config, dict | list | int | float | bool):
         return raw_config
     if isinstance(raw_config, str):
-        decoded = json.loads(raw_config)
-        if isinstance(decoded, dict):
-            return decoded
-    raise ValueError("notification_channels.config must contain a JSON object")
+        try:
+            return json.loads(raw_config)
+        except json.JSONDecodeError:
+            return raw_config
+    raise ValueError("notification_channels.config must contain JSON-serializable data")

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -266,6 +266,7 @@ Alert detection source of truth:
 - Alert rules count canonical served `evaluation_decisions` by `resolved_outcome`.
 - Evaluation-time detection is queued after the served decision is persisted; Celery beat also sweeps enabled alert rules as a repair loop.
 - V1 delivers via the in-app notification channel. Notification channel and policy tables are intentionally separate so email, Slack, PagerDuty, and webhook channels can be added later.
+- Notification channel configs are encrypted at rest, validated against an explicit schema per channel type, and redacted before safe display or dispatch-error persistence.
 
 ### Cases and Integration Events
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,9 +1,12 @@
 # What's New
 
+## v1.28.2
+
+* **Protected notification channel configs**: Notification channel configuration is now stored encrypted, validated by channel type, and redacted before dispatch errors or display-safe views can expose secret fields.
+
 ## v1.28.1
 
 * **User role assignment permission boundary**: Creating or inviting users no longer accepts `role_ids`; callers must create or invite the account first and then use the dedicated role-assignment endpoint with `MANAGE_USER_ROLES`.
-* **Protected notification channel configs**: Notification channel configuration is now stored encrypted, validated by channel type, and redacted before dispatch errors or display-safe views can expose secret fields.
 
 ## v1.28.0
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -3,6 +3,7 @@
 ## v1.28.1
 
 * **User role assignment permission boundary**: Creating or inviting users no longer accepts `role_ids`; callers must create or invite the account first and then use the dedicated role-assignment endpoint with `MANAGE_USER_ROLES`.
+* **Protected notification channel configs**: Notification channel configuration is now stored encrypted, validated by channel type, and redacted before dispatch errors or display-safe views can expose secret fields.
 
 ## v1.28.0
 

--- a/ezrules/backend/notifications/dispatcher.py
+++ b/ezrules/backend/notifications/dispatcher.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from ezrules.core.notification_channel_config import redact_notification_channel_error
 from ezrules.models.backend_core import (
     InAppNotification,
     NotificationAttempt,
@@ -153,7 +154,10 @@ def dispatch_notification(
             result = adapter.send(db, channel, message)
         except Exception as exc:
             logger.exception("Notification channel %s failed for incident %s", channel.nc_id, incident_id)
-            result = DeliveryResult(status="failure", error=str(exc))
+            result = DeliveryResult(
+                status="failure",
+                error=redact_notification_channel_error(str(channel.channel_type), channel.config, str(exc)),
+            )
 
         db.add(
             NotificationAttempt(

--- a/ezrules/backend/notifications/dispatcher.py
+++ b/ezrules/backend/notifications/dispatcher.py
@@ -12,6 +12,8 @@ from ezrules.models.backend_core import (
 
 logger = logging.getLogger(__name__)
 
+SAFE_REDACTION_FALLBACK_ERROR = "Notification delivery failed; error details could not be safely redacted"
+
 
 @dataclass(frozen=True, slots=True)
 class NotificationMessage:
@@ -107,6 +109,23 @@ def ensure_default_policy(db: Any, *, o_id: int, alert_rule_id: int) -> None:
     )
 
 
+def _redact_delivery_error(channel: NotificationChannel, error: str | None) -> str | None:
+    if error is None:
+        return None
+
+    try:
+        config = channel.config
+    except Exception:
+        logger.warning("Notification channel %s config could not be read while redacting error", channel.nc_id)
+        config = None
+
+    try:
+        return redact_notification_channel_error(str(channel.channel_type), config, error)
+    except Exception:
+        logger.exception("Notification channel %s error redaction failed", channel.nc_id)
+        return SAFE_REDACTION_FALLBACK_ERROR
+
+
 def dispatch_notification(
     db: Any, *, o_id: int, alert_rule_id: int, incident_id: int, message: NotificationMessage
 ) -> None:
@@ -156,8 +175,10 @@ def dispatch_notification(
             logger.exception("Notification channel %s failed for incident %s", channel.nc_id, incident_id)
             result = DeliveryResult(
                 status="failure",
-                error=redact_notification_channel_error(str(channel.channel_type), channel.config, str(exc)),
+                error=_redact_delivery_error(channel, str(exc)),
             )
+        else:
+            result = DeliveryResult(status=result.status, error=_redact_delivery_error(channel, result.error))
 
         db.add(
             NotificationAttempt(

--- a/ezrules/core/notification_channel_config.py
+++ b/ezrules/core/notification_channel_config.py
@@ -1,0 +1,243 @@
+import base64
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from ezrules.settings import app_settings
+
+CONFIG_ENCRYPTION_PREFIX = "fernet:v1:"
+REDACTED_VALUE = "[redacted]"
+
+
+@dataclass(frozen=True, slots=True)
+class NotificationChannelConfigSchema:
+    required_fields: frozenset[str]
+    optional_fields: frozenset[str]
+    secret_fields: frozenset[str]
+
+    @property
+    def allowed_fields(self) -> frozenset[str]:
+        return self.required_fields | self.optional_fields
+
+
+CHANNEL_CONFIG_SCHEMAS: dict[str, NotificationChannelConfigSchema] = {
+    "in_app": NotificationChannelConfigSchema(
+        required_fields=frozenset(),
+        optional_fields=frozenset(),
+        secret_fields=frozenset(),
+    ),
+    "email": NotificationChannelConfigSchema(
+        required_fields=frozenset({"to"}),
+        optional_fields=frozenset({"from_email", "reply_to", "smtp_host", "smtp_port", "smtp_user", "smtp_password"}),
+        secret_fields=frozenset({"smtp_password"}),
+    ),
+    "pagerduty": NotificationChannelConfigSchema(
+        required_fields=frozenset({"routing_key"}),
+        optional_fields=frozenset(),
+        secret_fields=frozenset({"routing_key"}),
+    ),
+    "slack": NotificationChannelConfigSchema(
+        required_fields=frozenset({"webhook_url"}),
+        optional_fields=frozenset({"channel", "username", "icon_emoji", "signing_secret"}),
+        secret_fields=frozenset({"webhook_url", "signing_secret"}),
+    ),
+    "webhook": NotificationChannelConfigSchema(
+        required_fields=frozenset({"url"}),
+        optional_fields=frozenset({"method", "headers", "signing_secret", "timeout_seconds"}),
+        secret_fields=frozenset({"url", "headers.authorization", "headers.x-api-key", "signing_secret"}),
+    ),
+}
+
+_SECRET_TEXT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(Bearer\s+)[A-Za-z0-9._~+/\-]+=*", re.IGNORECASE), rf"\1{REDACTED_VALUE}"),
+    (re.compile(r"([?&](?:api_?key|code|secret|sig|signature|token)=)[^&\s]+", re.IGNORECASE), rf"\1{REDACTED_VALUE}"),
+)
+
+
+def normalize_notification_channel_type(channel_type: str) -> str:
+    normalized = channel_type.strip().lower()
+    if normalized not in CHANNEL_CONFIG_SCHEMAS:
+        allowed = ", ".join(sorted(CHANNEL_CONFIG_SCHEMAS))
+        raise ValueError(f"Unsupported notification channel type '{channel_type}'. Allowed types: {allowed}")
+    return normalized
+
+
+def validate_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> dict[str, Any]:
+    normalized_type = normalize_notification_channel_type(channel_type)
+    if config is None:
+        candidate: dict[str, Any] = {}
+    elif isinstance(config, Mapping):
+        candidate = dict(config)
+    else:
+        raise ValueError("Notification channel config must be a JSON object")
+
+    schema = CHANNEL_CONFIG_SCHEMAS[normalized_type]
+    unknown_fields = sorted(set(candidate) - schema.allowed_fields)
+    if unknown_fields:
+        raise ValueError(f"Unsupported config field(s) for {normalized_type}: {', '.join(unknown_fields)}")
+
+    missing_fields = sorted(field for field in schema.required_fields if _is_empty_value(candidate.get(field)))
+    if missing_fields:
+        raise ValueError(f"Missing required config field(s) for {normalized_type}: {', '.join(missing_fields)}")
+
+    _validate_field_shapes(normalized_type, candidate)
+    return candidate
+
+
+def encrypt_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> str:
+    validated_config = validate_notification_channel_config(channel_type, config)
+    payload = json.dumps(validated_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return CONFIG_ENCRYPTION_PREFIX + _fernet().encrypt(payload).decode("utf-8")
+
+
+def decrypt_notification_channel_config(channel_type: str, encrypted_config: str | None) -> dict[str, Any]:
+    if not encrypted_config:
+        return validate_notification_channel_config(channel_type, {})
+    if not encrypted_config.startswith(CONFIG_ENCRYPTION_PREFIX):
+        raise ValueError("Notification channel config is not encrypted with a supported format")
+
+    token = encrypted_config.removeprefix(CONFIG_ENCRYPTION_PREFIX).encode("utf-8")
+    try:
+        payload = _fernet().decrypt(token)
+    except InvalidToken as exc:
+        raise ValueError("Notification channel config could not be decrypted") from exc
+
+    try:
+        decoded = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Notification channel config decrypted to invalid JSON") from exc
+    return validate_notification_channel_config(channel_type, decoded)
+
+
+def redact_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> dict[str, Any]:
+    validated_config = validate_notification_channel_config(channel_type, config)
+    schema = CHANNEL_CONFIG_SCHEMAS[normalize_notification_channel_type(channel_type)]
+    return {key: _redact_config_value((key,), value, schema.secret_fields) for key, value in validated_config.items()}
+
+
+def redact_notification_channel_error(
+    channel_type: str,
+    config: Mapping[str, Any] | None,
+    error_message: str | None,
+) -> str | None:
+    if error_message is None:
+        return None
+
+    redacted_message = error_message
+    for secret_value in _iter_secret_values(channel_type, config):
+        if secret_value:
+            redacted_message = redacted_message.replace(secret_value, REDACTED_VALUE)
+    for pattern, replacement in _SECRET_TEXT_PATTERNS:
+        redacted_message = pattern.sub(replacement, redacted_message)
+    return redacted_message
+
+
+def _fernet() -> Fernet:
+    digest = hashlib.sha256(app_settings.APP_SECRET.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))
+
+
+def _is_empty_value(value: Any) -> bool:
+    return value is None or value == "" or value == [] or value == {}
+
+
+def _validate_field_shapes(channel_type: str, config: Mapping[str, Any]) -> None:
+    if channel_type == "in_app" and config:
+        raise ValueError("in_app notification channel config must be empty")
+
+    for field in ("url", "webhook_url"):
+        if field in config:
+            _validate_http_url(field, config[field])
+
+    if "method" in config:
+        method = config["method"]
+        if method not in {"POST", "PUT", "PATCH"}:
+            raise ValueError("webhook method must be one of POST, PUT, PATCH")
+
+    if "headers" in config:
+        headers = config["headers"]
+        if not isinstance(headers, Mapping):
+            raise ValueError("webhook headers must be a JSON object")
+        for key, value in headers.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("webhook header names must be non-empty strings")
+            if not isinstance(value, str):
+                raise ValueError("webhook header values must be strings")
+
+    if "timeout_seconds" in config:
+        timeout_seconds = config["timeout_seconds"]
+        if not isinstance(timeout_seconds, int) or timeout_seconds < 1 or timeout_seconds > 60:
+            raise ValueError("webhook timeout_seconds must be an integer between 1 and 60")
+
+    if "smtp_port" in config:
+        smtp_port = config["smtp_port"]
+        if not isinstance(smtp_port, int) or smtp_port < 1 or smtp_port > 65535:
+            raise ValueError("email smtp_port must be an integer between 1 and 65535")
+
+    if "to" in config:
+        recipients = config["to"]
+        if (
+            not isinstance(recipients, list)
+            or not recipients
+            or not all(_is_non_empty_string(item) for item in recipients)
+        ):
+            raise ValueError("email to must be a non-empty list of email addresses")
+
+    for field in ("routing_key", "signing_secret", "smtp_password", "smtp_user", "smtp_host", "from_email", "reply_to"):
+        if field in config and not _is_non_empty_string(config[field]):
+            raise ValueError(f"{field} must be a non-empty string")
+
+
+def _validate_http_url(field: str, value: Any) -> None:
+    if not _is_non_empty_string(value):
+        raise ValueError(f"{field} must be a non-empty URL")
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"{field} must be an HTTP(S) URL")
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _redact_config_value(path: tuple[str, ...], value: Any, secret_fields: frozenset[str]) -> Any:
+    normalized_path = ".".join(path).lower()
+    if normalized_path in secret_fields:
+        return REDACTED_VALUE if not _is_empty_value(value) else value
+    if isinstance(value, Mapping):
+        return {key: _redact_config_value((*path, str(key)), item, secret_fields) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_config_value(path, item, secret_fields) for item in value]
+    return value
+
+
+def _iter_secret_values(channel_type: str, config: Mapping[str, Any] | None) -> list[str]:
+    redacted_config = redact_notification_channel_config(channel_type, config)
+    original_config = validate_notification_channel_config(channel_type, config)
+    secret_values: list[str] = []
+    _collect_redacted_values(original_config, redacted_config, secret_values)
+    return secret_values
+
+
+def _collect_redacted_values(original: Any, redacted: Any, values: list[str]) -> None:
+    if redacted == REDACTED_VALUE:
+        if isinstance(original, str):
+            values.append(original)
+        elif isinstance(original, Mapping):
+            values.extend(str(value) for value in original.values() if isinstance(value, str))
+        elif isinstance(original, list):
+            values.extend(str(value) for value in original if isinstance(value, str))
+        return
+    if isinstance(original, Mapping) and isinstance(redacted, Mapping):
+        for key, value in original.items():
+            _collect_redacted_values(value, redacted.get(key), values)
+    elif isinstance(original, list) and isinstance(redacted, list):
+        for index, value in enumerate(original):
+            if index < len(redacted):
+                _collect_redacted_values(value, redacted[index], values)

--- a/ezrules/core/notification_channel_config.py
+++ b/ezrules/core/notification_channel_config.py
@@ -1,18 +1,21 @@
 import base64
 import hashlib
 import json
+import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 from cryptography.fernet import Fernet, InvalidToken
 
-from ezrules.settings import app_settings
+from ezrules.settings import SETTINGS_ENV_FILE, app_settings
 
 CONFIG_ENCRYPTION_PREFIX = "fernet:v1:"
 REDACTED_VALUE = "[redacted]"
+ALEMBIC_PLACEHOLDER_APP_SECRET = "alembic-placeholder-secret"
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,7 +105,12 @@ def encrypt_notification_channel_config_unvalidated(config: Any) -> str:
 
 def decrypt_notification_channel_config(channel_type: str, encrypted_config: str | None) -> dict[str, Any]:
     decoded = decrypt_notification_channel_config_unvalidated(encrypted_config)
-    return validate_notification_channel_config(channel_type, decoded)
+    try:
+        return validate_notification_channel_config(channel_type, decoded)
+    except ValueError:
+        if isinstance(decoded, Mapping):
+            return dict(decoded)
+        return {"legacy_value": decoded}
 
 
 def decrypt_notification_channel_config_unvalidated(encrypted_config: str | None) -> Any:
@@ -148,8 +156,39 @@ def redact_notification_channel_error(
 
 
 def _fernet() -> Fernet:
-    digest = hashlib.sha256(app_settings.APP_SECRET.encode("utf-8")).digest()
+    digest = hashlib.sha256(_notification_config_app_secret().encode("utf-8")).digest()
     return Fernet(base64.urlsafe_b64encode(digest))
+
+
+def _notification_config_app_secret() -> str:
+    env_secret = os.getenv("EZRULES_APP_SECRET")
+    if env_secret and env_secret != ALEMBIC_PLACEHOLDER_APP_SECRET:
+        return env_secret
+
+    env_file_secret = _read_app_secret_from_settings_env()
+    if env_file_secret:
+        return env_file_secret
+
+    if app_settings.APP_SECRET and app_settings.APP_SECRET != ALEMBIC_PLACEHOLDER_APP_SECRET:
+        return app_settings.APP_SECRET
+
+    raise ValueError("Notification channel config encryption requires a non-placeholder EZRULES_APP_SECRET")
+
+
+def _read_app_secret_from_settings_env() -> str | None:
+    env_file = Path(SETTINGS_ENV_FILE)
+    if not env_file.exists():
+        return None
+
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key.strip() != "EZRULES_APP_SECRET":
+            continue
+        return value.strip().strip('"').strip("'")
+    return None
 
 
 def _is_empty_value(value: Any) -> bool:

--- a/ezrules/core/notification_channel_config.py
+++ b/ezrules/core/notification_channel_config.py
@@ -92,13 +92,22 @@ def validate_notification_channel_config(channel_type: str, config: Mapping[str,
 
 def encrypt_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> str:
     validated_config = validate_notification_channel_config(channel_type, config)
-    payload = json.dumps(validated_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return encrypt_notification_channel_config_unvalidated(validated_config)
+
+
+def encrypt_notification_channel_config_unvalidated(config: Any) -> str:
+    payload = json.dumps(config, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return CONFIG_ENCRYPTION_PREFIX + _fernet().encrypt(payload).decode("utf-8")
 
 
 def decrypt_notification_channel_config(channel_type: str, encrypted_config: str | None) -> dict[str, Any]:
+    decoded = decrypt_notification_channel_config_unvalidated(encrypted_config)
+    return validate_notification_channel_config(channel_type, decoded)
+
+
+def decrypt_notification_channel_config_unvalidated(encrypted_config: str | None) -> Any:
     if not encrypted_config:
-        return validate_notification_channel_config(channel_type, {})
+        return {}
     if not encrypted_config.startswith(CONFIG_ENCRYPTION_PREFIX):
         raise ValueError("Notification channel config is not encrypted with a supported format")
 
@@ -112,7 +121,7 @@ def decrypt_notification_channel_config(channel_type: str, encrypted_config: str
         decoded = json.loads(payload.decode("utf-8"))
     except json.JSONDecodeError as exc:
         raise ValueError("Notification channel config decrypted to invalid JSON") from exc
-    return validate_notification_channel_config(channel_type, decoded)
+    return decoded
 
 
 def redact_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -130,7 +139,7 @@ def redact_notification_channel_error(
         return None
 
     redacted_message = error_message
-    for secret_value in _iter_secret_values(channel_type, config):
+    for secret_value in _iter_secret_values_for_error(channel_type, config):
         if secret_value:
             redacted_message = redacted_message.replace(secret_value, REDACTED_VALUE)
     for pattern, replacement in _SECRET_TEXT_PATTERNS:
@@ -223,6 +232,49 @@ def _iter_secret_values(channel_type: str, config: Mapping[str, Any] | None) -> 
     secret_values: list[str] = []
     _collect_redacted_values(original_config, redacted_config, secret_values)
     return secret_values
+
+
+def _iter_secret_values_for_error(channel_type: str, config: Mapping[str, Any] | None) -> list[str]:
+    if not isinstance(config, Mapping):
+        return []
+    try:
+        schema = CHANNEL_CONFIG_SCHEMAS[normalize_notification_channel_type(channel_type)]
+    except ValueError:
+        return []
+
+    secret_values: list[str] = []
+    for secret_field in schema.secret_fields:
+        value = _get_path_value(config, tuple(secret_field.split(".")))
+        _collect_string_values(value, secret_values)
+    return secret_values
+
+
+def _get_path_value(config: Mapping[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = config
+    for segment in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = _get_mapping_value_case_insensitive(current, segment)
+    return current
+
+
+def _get_mapping_value_case_insensitive(config: Mapping[str, Any], key: str) -> Any:
+    if key in config:
+        return config[key]
+    normalized_key = key.lower()
+    for candidate_key, value in config.items():
+        if str(candidate_key).lower() == normalized_key:
+            return value
+    return None
+
+
+def _collect_string_values(value: Any, values: list[str]) -> None:
+    if isinstance(value, str):
+        values.append(value)
+    elif isinstance(value, Mapping):
+        values.extend(str(item) for item in value.values() if isinstance(item, str))
+    elif isinstance(value, list):
+        values.extend(str(item) for item in value if isinstance(item, str))
 
 
 def _collect_redacted_values(original: Any, redacted: Any, values: list[str]) -> None:

--- a/ezrules/core/notification_channel_config.py
+++ b/ezrules/core/notification_channel_config.py
@@ -1,21 +1,18 @@
 import base64
 import hashlib
 import json
-import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 from cryptography.fernet import Fernet, InvalidToken
 
-from ezrules.settings import SETTINGS_ENV_FILE, app_settings
+from ezrules.settings import app_settings
 
 CONFIG_ENCRYPTION_PREFIX = "fernet:v1:"
 REDACTED_VALUE = "[redacted]"
-ALEMBIC_PLACEHOLDER_APP_SECRET = "alembic-placeholder-secret"
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,25 +92,11 @@ def validate_notification_channel_config(channel_type: str, config: Mapping[str,
 
 def encrypt_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> str:
     validated_config = validate_notification_channel_config(channel_type, config)
-    return encrypt_notification_channel_config_unvalidated(validated_config)
-
-
-def encrypt_notification_channel_config_unvalidated(config: Any) -> str:
-    payload = json.dumps(config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload = json.dumps(validated_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return CONFIG_ENCRYPTION_PREFIX + _fernet().encrypt(payload).decode("utf-8")
 
 
 def decrypt_notification_channel_config(channel_type: str, encrypted_config: str | None) -> dict[str, Any]:
-    decoded = decrypt_notification_channel_config_unvalidated(encrypted_config)
-    try:
-        return validate_notification_channel_config(channel_type, decoded)
-    except ValueError:
-        if isinstance(decoded, Mapping):
-            return dict(decoded)
-        return {"legacy_value": decoded}
-
-
-def decrypt_notification_channel_config_unvalidated(encrypted_config: str | None) -> Any:
     if not encrypted_config:
         return {}
     if not encrypted_config.startswith(CONFIG_ENCRYPTION_PREFIX):
@@ -129,7 +112,7 @@ def decrypt_notification_channel_config_unvalidated(encrypted_config: str | None
         decoded = json.loads(payload.decode("utf-8"))
     except json.JSONDecodeError as exc:
         raise ValueError("Notification channel config decrypted to invalid JSON") from exc
-    return decoded
+    return validate_notification_channel_config(channel_type, decoded)
 
 
 def redact_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -156,39 +139,8 @@ def redact_notification_channel_error(
 
 
 def _fernet() -> Fernet:
-    digest = hashlib.sha256(_notification_config_app_secret().encode("utf-8")).digest()
+    digest = hashlib.sha256(app_settings.APP_SECRET.encode("utf-8")).digest()
     return Fernet(base64.urlsafe_b64encode(digest))
-
-
-def _notification_config_app_secret() -> str:
-    env_secret = os.getenv("EZRULES_APP_SECRET")
-    if env_secret and env_secret != ALEMBIC_PLACEHOLDER_APP_SECRET:
-        return env_secret
-
-    env_file_secret = _read_app_secret_from_settings_env()
-    if env_file_secret:
-        return env_file_secret
-
-    if app_settings.APP_SECRET and app_settings.APP_SECRET != ALEMBIC_PLACEHOLDER_APP_SECRET:
-        return app_settings.APP_SECRET
-
-    raise ValueError("Notification channel config encryption requires a non-placeholder EZRULES_APP_SECRET")
-
-
-def _read_app_secret_from_settings_env() -> str | None:
-    env_file = Path(SETTINGS_ENV_FILE)
-    if not env_file.exists():
-        return None
-
-    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        if key.strip() != "EZRULES_APP_SECRET":
-            continue
-        return value.strip().strip('"').strip("'")
-    return None
 
 
 def _is_empty_value(value: Any) -> bool:

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -727,6 +727,9 @@ class AlertIncident(Base):
     acknowledged_by = Column(String(255), nullable=True)
 
 
+_CONFIG_NOT_PROVIDED = object()
+
+
 class NotificationChannel(Base):
     __tablename__ = "notification_channels"
     __table_args__ = (
@@ -747,6 +750,12 @@ class NotificationChannel(Base):
         onupdate=lambda: datetime.datetime.now(datetime.UTC),
         nullable=False,
     )
+
+    def __init__(self, **kwargs: Any) -> None:
+        config = kwargs.pop("config", _CONFIG_NOT_PROVIDED)
+        super().__init__(**kwargs)
+        if config is not _CONFIG_NOT_PROVIDED:
+            self.config = config
 
     @property
     def config(self) -> dict[str, Any]:

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -1,5 +1,6 @@
 import datetime
 from enum import Enum
+from typing import Any
 
 from sqlalchemy import (
     JSON,
@@ -25,6 +26,11 @@ from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import Mapped, backref, mapped_column, relationship
 
 from ezrules.core.application_context import get_organization_id
+from ezrules.core.notification_channel_config import (
+    decrypt_notification_channel_config,
+    encrypt_notification_channel_config,
+    redact_notification_channel_config,
+)
 from ezrules.models.database import Base
 
 
@@ -733,7 +739,7 @@ class NotificationChannel(Base):
     name = Column(String(255), nullable=False)
     channel_type = Column(String(64), nullable=False)
     enabled = Column(Boolean, nullable=False, default=True)
-    config = Column(JSON, nullable=False, default=dict)
+    config_encrypted = Column(Text, nullable=False, default="")
     created_at = Column(DateTime, default=lambda: datetime.datetime.now(datetime.UTC), nullable=False)
     updated_at = Column(
         DateTime,
@@ -741,6 +747,18 @@ class NotificationChannel(Base):
         onupdate=lambda: datetime.datetime.now(datetime.UTC),
         nullable=False,
     )
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return decrypt_notification_channel_config(str(self.channel_type), str(self.config_encrypted or ""))
+
+    @config.setter
+    def config(self, value: dict[str, Any] | None) -> None:
+        self.config_encrypted = encrypt_notification_channel_config(str(self.channel_type), value)
+
+    @property
+    def redacted_config(self) -> dict[str, Any]:
+        return redact_notification_channel_config(str(self.channel_type), self.config)
 
 
 class NotificationPolicy(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.1"
+version = "1.28.2"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_notification_channel_config.py
+++ b/tests/test_notification_channel_config.py
@@ -1,0 +1,135 @@
+import datetime
+
+import pytest
+
+from ezrules.backend.notifications.dispatcher import CHANNEL_ADAPTERS, NotificationMessage, dispatch_notification
+from ezrules.core.notification_channel_config import REDACTED_VALUE
+from ezrules.models.backend_core import (
+    AlertIncident,
+    AlertRule,
+    NotificationAttempt,
+    NotificationChannel,
+    NotificationPolicy,
+    Organisation,
+)
+
+
+def test_notification_channel_config_is_encrypted_and_redacted():
+    config = {
+        "url": "https://hooks.example.com/secret-token",
+        "headers": {"Authorization": "Bearer api-token", "X-Trace": "visible"},
+        "signing_secret": "shared-secret",
+        "timeout_seconds": 10,
+    }
+
+    channel = NotificationChannel(
+        o_id=1,
+        name="Risk webhook",
+        channel_type="webhook",
+        enabled=True,
+        config=config,
+    )
+
+    assert channel.config == config
+    assert "secret-token" not in channel.config_encrypted
+    assert "api-token" not in channel.config_encrypted
+    assert "shared-secret" not in channel.config_encrypted
+    assert channel.redacted_config == {
+        "url": REDACTED_VALUE,
+        "headers": {"Authorization": REDACTED_VALUE, "X-Trace": "visible"},
+        "signing_secret": REDACTED_VALUE,
+        "timeout_seconds": 10,
+    }
+
+
+def test_notification_channel_config_rejects_unknown_and_missing_fields():
+    with pytest.raises(ValueError, match="Missing required config field"):
+        NotificationChannel(o_id=1, name="Slack", channel_type="slack", config={})
+
+    with pytest.raises(ValueError, match="Unsupported config field"):
+        NotificationChannel(
+            o_id=1,
+            name="Webhook",
+            channel_type="webhook",
+            config={"url": "https://hooks.example.com/a", "plaintext_token": "nope"},
+        )
+
+
+def test_dispatch_failure_persists_redacted_error(session, monkeypatch):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    rule = AlertRule(
+        o_id=int(org.o_id),
+        name="Cancel spike",
+        outcome="CANCEL",
+        threshold=1,
+        window_seconds=3600,
+        cooldown_seconds=1800,
+        enabled=True,
+    )
+    channel = NotificationChannel(
+        o_id=int(org.o_id),
+        name="Escalation webhook",
+        channel_type="webhook",
+        enabled=True,
+        config={
+            "url": "https://hooks.example.com/hidden-token",
+            "headers": {"Authorization": "Bearer hidden-auth"},
+            "signing_secret": "hidden-signing-secret",
+        },
+    )
+    session.add_all([rule, channel])
+    session.flush()
+    incident = AlertIncident(
+        o_id=int(org.o_id),
+        alert_rule_id=int(rule.ar_id),
+        outcome="CANCEL",
+        observed_count=2,
+        threshold=1,
+        window_start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1),
+        window_end=datetime.datetime.now(datetime.UTC),
+        dedupe_key="redaction-test",
+    )
+    session.add(incident)
+    session.flush()
+    session.add(
+        NotificationPolicy(
+            o_id=int(org.o_id),
+            alert_rule_id=int(rule.ar_id),
+            notification_channel_id=int(channel.nc_id),
+            enabled=True,
+        )
+    )
+
+    class FailingWebhookAdapter:
+        channel_type = "webhook"
+
+        def send(self, db, channel, message):
+            raise RuntimeError(
+                "failed "
+                f"{channel.config['url']} "
+                f"{channel.config['headers']['Authorization']} "
+                f"{channel.config['signing_secret']}"
+            )
+
+    monkeypatch.setitem(CHANNEL_ADAPTERS, "webhook", FailingWebhookAdapter())
+
+    dispatch_notification(
+        session,
+        o_id=int(org.o_id),
+        alert_rule_id=int(rule.ar_id),
+        incident_id=int(incident.ai_id),
+        message=NotificationMessage(
+            title="CANCEL spike detected",
+            body="2 CANCEL decisions in the last 60 minutes.",
+            severity="critical",
+            source_type="alert_incident",
+            source_id=int(incident.ai_id),
+        ),
+    )
+
+    attempt = session.query(NotificationAttempt).one()
+    assert attempt.status == "failure"
+    assert "hidden-token" not in str(attempt.error)
+    assert "hidden-auth" not in str(attempt.error)
+    assert "hidden-signing-secret" not in str(attempt.error)
+    assert str(attempt.error).count(REDACTED_VALUE) == 3

--- a/tests/test_notification_channel_config.py
+++ b/tests/test_notification_channel_config.py
@@ -2,7 +2,6 @@ import datetime
 
 import pytest
 
-import ezrules.core.notification_channel_config as config_module
 from ezrules.backend.notifications.dispatcher import (
     CHANNEL_ADAPTERS,
     SAFE_REDACTION_FALLBACK_ERROR,
@@ -12,9 +11,6 @@ from ezrules.backend.notifications.dispatcher import (
 )
 from ezrules.core.notification_channel_config import (
     REDACTED_VALUE,
-    decrypt_notification_channel_config,
-    decrypt_notification_channel_config_unvalidated,
-    encrypt_notification_channel_config_unvalidated,
 )
 from ezrules.models.backend_core import (
     AlertIncident,
@@ -79,41 +75,6 @@ def test_notification_channel_config_init_applies_config_after_channel_type():
     )
 
     assert channel.config == config
-
-
-def test_legacy_notification_channel_config_encryption_skips_validation():
-    legacy_config = {"unexpected": "legacy", "nested": ["still", "encrypted"]}
-
-    encrypted_config = encrypt_notification_channel_config_unvalidated(legacy_config)
-
-    assert "legacy" not in encrypted_config
-    assert decrypt_notification_channel_config_unvalidated(encrypted_config) == legacy_config
-    assert decrypt_notification_channel_config("webhook", encrypted_config) == legacy_config
-
-
-def test_placeholder_app_secret_uses_settings_env_secret(monkeypatch, tmp_path):
-    legacy_config = {"unexpected": "legacy"}
-    settings_env = tmp_path / "settings.env"
-    settings_env.write_text('EZRULES_APP_SECRET="settings-env-secret"\n', encoding="utf-8")
-
-    monkeypatch.setenv("EZRULES_APP_SECRET", config_module.ALEMBIC_PLACEHOLDER_APP_SECRET)
-    monkeypatch.setattr(config_module, "SETTINGS_ENV_FILE", str(settings_env))
-
-    encrypted_config = encrypt_notification_channel_config_unvalidated(legacy_config)
-
-    monkeypatch.setenv("EZRULES_APP_SECRET", "settings-env-secret")
-    monkeypatch.setattr(config_module, "SETTINGS_ENV_FILE", str(tmp_path / "missing.env"))
-
-    assert decrypt_notification_channel_config_unvalidated(encrypted_config) == legacy_config
-
-
-def test_placeholder_app_secret_without_real_secret_is_rejected(monkeypatch, tmp_path):
-    monkeypatch.setenv("EZRULES_APP_SECRET", config_module.ALEMBIC_PLACEHOLDER_APP_SECRET)
-    monkeypatch.setattr(config_module, "SETTINGS_ENV_FILE", str(tmp_path / "missing.env"))
-    monkeypatch.setattr(config_module.app_settings, "APP_SECRET", config_module.ALEMBIC_PLACEHOLDER_APP_SECRET)
-
-    with pytest.raises(ValueError, match="non-placeholder EZRULES_APP_SECRET"):
-        encrypt_notification_channel_config_unvalidated({})
 
 
 def test_dispatch_failure_persists_redacted_error(session, monkeypatch):

--- a/tests/test_notification_channel_config.py
+++ b/tests/test_notification_channel_config.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 
+import ezrules.core.notification_channel_config as config_module
 from ezrules.backend.notifications.dispatcher import (
     CHANNEL_ADAPTERS,
     SAFE_REDACTION_FALLBACK_ERROR,
@@ -11,6 +12,7 @@ from ezrules.backend.notifications.dispatcher import (
 )
 from ezrules.core.notification_channel_config import (
     REDACTED_VALUE,
+    decrypt_notification_channel_config,
     decrypt_notification_channel_config_unvalidated,
     encrypt_notification_channel_config_unvalidated,
 )
@@ -72,6 +74,32 @@ def test_legacy_notification_channel_config_encryption_skips_validation():
 
     assert "legacy" not in encrypted_config
     assert decrypt_notification_channel_config_unvalidated(encrypted_config) == legacy_config
+    assert decrypt_notification_channel_config("webhook", encrypted_config) == legacy_config
+
+
+def test_placeholder_app_secret_uses_settings_env_secret(monkeypatch, tmp_path):
+    legacy_config = {"unexpected": "legacy"}
+    settings_env = tmp_path / "settings.env"
+    settings_env.write_text('EZRULES_APP_SECRET="settings-env-secret"\n', encoding="utf-8")
+
+    monkeypatch.setenv("EZRULES_APP_SECRET", config_module.ALEMBIC_PLACEHOLDER_APP_SECRET)
+    monkeypatch.setattr(config_module, "SETTINGS_ENV_FILE", str(settings_env))
+
+    encrypted_config = encrypt_notification_channel_config_unvalidated(legacy_config)
+
+    monkeypatch.setenv("EZRULES_APP_SECRET", "settings-env-secret")
+    monkeypatch.setattr(config_module, "SETTINGS_ENV_FILE", str(tmp_path / "missing.env"))
+
+    assert decrypt_notification_channel_config_unvalidated(encrypted_config) == legacy_config
+
+
+def test_placeholder_app_secret_without_real_secret_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv("EZRULES_APP_SECRET", config_module.ALEMBIC_PLACEHOLDER_APP_SECRET)
+    monkeypatch.setattr(config_module, "SETTINGS_ENV_FILE", str(tmp_path / "missing.env"))
+    monkeypatch.setattr(config_module.app_settings, "APP_SECRET", config_module.ALEMBIC_PLACEHOLDER_APP_SECRET)
+
+    with pytest.raises(ValueError, match="non-placeholder EZRULES_APP_SECRET"):
+        encrypt_notification_channel_config_unvalidated({})
 
 
 def test_dispatch_failure_persists_redacted_error(session, monkeypatch):

--- a/tests/test_notification_channel_config.py
+++ b/tests/test_notification_channel_config.py
@@ -67,6 +67,20 @@ def test_notification_channel_config_rejects_unknown_and_missing_fields():
         )
 
 
+def test_notification_channel_config_init_applies_config_after_channel_type():
+    config = {"url": "https://hooks.example.com/secret-token"}
+
+    channel = NotificationChannel(
+        o_id=1,
+        name="Order-insensitive webhook",
+        config=config,
+        channel_type="webhook",
+        enabled=True,
+    )
+
+    assert channel.config == config
+
+
 def test_legacy_notification_channel_config_encryption_skips_validation():
     legacy_config = {"unexpected": "legacy", "nested": ["still", "encrypted"]}
 

--- a/tests/test_notification_channel_config.py
+++ b/tests/test_notification_channel_config.py
@@ -2,8 +2,18 @@ import datetime
 
 import pytest
 
-from ezrules.backend.notifications.dispatcher import CHANNEL_ADAPTERS, NotificationMessage, dispatch_notification
-from ezrules.core.notification_channel_config import REDACTED_VALUE
+from ezrules.backend.notifications.dispatcher import (
+    CHANNEL_ADAPTERS,
+    SAFE_REDACTION_FALLBACK_ERROR,
+    DeliveryResult,
+    NotificationMessage,
+    dispatch_notification,
+)
+from ezrules.core.notification_channel_config import (
+    REDACTED_VALUE,
+    decrypt_notification_channel_config_unvalidated,
+    encrypt_notification_channel_config_unvalidated,
+)
 from ezrules.models.backend_core import (
     AlertIncident,
     AlertRule,
@@ -53,6 +63,15 @@ def test_notification_channel_config_rejects_unknown_and_missing_fields():
             channel_type="webhook",
             config={"url": "https://hooks.example.com/a", "plaintext_token": "nope"},
         )
+
+
+def test_legacy_notification_channel_config_encryption_skips_validation():
+    legacy_config = {"unexpected": "legacy", "nested": ["still", "encrypted"]}
+
+    encrypted_config = encrypt_notification_channel_config_unvalidated(legacy_config)
+
+    assert "legacy" not in encrypted_config
+    assert decrypt_notification_channel_config_unvalidated(encrypted_config) == legacy_config
 
 
 def test_dispatch_failure_persists_redacted_error(session, monkeypatch):
@@ -133,3 +152,154 @@ def test_dispatch_failure_persists_redacted_error(session, monkeypatch):
     assert "hidden-auth" not in str(attempt.error)
     assert "hidden-signing-secret" not in str(attempt.error)
     assert str(attempt.error).count(REDACTED_VALUE) == 3
+
+
+def test_dispatch_returned_failure_error_is_redacted(session, monkeypatch):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    rule, channel, incident = _add_webhook_policy_fixture(session, org_id=int(org.o_id))
+
+    class FailedWebhookAdapter:
+        channel_type = "webhook"
+
+        def send(self, db, channel, message):
+            return DeliveryResult(
+                status="failure",
+                error=(
+                    "failed "
+                    f"{channel.config['url']} "
+                    f"{channel.config['headers']['Authorization']} "
+                    f"{channel.config['signing_secret']}"
+                ),
+            )
+
+    monkeypatch.setitem(CHANNEL_ADAPTERS, "webhook", FailedWebhookAdapter())
+
+    dispatch_notification(
+        session,
+        o_id=int(org.o_id),
+        alert_rule_id=int(rule.ar_id),
+        incident_id=int(incident.ai_id),
+        message=_notification_message(int(incident.ai_id)),
+    )
+
+    attempt = session.query(NotificationAttempt).one()
+    assert attempt.status == "failure"
+    assert "hidden-token" not in str(attempt.error)
+    assert "hidden-auth" not in str(attempt.error)
+    assert "hidden-signing-secret" not in str(attempt.error)
+    assert str(attempt.error).count(REDACTED_VALUE) == 3
+
+
+def test_dispatch_records_failure_when_config_cannot_be_read(session, monkeypatch):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    rule, channel, incident = _add_webhook_policy_fixture(session, org_id=int(org.o_id))
+    channel.config_encrypted = "not-encrypted"
+
+    class FailingWebhookAdapter:
+        channel_type = "webhook"
+
+        def send(self, db, channel, message):
+            raise RuntimeError("failed Bearer fallback-secret")
+
+    monkeypatch.setitem(CHANNEL_ADAPTERS, "webhook", FailingWebhookAdapter())
+
+    dispatch_notification(
+        session,
+        o_id=int(org.o_id),
+        alert_rule_id=int(rule.ar_id),
+        incident_id=int(incident.ai_id),
+        message=_notification_message(int(incident.ai_id)),
+    )
+
+    attempt = session.query(NotificationAttempt).one()
+    assert attempt.status == "failure"
+    assert "fallback-secret" not in str(attempt.error)
+    assert attempt.error == f"failed Bearer {REDACTED_VALUE}"
+
+
+def test_dispatch_uses_safe_fallback_if_redaction_fails(session, monkeypatch):
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    rule, _channel, incident = _add_webhook_policy_fixture(session, org_id=int(org.o_id))
+
+    class BadError:
+        def replace(self, old, new):
+            raise RuntimeError("replace failed")
+
+        def __str__(self):
+            return "still a string"
+
+    class FailedWebhookAdapter:
+        channel_type = "webhook"
+
+        def send(self, db, channel, message):
+            return DeliveryResult(status="failure", error=BadError())  # type: ignore[arg-type]
+
+    monkeypatch.setitem(CHANNEL_ADAPTERS, "webhook", FailedWebhookAdapter())
+
+    dispatch_notification(
+        session,
+        o_id=int(org.o_id),
+        alert_rule_id=int(rule.ar_id),
+        incident_id=int(incident.ai_id),
+        message=_notification_message(int(incident.ai_id)),
+    )
+
+    attempt = session.query(NotificationAttempt).one()
+    assert attempt.status == "failure"
+    assert attempt.error == SAFE_REDACTION_FALLBACK_ERROR
+
+
+def _add_webhook_policy_fixture(session, *, org_id: int):
+    rule = AlertRule(
+        o_id=org_id,
+        name="Cancel spike",
+        outcome="CANCEL",
+        threshold=1,
+        window_seconds=3600,
+        cooldown_seconds=1800,
+        enabled=True,
+    )
+    channel = NotificationChannel(
+        o_id=org_id,
+        name="Escalation webhook",
+        channel_type="webhook",
+        enabled=True,
+        config={
+            "url": "https://hooks.example.com/hidden-token",
+            "headers": {"Authorization": "Bearer hidden-auth"},
+            "signing_secret": "hidden-signing-secret",
+        },
+    )
+    session.add_all([rule, channel])
+    session.flush()
+    incident = AlertIncident(
+        o_id=org_id,
+        alert_rule_id=int(rule.ar_id),
+        outcome="CANCEL",
+        observed_count=2,
+        threshold=1,
+        window_start=datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1),
+        window_end=datetime.datetime.now(datetime.UTC),
+        dedupe_key="redaction-test",
+    )
+    session.add(incident)
+    session.flush()
+    session.add(
+        NotificationPolicy(
+            o_id=org_id,
+            alert_rule_id=int(rule.ar_id),
+            notification_channel_id=int(channel.nc_id),
+            enabled=True,
+        )
+    )
+    return rule, channel, incident
+
+
+def _notification_message(incident_id: int) -> NotificationMessage:
+    return NotificationMessage(
+        title="CANCEL spike detected",
+        body="2 CANCEL decisions in the last 60 minutes.",
+        severity="critical",
+        source_type="alert_incident",
+        source_id=incident_id,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.1"
+version = "1.28.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- store notification channel configs through a Fernet-backed `config_encrypted` column while preserving the `channel.config` model interface
- validate config shape by channel type for in-app, email, Slack, webhook, and PagerDuty channels, with explicit secret-field redaction rules
- scrub notification dispatch failure messages before persisting `NotificationAttempt.error`
- add the Alembic migration, regression coverage, docs note, and patch version bump to `1.28.1`

Asana: https://app.asana.com/1/106415343104513/project/1211443964065287/task/1214435668829085

## Verification

- `uv run poe check`
- `uv run ruff check tests/test_notification_channel_config.py alembic/versions/20260707_0036_encrypt_notification_channel_configs.py`
- `uv run pytest --collect-only -q tests/test_notification_channel_config.py`

## Notes

Full backend pytest and live Postgres migration execution are left to GitHub Actions per the repo verification policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration rewrites all channel configs and ties decryption to APP_SECRET; misconfiguration or failed migration could break notification delivery, but scope is limited to notification channels and includes downgrade path and tests.
> 
> **Overview**
> Notification channel settings move from plain JSON (`config`) to **Fernet-encrypted** `config_encrypted`, with an Alembic migration that re-encrypts existing rows and drops the old column. The `NotificationChannel` model keeps a **`config` property** for read/write and adds **`redacted_config`** for display-safe views.
> 
> A new **`notification_channel_config`** module validates configs per channel type (in-app, email, Slack, webhook, PagerDuty), encrypts/decrypts with `APP_SECRET`, and redacts secret fields plus common token patterns in error text.
> 
> **`dispatch_notification`** now runs delivery failures through redaction before persisting `NotificationAttempt.error`, with a safe fallback when redaction itself fails.
> 
> Docs and **v1.28.2** note the behavior; regression tests cover encryption, validation, and dispatch error scrubbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4ca1ff6bd3e436259d3b081d796a34f8df8afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->