### PR TITLE
Add live Redis/Celery CI smoke tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,92 @@ jobs:
 
     - name: Run tests
       run: uv run pytest -q --cov=ezrules.backend --cov=ezrules.core --cov-report=xml tests
+
+  redis-celery-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: root
+          POSTGRES_DB: tests
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      EZRULES_DB_ENDPOINT: postgresql://postgres:root@localhost:5432/tests
+      EZRULES_TESTING: "false"
+      EZRULES_APP_SECRET: "test-secret"
+      EZRULES_ORG_ID: "1"
+      EZRULES_CELERY_BROKER_URL: redis://localhost:6379/0
+      EZRULES_OBSERVATION_QUEUE_REDIS_URL: redis://localhost:6379/0
+      EZRULES_OBSERVATION_QUEUE_KEY: ezrules:ci:field_observation_queue
+      EZRULES_OBSERVATION_QUEUE_LOCK_KEY: ezrules:ci:field_observation_queue:lock
+      EZRULES_LIVE_REDIS_CELERY_SMOKE: "true"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install UV
+      uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Apply database migrations
+      run: uv run alembic upgrade head
+
+    - name: Start Celery worker
+      run: |
+        nohup uv run celery -A ezrules.backend.tasks worker -l INFO --pool=solo --concurrency=1 > /tmp/ezrules-worker.log 2>&1 &
+        echo $! > /tmp/ezrules-worker.pid
+
+    - name: Wait for Celery worker
+      run: |
+        for i in {1..30}; do
+          if uv run celery -A ezrules.backend.tasks inspect ping --timeout=5 | grep -q "pong"; then
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "Worker did not become ready in time"
+        cat /tmp/ezrules-worker.log || true
+        exit 1
+
+    - name: Run Redis/Celery smoke tests
+      run: uv run pytest -q tests/test_redis_celery_smoke.py
+
+    - name: Show Celery worker log on failure
+      if: failure()
+      run: cat /tmp/ezrules-worker.log || true
+
+    - name: Stop Celery worker
+      if: always()
+      run: |
+        if [ -f /tmp/ezrules-worker.pid ]; then
+          kill "$(cat /tmp/ezrules-worker.pid)" || true
+        fi

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,9 @@
 # What's New
 
+## v1.28.4
+
+* **Live Redis/Celery CI smoke lane**: Backend CI now includes a focused Postgres, Redis, and Celery worker job that exercises real queue draining, Redis locking, broker dispatch, result handling, and Redis-backed cache invalidation.
+
 ## v1.28.3
 
 * **Rule-quality report generation permission**: Added a dedicated `generate_rule_quality_reports` permission so readonly users can view existing rule-quality snapshots without being able to enqueue expensive refreshes or trigger synchronous report computation.

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,10 +1,13 @@
 # What's New
 
+## v1.28.5
+
+* **Live Redis/Celery CI smoke lane**: Backend CI now includes a focused Postgres, Redis, and Celery worker job that exercises real queue draining, Redis locking, broker dispatch, result handling, and Redis-backed cache invalidation.
+
 ## v1.28.4
 
 * **Canonical business scenario fixtures**: Added YAML-backed canonical scenarios for rule lifecycle, shadow/rollout provenance, labels and audit, graph-feature decisions, and backtesting so these operational journeys can be expanded from readable fixtures.
 * **Generated invariant coverage**: Added deterministic property-style fuzz tests for rule parsing/execution, dotted field paths, type casting, event normalization, CSV label upload parsing, idempotency-key scoping, duplicate evaluation lookup, and outcome resolution.
-* **Live Redis/Celery CI smoke lane**: Backend CI now includes a focused Postgres, Redis, and Celery worker job that exercises real queue draining, Redis locking, broker dispatch, result handling, and Redis-backed cache invalidation.
 
 ## v1.28.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.3"
+version = "1.28.4"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.4"
+version = "1.28.5"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_redis_celery_smoke.py
+++ b/tests/test_redis_celery_smoke.py
@@ -121,6 +121,7 @@ def test_real_celery_worker_drains_observation_queue_through_redis(reset_live_sm
     assert observed_rows == [
         ("amount", "int"),
         ("country", "str"),
+        ("risk", "dict"),
         ("risk.score", "float"),
     ]
 

--- a/tests/test_redis_celery_smoke.py
+++ b/tests/test_redis_celery_smoke.py
@@ -1,0 +1,161 @@
+import hashlib
+import os
+import secrets
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+import pytest
+from redis import Redis
+from sqlalchemy.orm import Session, sessionmaker
+
+from ezrules.backend import api_key_cache, observation_queue
+from ezrules.backend.runtime_settings import bump_api_key_cache_version
+from ezrules.backend.tasks import app as celery_app
+from ezrules.backend.tasks import drain_field_observation_queue
+from ezrules.models.backend_core import ApiKey, FieldObservation, Organisation
+from ezrules.models.database import engine
+from ezrules.settings import app_settings
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("EZRULES_LIVE_REDIS_CELERY_SMOKE") != "true",
+    reason="live Redis/Celery smoke tests run only in the dedicated CI lane",
+)
+
+
+SMOKE_ORG_ID = 1
+SMOKE_API_KEY_LABEL = "live-redis-celery-smoke"
+SessionLocal = sessionmaker(bind=engine)
+
+
+@contextmanager
+def _session_scope() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _ensure_smoke_org(session: Session) -> None:
+    if session.get(Organisation, SMOKE_ORG_ID) is None:
+        session.add(Organisation(o_id=SMOKE_ORG_ID, name="Live Redis Celery Smoke"))
+
+
+@pytest.fixture(autouse=True)
+def reset_live_smoke_state() -> Iterator[Redis]:
+    redis_client = Redis.from_url(app_settings.CELERY_BROKER_URL, decode_responses=True)
+    redis_client.delete(
+        app_settings.OBSERVATION_QUEUE_KEY,
+        app_settings.OBSERVATION_QUEUE_LOCK_KEY,
+        f"ezrules:api_key_auth_version:{SMOKE_ORG_ID}",
+    )
+    observation_queue.get_observation_queue_client.cache_clear()
+    api_key_cache.reset_api_key_auth_cache()
+    celery_app.conf.task_always_eager = False
+    celery_app.conf.task_eager_propagates = False
+
+    with _session_scope() as session:
+        _ensure_smoke_org(session)
+        session.query(FieldObservation).filter(FieldObservation.o_id == SMOKE_ORG_ID).delete()
+        session.query(ApiKey).filter(ApiKey.label == SMOKE_API_KEY_LABEL).delete()
+
+    yield redis_client
+
+    redis_client.delete(
+        app_settings.OBSERVATION_QUEUE_KEY,
+        app_settings.OBSERVATION_QUEUE_LOCK_KEY,
+        f"ezrules:api_key_auth_version:{SMOKE_ORG_ID}",
+    )
+    observation_queue.get_observation_queue_client.cache_clear()
+    api_key_cache.reset_api_key_auth_cache()
+
+
+def test_real_celery_worker_drains_observation_queue_through_redis(reset_live_smoke_state: Redis):
+    redis_client = reset_live_smoke_state
+
+    queued = observation_queue.enqueue_observations(
+        {"amount": 500, "country": "US", "risk": {"score": 0.82}},
+        SMOKE_ORG_ID,
+    )
+
+    assert queued is True
+    assert redis_client.llen(app_settings.OBSERVATION_QUEUE_KEY) == 1
+
+    held_lock = redis_client.lock(
+        app_settings.OBSERVATION_QUEUE_LOCK_KEY,
+        timeout=30,
+        blocking=False,
+    )
+    assert held_lock.acquire(blocking=False) is True
+
+    try:
+        skipped_result = drain_field_observation_queue.apply_async().get(timeout=20)
+    finally:
+        held_lock.release()
+
+    assert skipped_result == {"drained_batches": 0, "drained_messages": 0}
+    assert redis_client.llen(app_settings.OBSERVATION_QUEUE_KEY) == 1
+
+    drained_result = drain_field_observation_queue.apply_async().get(timeout=20)
+
+    assert drained_result == {"drained_batches": 1, "drained_messages": 1}
+    assert redis_client.llen(app_settings.OBSERVATION_QUEUE_KEY) == 0
+
+    with _session_scope() as session:
+        observed_rows = [
+            (row.field_name, row.observed_json_type)
+            for row in (
+                session.query(FieldObservation)
+                .filter(FieldObservation.o_id == SMOKE_ORG_ID)
+                .order_by(FieldObservation.field_name, FieldObservation.observed_json_type)
+                .all()
+            )
+        ]
+
+    assert observed_rows == [
+        ("amount", "int"),
+        ("country", "str"),
+        ("risk.score", "float"),
+    ]
+
+
+def test_real_redis_cache_version_invalidates_stale_api_key_metadata(reset_live_smoke_state: Redis):
+    redis_client = reset_live_smoke_state
+    raw_key = "ezrk_" + secrets.token_hex(32)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    worker_one_cache = api_key_cache.ApiKeyAuthCache()
+    worker_two_cache = api_key_cache.ApiKeyAuthCache()
+
+    with _session_scope() as session:
+        _ensure_smoke_org(session)
+        session.add(
+            ApiKey(
+                gid=str(uuid.uuid4()),
+                key_hash=key_hash,
+                label=SMOKE_API_KEY_LABEL,
+                o_id=SMOKE_ORG_ID,
+            )
+        )
+
+    with _session_scope() as session:
+        assert worker_one_cache.load(session, raw_key) == api_key_cache.ApiKeyAuthMetadata(org_id=SMOKE_ORG_ID)
+        assert worker_two_cache.load(session, raw_key) == api_key_cache.ApiKeyAuthMetadata(org_id=SMOKE_ORG_ID)
+
+    assert redis_client.get(f"ezrules:api_key_auth_version:{SMOKE_ORG_ID}") == "0"
+
+    with _session_scope() as session:
+        api_key = session.query(ApiKey).filter(ApiKey.key_hash == key_hash).one()
+        api_key.revoked_at = datetime.now(UTC)
+        next_version = bump_api_key_cache_version(session, SMOKE_ORG_ID)
+
+    assert worker_one_cache.publish(SMOKE_ORG_ID, next_version) is True
+    assert redis_client.get(f"ezrules:api_key_auth_version:{SMOKE_ORG_ID}") == str(next_version)
+
+    with _session_scope() as session:
+        assert worker_two_cache.load(session, raw_key) is None

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.3"
+version = "1.28.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.4"
+version = "1.28.5"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- add a skipped-by-default pytest smoke file for real Redis/Celery integration coverage
- exercise Redis queue serialization, cross-process Redis locking, Celery broker/worker dispatch, DB result handling, and field observation persistence
- exercise real Redis-backed API key cache version invalidation between worker-local cache instances
- add a dedicated backend CI job with Postgres, Redis, and a Celery worker so normal local/default test runs stay lightweight

## Validation
- uv run poe check

## Notes
- The live smoke tests are gated by EZRULES_LIVE_REDIS_CELERY_SMOKE=true and are intended to run in GitHub Actions with service containers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI, test, and release-note changes only; no production runtime or API behavior is modified.
> 
> **Overview**
> Adds **live Redis/Celery integration coverage** without changing default local pytest runs: new `tests/test_redis_celery_smoke.py` runs only when `EZRULES_LIVE_REDIS_CELERY_SMOKE=true`.
> 
> The smoke file exercises real **field observation queue** behavior (Redis list length, lock-held skip vs successful `drain_field_observation_queue` via Celery, nested field persistence) and **API key auth cache** invalidation across two in-process cache instances after `bump_api_key_cache_version` and Redis version publish.
> 
> Backend CI gains a separate **`redis-celery-smoke` job** (Postgres + Redis service containers, migrations, solo Celery worker with readiness ping, focused pytest, worker log on failure). Version is bumped to **1.28.5** with a whatsnew entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b868330b3bae15fb93c7c4c04c05b625d67d4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->