### PR TITLE
Harden Playwright diagnostics and stateful specs

### DIFF
--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,9 @@
 # What's New
 
+## v1.28.7
+
+* **Playwright E2E hardening**: Added shared deterministic test data, API setup/cleanup helpers, stateful-spec tags, failure diagnostics, and event-based waits so flaky runs are easier to debug.
+
 ## v1.28.6
 
 * **CLI smoke coverage in CI**: Promoted the database-backed CLI smoke flow into pytest so GitHub's backend test workflow now exercises core CLI commands against Postgres, replacing the legacy shell helper.

--- a/ezrules/frontend/e2e/README.md
+++ b/ezrules/frontend/e2e/README.md
@@ -49,6 +49,7 @@ npm run test:e2e
 e2e/
 ├── tests/           # Test specifications
 ├── pages/           # Page Object Models
+├── support/         # Shared config, API helpers, fixtures, and deterministic test data
 └── README.md        # This file
 ```
 
@@ -134,6 +135,9 @@ npm run test:e2e -- rule-list.spec.ts
 # Run tests matching a pattern
 npm run test:e2e -- --grep "should display"
 
+# Run stateful specs with repeats
+npm run test:e2e -- --grep "@stateful" --project=chromium --workers=1 --repeat-each=5
+
 # Run a specific test by line number
 npm run test:e2e -- rule-list.spec.ts:42
 ```
@@ -179,8 +183,9 @@ test('example test', async ({ page }) => {
 
 Example template:
 ```typescript
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { YourPage } from '../pages/your-page.page';
+import { testResourceName } from '../support/test-data';
 
 test.describe('Your Feature', () => {
   let yourPage: YourPage;
@@ -193,12 +198,13 @@ test.describe('Your Feature', () => {
   test('should do something', async () => {
     // Arrange
     await yourPage.waitForPageLoad();
+    const name = testResourceName(test.info(), 'E2E_RESOURCE');
 
     // Act
-    await yourPage.clickSomething();
+    await yourPage.createSomething(name);
 
     // Assert
-    await expect(yourPage.someElement).toBeVisible();
+    await expect(yourPage.rowFor(name)).toBeVisible();
   });
 });
 ```
@@ -250,11 +256,12 @@ Main configuration is in `playwright.config.ts`:
 - **Base URL**: `E2E_BASE_URL` (defaults to `http://localhost:4200`)
 - **Timeout**: 30s per test
 - **Retries**: 2 on CI, 0 locally
-- **Workers**: 4 parallel (1 on CI)
+- **Workers**: 1 locally, 4 on CI
 - **Browsers**: Chromium (Firefox and WebKit available)
 - **Screenshots**: On failure only
 - **Videos**: Retained on failure
-- **Traces**: On first retry
+- **Traces**: Retained on failure
+- **Diagnostics**: Specs importing `../support/fixtures` attach console errors, page errors, failed requests, and failed API response bodies on failure
 
 ## CI/CD Integration
 
@@ -287,9 +294,11 @@ Tests can be integrated into CI/CD pipelines. Example GitHub Actions workflow:
 
 ### Tests are flaky
 
-1. **Add explicit waits**: Use `waitFor()` instead of fixed `sleep()`
+1. **Add event-based waits**: Wait for responses, URL changes, toast text, modal close, row counts, or polling status instead of fixed sleeps
 2. **Check network timing**: Ensure API responses are awaited
-3. **Increase timeout**: For slow operations, use `test.setTimeout(60000)`
+3. **Use deterministic data**: Build names with `testResourceName(test.info(), ...)` so cleanup failures are easy to find
+4. **Tag stateful specs**: Add `@stateful` to settings/auth/global-order/data-mutating specs so they can be repeated with `--grep`
+5. **Increase timeout**: For slow operations, use `test.setTimeout(60000)`
 
 ### "Connection refused" errors
 
@@ -328,8 +337,10 @@ Likely a frontend/API topology mismatch rather than a bad password.
 3. **Clean state**: Each test should be independent
 4. **Descriptive names**: Test names should describe expected behavior
 5. **Arrange-Act-Assert**: Follow AAA pattern in tests
-6. **Wait explicitly**: Don't use `sleep()`, use `waitFor()` methods
-7. **Test user workflows**: Focus on real user journeys, not implementation details
+6. **Wait explicitly**: Don't use `sleep()`, use event-based waits or page-object wait helpers
+7. **Clean with API helpers**: Use `e2e/support/api-helpers.ts` for setup/cleanup such as rules, labels, user lists, field types, runtime settings, and outcome order
+8. **Assert restoration**: Specs that mutate shared state should restore the original value and assert it was restored
+9. **Test user workflows**: Focus on real user journeys, not implementation details
 
 ## Resources
 

--- a/ezrules/frontend/e2e/pages/api-keys.page.ts
+++ b/ezrules/frontend/e2e/pages/api-keys.page.ts
@@ -1,4 +1,5 @@
 import { Page, Locator } from '@playwright/test';
+import { acceptDialog } from '../support/dialogs';
 
 /**
  * Page Object Model for the API Keys management page.
@@ -65,7 +66,6 @@ export class ApiKeysPage {
 
   async revokeKeyByLabel(label: string) {
     const row = this.page.locator('[data-testid="api-key-row"]').filter({ hasText: label });
-    this.page.on('dialog', d => d.accept());
-    await row.locator('[data-testid="revoke-btn"]').click();
+    await acceptDialog(this.page, () => row.locator('[data-testid="revoke-btn"]').click());
   }
 }

--- a/ezrules/frontend/e2e/pages/field-types.page.ts
+++ b/ezrules/frontend/e2e/pages/field-types.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 /**
  * Page Object Model for the Field Types management page.
@@ -10,6 +10,7 @@ export class FieldTypesPage {
   readonly typeSelect: Locator;
   readonly saveButton: Locator;
   readonly loadingSpinner: Locator;
+  readonly configuredRows: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -18,6 +19,7 @@ export class FieldTypesPage {
     this.typeSelect = page.locator('select');
     this.saveButton = page.locator('button:has-text("Save")');
     this.loadingSpinner = page.locator('.animate-spin');
+    this.configuredRows = page.locator('tbody tr');
   }
 
   async goto() {
@@ -38,11 +40,7 @@ export class FieldTypesPage {
 
   async hasConfiguredField(fieldName: string): Promise<boolean> {
     await this.waitForLoad();
-    return await this.page
-      .locator('tbody tr td:first-child')
-      .filter({ hasText: fieldName })
-      .isVisible()
-      .catch(() => false);
+    return await this.configuredFieldRow(fieldName).isVisible().catch(() => false);
   }
 
   async saveFieldType(fieldName: string, type: string) {
@@ -52,7 +50,19 @@ export class FieldTypesPage {
   }
 
   async deleteFieldType(fieldName: string) {
-    const row = this.page.locator('tbody tr').filter({ hasText: fieldName }).first();
+    const row = this.configuredFieldRow(fieldName).first();
     await row.locator('button:has-text("Delete")').click();
+  }
+
+  configuredFieldRow(fieldName: string): Locator {
+    return this.configuredRows.filter({ hasText: fieldName });
+  }
+
+  async waitForConfiguredField(fieldName: string) {
+    await expect(this.configuredFieldRow(fieldName)).toBeVisible();
+  }
+
+  async waitForConfiguredFieldRemoved(fieldName: string) {
+    await expect(this.configuredFieldRow(fieldName)).toHaveCount(0);
   }
 }

--- a/ezrules/frontend/e2e/pages/field-types.page.ts
+++ b/ezrules/frontend/e2e/pages/field-types.page.ts
@@ -10,6 +10,7 @@ export class FieldTypesPage {
   readonly typeSelect: Locator;
   readonly saveButton: Locator;
   readonly loadingSpinner: Locator;
+  readonly configuredSection: Locator;
   readonly configuredRows: Locator;
 
   constructor(page: Page) {
@@ -19,7 +20,8 @@ export class FieldTypesPage {
     this.typeSelect = page.locator('select');
     this.saveButton = page.locator('button:has-text("Save")');
     this.loadingSpinner = page.locator('.animate-spin');
-    this.configuredRows = page.locator('tbody tr');
+    this.configuredSection = page.locator('h2:has-text("Configured Fields")').locator('../..');
+    this.configuredRows = this.configuredSection.locator('tbody tr');
   }
 
   async goto() {
@@ -31,11 +33,7 @@ export class FieldTypesPage {
   }
 
   async getConfiguredCount(): Promise<number> {
-    // Count rows in the Configured Fields table
-    const section = this.page.locator('h2:has-text("Configured Fields")').locator('../..');
-    const rows = section.locator('tbody tr');
-    const count = await rows.count();
-    return count;
+    return await this.configuredRows.count();
   }
 
   async hasConfiguredField(fieldName: string): Promise<boolean> {

--- a/ezrules/frontend/e2e/pages/rule-create.page.ts
+++ b/ezrules/frontend/e2e/pages/rule-create.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 /**
  * Page Object Model for the Create Rule page.
@@ -108,5 +108,16 @@ export class RuleCreatePage {
    */
   async getTestJsonValue(): Promise<string> {
     return await this.testJsonTextarea.inputValue();
+  }
+
+  async waitForVerifyResponse() {
+    const response = await this.page.waitForResponse(resp =>
+      resp.url().includes('/api/v2/rules/verify') && resp.request().method() === 'POST'
+    );
+    expect(response.ok()).toBeTruthy();
+  }
+
+  async waitForTestJsonToContain(value: string) {
+    await expect(this.testJsonTextarea).toHaveValue(new RegExp(value));
   }
 }

--- a/ezrules/frontend/e2e/pages/rule-create.page.ts
+++ b/ezrules/frontend/e2e/pages/rule-create.page.ts
@@ -118,6 +118,8 @@ export class RuleCreatePage {
   }
 
   async waitForTestJsonToContain(value: string) {
-    await expect(this.testJsonTextarea).toHaveValue(new RegExp(value));
+    await expect
+      .poll(async () => await this.testJsonTextarea.inputValue())
+      .toContain(value);
   }
 }

--- a/ezrules/frontend/e2e/pages/rule-detail.page.ts
+++ b/ezrules/frontend/e2e/pages/rule-detail.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 /**
  * Page Object Model for the Rule Detail page.
@@ -216,6 +216,10 @@ export class RuleDetailPage {
    */
   async waitForSaveSuccess() {
     await this.saveSuccessMessage.waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  async waitForTestJsonToContain(value: string) {
+    await expect(this.testJsonTextarea).toHaveValue(new RegExp(value));
   }
 
   /**

--- a/ezrules/frontend/e2e/pages/rule-detail.page.ts
+++ b/ezrules/frontend/e2e/pages/rule-detail.page.ts
@@ -219,7 +219,9 @@ export class RuleDetailPage {
   }
 
   async waitForTestJsonToContain(value: string) {
-    await expect(this.testJsonTextarea).toHaveValue(new RegExp(value));
+    await expect
+      .poll(async () => await this.testJsonTextarea.inputValue())
+      .toContain(value);
   }
 
   /**

--- a/ezrules/frontend/e2e/pages/user-lists.page.ts
+++ b/ezrules/frontend/e2e/pages/user-lists.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 /**
  * Page Object Model for the User Lists management page.
@@ -15,6 +15,8 @@ export class UserListsPage {
   readonly errorMessage: Locator;
   readonly listCountText: Locator;
   readonly entryCountText: Locator;
+  readonly listItems: Locator;
+  readonly entryItems: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -27,6 +29,8 @@ export class UserListsPage {
     this.errorMessage = page.locator('.bg-red-50.border-red-200');
     this.listCountText = page.locator('text=/\\d+ lists? total/');
     this.entryCountText = page.locator('.w-2\\/3 .bg-gray-50 p');
+    this.listItems = page.locator('.w-1\\/3 ul li');
+    this.entryItems = page.locator('.w-2\\/3 ul li');
   }
 
   /**
@@ -48,8 +52,7 @@ export class UserListsPage {
    */
   async getListCount(): Promise<number> {
     await this.waitForListsToLoad();
-    // Lists are in the left panel (w-1/3) ul
-    return await this.page.locator('.w-1\\/3 ul li').count();
+    return await this.listItems.count();
   }
 
   /**
@@ -57,7 +60,7 @@ export class UserListsPage {
    */
   async hasListWithName(name: string): Promise<boolean> {
     await this.waitForListsToLoad();
-    return await this.page.locator('.w-1\\/3 li:has-text("' + name + '")').isVisible();
+    return await this.listItem(name).isVisible();
   }
 
   /**
@@ -72,16 +75,14 @@ export class UserListsPage {
    * Click on a list to select it and view its entries
    */
   async selectList(name: string) {
-    const listItem = this.page.locator('.w-1\\/3 li', { hasText: name });
-    await listItem.click();
+    await this.listItem(name).click();
   }
 
   /**
    * Click the Delete button for a specific list
    */
   async clickDeleteList(name: string) {
-    const row = this.page.locator('.w-1\\/3 li', { hasText: name });
-    await row.locator('button:has-text("Delete")').click();
+    await this.listItem(name).locator('button:has-text("Delete")').click();
   }
 
   /**
@@ -96,15 +97,14 @@ export class UserListsPage {
    * Check if an entry with the given value exists in the right panel
    */
   async hasEntry(value: string): Promise<boolean> {
-    return await this.page.locator('.w-2\\/3 li:has-text("' + value + '")').isVisible();
+    return await this.entryItem(value).isVisible();
   }
 
   /**
    * Click the Delete button for a specific entry
    */
   async clickDeleteEntry(value: string) {
-    const row = this.page.locator('.w-2\\/3 li', { hasText: value });
-    await row.locator('button:has-text("Delete")').click();
+    await this.entryItem(value).locator('button:has-text("Delete")').click();
   }
 
   /**
@@ -112,5 +112,29 @@ export class UserListsPage {
    */
   async waitForEntriesToLoad() {
     await this.entryCountText.waitFor({ state: 'visible' });
+  }
+
+  listItem(name: string): Locator {
+    return this.listItems.filter({ hasText: name });
+  }
+
+  entryItem(value: string): Locator {
+    return this.entryItems.filter({ hasText: value });
+  }
+
+  async waitForList(name: string) {
+    await expect(this.listItem(name)).toBeVisible();
+  }
+
+  async waitForListRemoved(name: string) {
+    await expect(this.listItem(name)).toHaveCount(0);
+  }
+
+  async waitForEntry(value: string) {
+    await expect(this.entryItem(value)).toBeVisible();
+  }
+
+  async waitForEntryRemoved(value: string) {
+    await expect(this.entryItem(value)).toHaveCount(0);
   }
 }

--- a/ezrules/frontend/e2e/support/api-helpers.ts
+++ b/ezrules/frontend/e2e/support/api-helpers.ts
@@ -107,49 +107,6 @@ export async function deleteRuleById(request: APIRequestContext, ruleId: number)
   await deleteIgnoringMissing(response, `Delete rule ${ruleId}`);
 }
 
-export async function deleteRuleByRid(request: APIRequestContext, rid: string): Promise<void> {
-  const response = await request.get(`${API_BASE}/api/v2/rules`, { headers: authHeaders() });
-  const body = await jsonResponse<{ rules: CreatedRule[] }>(response, `Find rule ${rid}`);
-  const rule = body.rules.find(candidate => candidate.rid === rid);
-  if (rule) {
-    await deleteRuleById(request, rule.r_id);
-  }
-}
-
-export async function createUserList(request: APIRequestContext, name: string): Promise<CreatedUserList> {
-  const response = await request.post(`${API_BASE}/api/v2/user-lists`, {
-    headers: authHeaders(),
-    data: { name },
-  });
-  const body = await jsonResponse<{ success: boolean; list?: CreatedUserList; error?: string }>(
-    response,
-    `Create user list ${name}`
-  );
-  if (!body.success || !body.list?.id) {
-    throw new Error(`Create user list returned an unsuccessful body: ${JSON.stringify(body)}`);
-  }
-  return body.list;
-}
-
-export async function createUserListEntry(
-  request: APIRequestContext,
-  listId: number,
-  value: string
-): Promise<{ id: number; value: string }> {
-  const response = await request.post(`${API_BASE}/api/v2/user-lists/${listId}/entries`, {
-    headers: authHeaders(),
-    data: { value },
-  });
-  const body = await jsonResponse<{ success: boolean; entry?: { id: number; value: string }; error?: string }>(
-    response,
-    `Create entry ${value} in user list ${listId}`
-  );
-  if (!body.success || !body.entry?.id) {
-    throw new Error(`Create user-list entry returned an unsuccessful body: ${JSON.stringify(body)}`);
-  }
-  return body.entry;
-}
-
 export async function deleteUserListById(request: APIRequestContext, listId: number): Promise<void> {
   const response = await request.delete(`${API_BASE}/api/v2/user-lists/${listId}`, {
     headers: authHeaders(),
@@ -164,28 +121,6 @@ export async function deleteUserListByName(request: APIRequestContext, name: str
   if (list) {
     await deleteUserListById(request, list.id);
   }
-}
-
-export async function createLabel(request: APIRequestContext, name: string): Promise<{ el_id: number; label: string }> {
-  const response = await request.post(`${API_BASE}/api/v2/labels`, {
-    headers: authHeaders(),
-    data: { label_name: name },
-  });
-  const body = await jsonResponse<{ success: boolean; label?: { el_id: number; label: string }; error?: string }>(
-    response,
-    `Create label ${name}`
-  );
-  if (!body.success || !body.label?.el_id) {
-    throw new Error(`Create label returned an unsuccessful body: ${JSON.stringify(body)}`);
-  }
-  return body.label;
-}
-
-export async function deleteLabelByName(request: APIRequestContext, name: string): Promise<void> {
-  const response = await request.delete(`${API_BASE}/api/v2/labels/${encodeURIComponent(name)}`, {
-    headers: authHeaders(),
-  });
-  await deleteIgnoringMissing(response, `Delete label ${name}`);
 }
 
 export async function deleteFieldTypeByName(request: APIRequestContext, fieldName: string): Promise<void> {

--- a/ezrules/frontend/e2e/support/api-helpers.ts
+++ b/ezrules/frontend/e2e/support/api-helpers.ts
@@ -1,0 +1,267 @@
+import type { APIRequestContext, APIResponse } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { getApiBaseUrl, getAuthToken } from './config';
+
+const API_BASE = getApiBaseUrl();
+
+type RuntimeSettings = {
+  auto_promote_active_rule_updates: boolean;
+  strict_mode_enabled: boolean;
+  main_rule_execution_mode: string;
+  rule_quality_lookback_days: number;
+  neutral_outcome: string;
+};
+
+type AIAuthoringSettings = {
+  provider: string;
+  enabled: boolean;
+  model: string;
+  api_key_configured: boolean;
+};
+
+type OutcomeHierarchy = {
+  outcomes: { ao_id: number; outcome_name: string; severity_rank: number }[];
+};
+
+export type CreatedRule = {
+  r_id: number;
+  rid: string;
+  description: string;
+  logic: string;
+  status: string;
+};
+
+export type CreatedUserList = {
+  id: number;
+  name: string;
+  entry_count: number;
+};
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getAuthToken()}` };
+}
+
+function truncateBody(body: string): string {
+  return body.length > 4_000 ? `${body.slice(0, 4_000)}... [truncated]` : body;
+}
+
+async function responseBody(response: APIResponse): Promise<string> {
+  try {
+    return truncateBody(await response.text());
+  } catch (error) {
+    return `[body unavailable: ${String(error)}]`;
+  }
+}
+
+export async function expectApiOk(response: APIResponse, context: string): Promise<void> {
+  if (response.ok()) {
+    return;
+  }
+
+  throw new Error(`${context} failed with HTTP ${response.status()}: ${await responseBody(response)}`);
+}
+
+async function jsonResponse<T>(response: APIResponse, context: string): Promise<T> {
+  await expectApiOk(response, context);
+  return (await response.json()) as T;
+}
+
+async function deleteIgnoringMissing(response: APIResponse, context: string): Promise<void> {
+  if (response.ok() || response.status() === 404) {
+    return;
+  }
+
+  throw new Error(`${context} failed with HTTP ${response.status()}: ${await responseBody(response)}`);
+}
+
+export async function createRule(
+  request: APIRequestContext,
+  data: { rid: string; description?: string; logic?: string; evaluation_lane?: string; execution_order?: number }
+): Promise<CreatedRule> {
+  const response = await request.post(`${API_BASE}/api/v2/rules`, {
+    headers: authHeaders(),
+    data: {
+      description: 'E2E rule created by Playwright',
+      logic: "if $amount > 100:\n\treturn !HOLD",
+      ...data,
+    },
+  });
+  const body = await jsonResponse<{ success: boolean; rule?: CreatedRule; error?: string }>(response, 'Create rule');
+  if (!body.success || !body.rule?.r_id) {
+    throw new Error(`Create rule returned an unsuccessful body: ${JSON.stringify(body)}`);
+  }
+  return body.rule;
+}
+
+export async function promoteRule(request: APIRequestContext, ruleId: number): Promise<void> {
+  const response = await request.post(`${API_BASE}/api/v2/rules/${ruleId}/promote`, {
+    headers: authHeaders(),
+  });
+  await expectApiOk(response, `Promote rule ${ruleId}`);
+}
+
+export async function deleteRuleById(request: APIRequestContext, ruleId: number): Promise<void> {
+  const response = await request.delete(`${API_BASE}/api/v2/rules/${ruleId}`, {
+    headers: authHeaders(),
+  });
+  await deleteIgnoringMissing(response, `Delete rule ${ruleId}`);
+}
+
+export async function deleteRuleByRid(request: APIRequestContext, rid: string): Promise<void> {
+  const response = await request.get(`${API_BASE}/api/v2/rules`, { headers: authHeaders() });
+  const body = await jsonResponse<{ rules: CreatedRule[] }>(response, `Find rule ${rid}`);
+  const rule = body.rules.find(candidate => candidate.rid === rid);
+  if (rule) {
+    await deleteRuleById(request, rule.r_id);
+  }
+}
+
+export async function createUserList(request: APIRequestContext, name: string): Promise<CreatedUserList> {
+  const response = await request.post(`${API_BASE}/api/v2/user-lists`, {
+    headers: authHeaders(),
+    data: { name },
+  });
+  const body = await jsonResponse<{ success: boolean; list?: CreatedUserList; error?: string }>(
+    response,
+    `Create user list ${name}`
+  );
+  if (!body.success || !body.list?.id) {
+    throw new Error(`Create user list returned an unsuccessful body: ${JSON.stringify(body)}`);
+  }
+  return body.list;
+}
+
+export async function createUserListEntry(
+  request: APIRequestContext,
+  listId: number,
+  value: string
+): Promise<{ id: number; value: string }> {
+  const response = await request.post(`${API_BASE}/api/v2/user-lists/${listId}/entries`, {
+    headers: authHeaders(),
+    data: { value },
+  });
+  const body = await jsonResponse<{ success: boolean; entry?: { id: number; value: string }; error?: string }>(
+    response,
+    `Create entry ${value} in user list ${listId}`
+  );
+  if (!body.success || !body.entry?.id) {
+    throw new Error(`Create user-list entry returned an unsuccessful body: ${JSON.stringify(body)}`);
+  }
+  return body.entry;
+}
+
+export async function deleteUserListById(request: APIRequestContext, listId: number): Promise<void> {
+  const response = await request.delete(`${API_BASE}/api/v2/user-lists/${listId}`, {
+    headers: authHeaders(),
+  });
+  await deleteIgnoringMissing(response, `Delete user list ${listId}`);
+}
+
+export async function deleteUserListByName(request: APIRequestContext, name: string): Promise<void> {
+  const response = await request.get(`${API_BASE}/api/v2/user-lists`, { headers: authHeaders() });
+  const body = await jsonResponse<{ lists: CreatedUserList[] }>(response, `Find user list ${name}`);
+  const list = body.lists.find(candidate => candidate.name === name);
+  if (list) {
+    await deleteUserListById(request, list.id);
+  }
+}
+
+export async function createLabel(request: APIRequestContext, name: string): Promise<{ el_id: number; label: string }> {
+  const response = await request.post(`${API_BASE}/api/v2/labels`, {
+    headers: authHeaders(),
+    data: { label_name: name },
+  });
+  const body = await jsonResponse<{ success: boolean; label?: { el_id: number; label: string }; error?: string }>(
+    response,
+    `Create label ${name}`
+  );
+  if (!body.success || !body.label?.el_id) {
+    throw new Error(`Create label returned an unsuccessful body: ${JSON.stringify(body)}`);
+  }
+  return body.label;
+}
+
+export async function deleteLabelByName(request: APIRequestContext, name: string): Promise<void> {
+  const response = await request.delete(`${API_BASE}/api/v2/labels/${encodeURIComponent(name)}`, {
+    headers: authHeaders(),
+  });
+  await deleteIgnoringMissing(response, `Delete label ${name}`);
+}
+
+export async function deleteFieldTypeByName(request: APIRequestContext, fieldName: string): Promise<void> {
+  const response = await request.delete(`${API_BASE}/api/v2/field-types/${encodeURIComponent(fieldName)}`, {
+    headers: authHeaders(),
+  });
+  await deleteIgnoringMissing(response, `Delete field type ${fieldName}`);
+}
+
+export async function getRuntimeSettings(request: APIRequestContext): Promise<RuntimeSettings> {
+  const response = await request.get(`${API_BASE}/api/v2/settings/runtime`, { headers: authHeaders() });
+  return await jsonResponse<RuntimeSettings>(response, 'Get runtime settings');
+}
+
+export async function restoreRuntimeSettings(
+  request: APIRequestContext,
+  settings: RuntimeSettings
+): Promise<RuntimeSettings> {
+  const response = await request.put(`${API_BASE}/api/v2/settings/runtime`, {
+    headers: authHeaders(),
+    data: {
+      auto_promote_active_rule_updates: settings.auto_promote_active_rule_updates,
+      strict_mode_enabled: settings.strict_mode_enabled,
+      main_rule_execution_mode: settings.main_rule_execution_mode,
+      rule_quality_lookback_days: settings.rule_quality_lookback_days,
+      neutral_outcome: settings.neutral_outcome,
+    },
+  });
+  return await jsonResponse<RuntimeSettings>(response, 'Restore runtime settings');
+}
+
+export async function expectRuntimeSettingsRestored(
+  request: APIRequestContext,
+  expected: RuntimeSettings
+): Promise<void> {
+  const actual = await getRuntimeSettings(request);
+  expect(actual.auto_promote_active_rule_updates).toBe(expected.auto_promote_active_rule_updates);
+  expect(actual.strict_mode_enabled).toBe(expected.strict_mode_enabled);
+  expect(actual.main_rule_execution_mode).toBe(expected.main_rule_execution_mode);
+  expect(actual.rule_quality_lookback_days).toBe(expected.rule_quality_lookback_days);
+  expect(actual.neutral_outcome).toBe(expected.neutral_outcome);
+}
+
+export async function getAIAuthoringSettings(request: APIRequestContext): Promise<AIAuthoringSettings> {
+  const response = await request.get(`${API_BASE}/api/v2/settings/ai-authoring`, { headers: authHeaders() });
+  return await jsonResponse<AIAuthoringSettings>(response, 'Get AI authoring settings');
+}
+
+export async function restoreAIAuthoringSettings(
+  request: APIRequestContext,
+  settings: AIAuthoringSettings
+): Promise<AIAuthoringSettings> {
+  const response = await request.put(`${API_BASE}/api/v2/settings/ai-authoring`, {
+    headers: authHeaders(),
+    data: {
+      provider: settings.provider,
+      enabled: settings.api_key_configured ? settings.enabled : false,
+      model: settings.model,
+      clear_api_key: settings.api_key_configured ? undefined : true,
+    },
+  });
+  return await jsonResponse<AIAuthoringSettings>(response, 'Restore AI authoring settings');
+}
+
+export async function getOutcomeHierarchy(request: APIRequestContext): Promise<OutcomeHierarchy> {
+  const response = await request.get(`${API_BASE}/api/v2/settings/outcome-hierarchy`, { headers: authHeaders() });
+  return await jsonResponse<OutcomeHierarchy>(response, 'Get outcome hierarchy');
+}
+
+export async function restoreOutcomeHierarchy(
+  request: APIRequestContext,
+  hierarchy: OutcomeHierarchy
+): Promise<OutcomeHierarchy> {
+  const response = await request.put(`${API_BASE}/api/v2/settings/outcome-hierarchy`, {
+    headers: authHeaders(),
+    data: { ordered_ao_ids: hierarchy.outcomes.map(outcome => outcome.ao_id) },
+  });
+  return await jsonResponse<OutcomeHierarchy>(response, 'Restore outcome hierarchy');
+}

--- a/ezrules/frontend/e2e/support/dialogs.ts
+++ b/ezrules/frontend/e2e/support/dialogs.ts
@@ -1,0 +1,13 @@
+import type { Dialog, Page } from '@playwright/test';
+
+async function runWithDialog(page: Page, action: () => Promise<unknown>, handleDialog: (dialog: Dialog) => Promise<void>) {
+  await Promise.all([page.waitForEvent('dialog').then(handleDialog), action()]);
+}
+
+export async function acceptDialog(page: Page, action: () => Promise<unknown>) {
+  await runWithDialog(page, action, dialog => dialog.accept());
+}
+
+export async function dismissDialog(page: Page, action: () => Promise<unknown>) {
+  await runWithDialog(page, action, dialog => dialog.dismiss());
+}

--- a/ezrules/frontend/e2e/support/fixtures.ts
+++ b/ezrules/frontend/e2e/support/fixtures.ts
@@ -1,0 +1,101 @@
+import { test as base, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { getApiBaseUrl } from './config';
+
+type DiagnosticEntry = {
+  type: string;
+  message?: string;
+  url?: string;
+  method?: string;
+  status?: number;
+  body?: string;
+  location?: unknown;
+  failure?: string | null;
+};
+
+function truncate(value: string, maxLength = 4_000): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}... [truncated]` : value;
+}
+
+function registerDiagnostics(page: Page) {
+  const apiBase = getApiBaseUrl();
+  const entries: DiagnosticEntry[] = [];
+  const pending: Promise<void>[] = [];
+
+  page.on('console', message => {
+    if (message.type() !== 'error') {
+      return;
+    }
+    entries.push({
+      type: 'console-error',
+      message: message.text(),
+      location: message.location(),
+    });
+  });
+
+  page.on('pageerror', error => {
+    entries.push({
+      type: 'page-error',
+      message: error.stack ?? error.message,
+    });
+  });
+
+  page.on('requestfailed', request => {
+    entries.push({
+      type: 'request-failed',
+      method: request.method(),
+      url: request.url(),
+      failure: request.failure()?.errorText ?? null,
+    });
+  });
+
+  page.on('response', response => {
+    const isApiResponse = response.url().startsWith(apiBase) || response.url().includes('/api/v2/');
+    if (!isApiResponse || response.status() < 400) {
+      return;
+    }
+
+    const task = response.text()
+      .then(body => {
+        entries.push({
+          type: 'http-error',
+          method: response.request().method(),
+          url: response.url(),
+          status: response.status(),
+          body: truncate(body),
+        });
+      })
+      .catch(error => {
+        entries.push({
+          type: 'http-error',
+          method: response.request().method(),
+          url: response.url(),
+          status: response.status(),
+          body: `[body unavailable: ${String(error)}]`,
+        });
+      });
+    pending.push(task);
+  });
+
+  return async () => {
+    await Promise.allSettled(pending);
+    return entries;
+  };
+}
+
+export const test = base.extend<{ page: Page }>({
+  page: async ({ page }, use, testInfo) => {
+    const collectDiagnostics = registerDiagnostics(page);
+    await use(page);
+
+    const diagnostics = await collectDiagnostics();
+    if (testInfo.status !== testInfo.expectedStatus && diagnostics.length > 0) {
+      await testInfo.attach('e2e-diagnostics.json', {
+        body: JSON.stringify(diagnostics, null, 2),
+        contentType: 'application/json',
+      });
+    }
+  },
+});
+
+export { expect };

--- a/ezrules/frontend/e2e/support/tags.ts
+++ b/ezrules/frontend/e2e/support/tags.ts
@@ -1,0 +1,3 @@
+export const STATEFUL_TAG = '@stateful';
+export const SETTINGS_TAG = '@settings';
+export const TEST_DATA_TAG = '@test-data';

--- a/ezrules/frontend/e2e/support/test-data.ts
+++ b/ezrules/frontend/e2e/support/test-data.ts
@@ -1,0 +1,58 @@
+import type { TestInfo } from '@playwright/test';
+
+type ResourceNameOptions = {
+  maxLength?: number;
+  uppercase?: boolean;
+};
+
+function testInfoId(testInfo: TestInfo): string {
+  const candidate = (testInfo as TestInfo & { testId?: string }).testId;
+  if (candidate) {
+    return candidate;
+  }
+
+  const titlePath = (testInfo as unknown as { titlePath?: string[] | (() => string[]) }).titlePath;
+  if (Array.isArray(titlePath)) {
+    return titlePath.join(' ');
+  }
+  if (typeof titlePath === 'function') {
+    return titlePath().join(' ');
+  }
+  return testInfo.title;
+}
+
+function compactToken(value: string, maxLength: number): string {
+  const normalized = value
+    .normalize('NFKD')
+    .replace(/[^\w]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/_{2,}/g, '_');
+  const fallback = normalized || 'test';
+  return fallback.slice(0, maxLength).replace(/_+$/g, '') || 'test';
+}
+
+export function sanitizeTestToken(value: string, maxLength = 48): string {
+  return compactToken(value, maxLength);
+}
+
+export function testResourceName(
+  testInfo: TestInfo,
+  prefix: string,
+  { maxLength = 64, uppercase = false }: ResourceNameOptions = {}
+): string {
+  const suffixBudget = Math.max(8, maxLength - prefix.length - 1);
+  const repeatSuffix = testInfo.repeatEachIndex > 0 ? `_repeat_${testInfo.repeatEachIndex}` : '';
+  const retrySuffix = testInfo.retry > 0 ? `_retry_${testInfo.retry}` : '';
+  const suffix = compactToken(`${testInfoId(testInfo)}${repeatSuffix}${retrySuffix}`, suffixBudget);
+  const name = `${prefix}_${suffix}`.slice(0, maxLength).replace(/_+$/g, '');
+  return uppercase ? name.toUpperCase() : name;
+}
+
+export function deterministicUnixTimestamp(testInfo: TestInfo, baseTimestamp = 1_893_456_000): number {
+  const source = testInfoId(testInfo);
+  let hash = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    hash = (hash * 31 + source.charCodeAt(index)) % 86_400;
+  }
+  return baseTimestamp + hash + testInfo.repeatEachIndex * 1_000 + testInfo.retry;
+}

--- a/ezrules/frontend/e2e/support/test-data.ts
+++ b/ezrules/frontend/e2e/support/test-data.ts
@@ -48,7 +48,12 @@ export function testResourceName(
   return uppercase ? name.toUpperCase() : name;
 }
 
-export function deterministicUnixTimestamp(testInfo: TestInfo, baseTimestamp = 1_893_456_000): number {
+function currentUtcDayBaseTimestamp(): number {
+  const now = new Date();
+  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1000);
+}
+
+export function deterministicUnixTimestamp(testInfo: TestInfo, baseTimestamp = currentUtcDayBaseTimestamp()): number {
   const source = testInfoId(testInfo);
   let hash = 0;
   for (let index = 0; index < source.length; index += 1) {

--- a/ezrules/frontend/e2e/support/test-data.ts
+++ b/ezrules/frontend/e2e/support/test-data.ts
@@ -31,10 +31,6 @@ function compactToken(value: string, maxLength: number): string {
   return fallback.slice(0, maxLength).replace(/_+$/g, '') || 'test';
 }
 
-export function sanitizeTestToken(value: string, maxLength = 48): string {
-  return compactToken(value, maxLength);
-}
-
 export function testResourceName(
   testInfo: TestInfo,
   prefix: string,

--- a/ezrules/frontend/e2e/tests/api-keys.spec.ts
+++ b/ezrules/frontend/e2e/tests/api-keys.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { ApiKeysPage } from '../pages/api-keys.page';
+import { testResourceName } from '../support/test-data';
 
 test.describe('API Keys Page', () => {
   let apiKeysPage: ApiKeysPage;
@@ -57,11 +58,11 @@ test.describe('API Keys Page', () => {
       await expect(apiKeysPage.createDialog).not.toBeVisible();
     });
 
-    test('should create a key and show the raw key once', async ({ page }) => {
+    test('should create a key and show the raw key once', async ({ page }, testInfo) => {
       await apiKeysPage.goto();
       await apiKeysPage.waitForLoad();
 
-      const label = `e2e-key-${Date.now()}`;
+      const label = testResourceName(testInfo, 'e2e-key', { maxLength: 48 });
       await apiKeysPage.createBtn.click();
       await apiKeysPage.labelInput.fill(label);
       await apiKeysPage.confirmCreateBtn.click();
@@ -83,6 +84,8 @@ test.describe('API Keys Page', () => {
 
       // Key should now appear in the table
       await expect(page.locator('[data-testid="api-key-row"]').filter({ hasText: label })).toBeVisible();
+      await apiKeysPage.revokeKeyByLabel(label);
+      await expect(page.locator('[data-testid="api-key-row"]').filter({ hasText: label })).not.toBeVisible();
     });
 
     test('confirm button should be disabled when label is empty', async () => {
@@ -94,11 +97,11 @@ test.describe('API Keys Page', () => {
   });
 
   test.describe('Revoke API Key', () => {
-    test('should revoke a key and remove it from the list', async ({ page }) => {
+    test('should revoke a key and remove it from the list', async ({ page }, testInfo) => {
       await apiKeysPage.goto();
       await apiKeysPage.waitForLoad();
 
-      const label = `e2e-revoke-${Date.now()}`;
+      const label = testResourceName(testInfo, 'e2e-revoke', { maxLength: 48 });
       await apiKeysPage.createKey(label);
 
       // Key should be in the list
@@ -106,10 +109,7 @@ test.describe('API Keys Page', () => {
 
       const initialCount = await apiKeysPage.getKeyCount();
 
-      // Revoke it
-      page.on('dialog', d => d.accept());
-      const row = page.locator('[data-testid="api-key-row"]').filter({ hasText: label });
-      await row.locator('[data-testid="revoke-btn"]').click();
+      await apiKeysPage.revokeKeyByLabel(label);
 
       // Row should disappear
       await expect(page.locator('[data-testid="api-key-row"]').filter({ hasText: label })).not.toBeVisible();

--- a/ezrules/frontend/e2e/tests/field-types-required.spec.ts
+++ b/ezrules/frontend/e2e/tests/field-types-required.spec.ts
@@ -1,10 +1,12 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../support/fixtures';
 import { FieldTypesPage } from '../pages/field-types.page';
+import { acceptDialog } from '../support/dialogs';
+import { testResourceName } from '../support/test-data';
 
 test.describe('Field Types Required Flag', () => {
-  test('should save a required field configuration and show the required badge', async ({ page }) => {
+  test('should save a required field configuration and show the required badge', async ({ page }, testInfo) => {
     const fieldTypesPage = new FieldTypesPage(page);
-    const fieldName = `required_field_${Date.now()}`;
+    const fieldName = testResourceName(testInfo, 'required_field');
 
     await fieldTypesPage.goto();
     await fieldTypesPage.waitForLoad();
@@ -18,7 +20,6 @@ test.describe('Field Types Required Flag', () => {
     await expect(row).toBeVisible();
     await expect(row).toContainText('required');
 
-    page.on('dialog', dialog => dialog.accept());
-    await row.getByRole('button', { name: 'Delete' }).click();
+    await acceptDialog(page, () => row.getByRole('button', { name: 'Delete' }).click());
   });
 });

--- a/ezrules/frontend/e2e/tests/field-types.spec.ts
+++ b/ezrules/frontend/e2e/tests/field-types.spec.ts
@@ -1,11 +1,22 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { FieldTypesPage } from '../pages/field-types.page';
+import { deleteFieldTypeByName } from '../support/api-helpers';
+import { testResourceName } from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
-test.describe('Field Types Page', () => {
+test.describe(`Field Types Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   let fieldTypesPage: FieldTypesPage;
+  let createdFieldNames: string[];
 
   test.beforeEach(async ({ page }) => {
     fieldTypesPage = new FieldTypesPage(page);
+    createdFieldNames = [];
+  });
+
+  test.afterEach(async ({ request }) => {
+    for (const fieldName of createdFieldNames) {
+      await deleteFieldTypeByName(request, fieldName);
+    }
   });
 
   test.describe('Page Structure', () => {
@@ -56,37 +67,24 @@ test.describe('Field Types Page', () => {
   });
 
   test.describe('Configure Field Type', () => {
-    test('should save a new field type configuration and show it in the table', async ({ page }) => {
+    test('should save a new field type configuration and show it in the table', async ({ page }, testInfo) => {
       await fieldTypesPage.goto();
       await fieldTypesPage.waitForLoad();
 
-      const fieldName = `e2e_field_${Date.now()}`;
+      const fieldName = testResourceName(testInfo, 'e2e_field');
+      createdFieldNames.push(fieldName);
 
       await fieldTypesPage.saveFieldType(fieldName, 'integer');
-
-      // Wait for the row to appear in the table
-      await page.waitForFunction(
-        (name: string) => {
-          const cells = document.querySelectorAll('tbody tr td:first-child');
-          return Array.from(cells).some(c => c.textContent?.trim() === name);
-        },
-        fieldName,
-        { timeout: 5000 }
-      );
+      await fieldTypesPage.waitForConfiguredField(fieldName);
 
       expect(await fieldTypesPage.hasConfiguredField(fieldName)).toBe(true);
 
       // Cleanup
-      page.on('dialog', d => d.accept());
+      const dialogPromise = page.waitForEvent('dialog');
       await fieldTypesPage.deleteFieldType(fieldName);
-      await page.waitForFunction(
-        (name: string) => {
-          const cells = document.querySelectorAll('tbody tr td:first-child');
-          return !Array.from(cells).some(c => c.textContent?.trim() === name);
-        },
-        fieldName,
-        { timeout: 5000 }
-      );
+      const dialog = await dialogPromise;
+      await dialog.accept();
+      await fieldTypesPage.waitForConfiguredFieldRemoved(fieldName);
     });
 
     test('should show all type options in the select', async ({ page }) => {
@@ -122,71 +120,51 @@ test.describe('Field Types Page', () => {
   });
 
   test.describe('Delete Field Type', () => {
-    test('should delete a configuration after confirmation', async ({ page }) => {
+    test('should delete a configuration after confirmation', async ({ page }, testInfo) => {
       await fieldTypesPage.goto();
       await fieldTypesPage.waitForLoad();
 
-      const fieldName = `del_e2e_${Date.now()}`;
+      const fieldName = testResourceName(testInfo, 'del_e2e');
+      createdFieldNames.push(fieldName);
       await fieldTypesPage.saveFieldType(fieldName, 'float');
 
-      await page.waitForFunction(
-        (name: string) => {
-          const cells = document.querySelectorAll('tbody tr td:first-child');
-          return Array.from(cells).some(c => c.textContent?.trim() === name);
-        },
-        fieldName,
-        { timeout: 5000 }
-      );
+      await fieldTypesPage.waitForConfiguredField(fieldName);
 
-      page.on('dialog', d => d.accept());
+      const dialogPromise = page.waitForEvent('dialog');
       await fieldTypesPage.deleteFieldType(fieldName);
+      const dialog = await dialogPromise;
+      await dialog.accept();
 
-      await page.waitForFunction(
-        (name: string) => {
-          const cells = document.querySelectorAll('tbody tr td:first-child');
-          return !Array.from(cells).some(c => c.textContent?.trim() === name);
-        },
-        fieldName,
-        { timeout: 5000 }
-      );
+      await fieldTypesPage.waitForConfiguredFieldRemoved(fieldName);
 
       expect(await fieldTypesPage.hasConfiguredField(fieldName)).toBe(false);
     });
 
-    test('should not delete when confirmation is dismissed', async ({ page }) => {
+    test('should not delete when confirmation is dismissed', async ({ page }, testInfo) => {
       await fieldTypesPage.goto();
       await fieldTypesPage.waitForLoad();
 
-      const fieldName = `nodelete_e2e_${Date.now()}`;
+      const fieldName = testResourceName(testInfo, 'nodelete_e2e');
+      createdFieldNames.push(fieldName);
       await fieldTypesPage.saveFieldType(fieldName, 'string');
 
-      await page.waitForFunction(
-        (name: string) => {
-          const cells = document.querySelectorAll('tbody tr td:first-child');
-          return Array.from(cells).some(c => c.textContent?.trim() === name);
-        },
-        fieldName,
-        { timeout: 5000 }
-      );
+      await fieldTypesPage.waitForConfiguredField(fieldName);
 
-      page.on('dialog', d => d.dismiss());
+      const countBefore = await fieldTypesPage.getConfiguredCount();
+      const dismissDialogPromise = page.waitForEvent('dialog');
       await fieldTypesPage.deleteFieldType(fieldName);
+      const dismissDialog = await dismissDialogPromise;
+      await dismissDialog.dismiss();
 
-      await page.waitForTimeout(500);
+      await expect(fieldTypesPage.configuredRows).toHaveCount(countBefore);
       expect(await fieldTypesPage.hasConfiguredField(fieldName)).toBe(true);
 
       // Cleanup
-      page.removeAllListeners('dialog');
-      page.on('dialog', d => d.accept());
+      const acceptDialogPromise = page.waitForEvent('dialog');
       await fieldTypesPage.deleteFieldType(fieldName);
-      await page.waitForFunction(
-        (name: string) => {
-          const cells = document.querySelectorAll('tbody tr td:first-child');
-          return !Array.from(cells).some(c => c.textContent?.trim() === name);
-        },
-        fieldName,
-        { timeout: 5000 }
-      );
+      const acceptDialog = await acceptDialogPromise;
+      await acceptDialog.accept();
+      await fieldTypesPage.waitForConfiguredFieldRemoved(fieldName);
     });
   });
 });

--- a/ezrules/frontend/e2e/tests/field-types.spec.ts
+++ b/ezrules/frontend/e2e/tests/field-types.spec.ts
@@ -145,10 +145,9 @@ test.describe(`Field Types Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       await fieldTypesPage.waitForConfiguredField(fieldName);
 
-      const countBefore = await fieldTypesPage.getConfiguredCount();
       await dismissDialog(page, () => fieldTypesPage.deleteFieldType(fieldName));
 
-      await expect(fieldTypesPage.configuredRows).toHaveCount(countBefore);
+      await expect(fieldTypesPage.configuredFieldRow(fieldName)).toHaveCount(1);
       expect(await fieldTypesPage.hasConfiguredField(fieldName)).toBe(true);
 
       // Cleanup

--- a/ezrules/frontend/e2e/tests/field-types.spec.ts
+++ b/ezrules/frontend/e2e/tests/field-types.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../support/fixtures';
 import { FieldTypesPage } from '../pages/field-types.page';
 import { deleteFieldTypeByName } from '../support/api-helpers';
+import { acceptDialog, dismissDialog } from '../support/dialogs';
 import { testResourceName } from '../support/test-data';
 import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
@@ -80,10 +81,7 @@ test.describe(`Field Types Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       expect(await fieldTypesPage.hasConfiguredField(fieldName)).toBe(true);
 
       // Cleanup
-      const dialogPromise = page.waitForEvent('dialog');
-      await fieldTypesPage.deleteFieldType(fieldName);
-      const dialog = await dialogPromise;
-      await dialog.accept();
+      await acceptDialog(page, () => fieldTypesPage.deleteFieldType(fieldName));
       await fieldTypesPage.waitForConfiguredFieldRemoved(fieldName);
     });
 
@@ -130,10 +128,7 @@ test.describe(`Field Types Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       await fieldTypesPage.waitForConfiguredField(fieldName);
 
-      const dialogPromise = page.waitForEvent('dialog');
-      await fieldTypesPage.deleteFieldType(fieldName);
-      const dialog = await dialogPromise;
-      await dialog.accept();
+      await acceptDialog(page, () => fieldTypesPage.deleteFieldType(fieldName));
 
       await fieldTypesPage.waitForConfiguredFieldRemoved(fieldName);
 
@@ -151,19 +146,13 @@ test.describe(`Field Types Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       await fieldTypesPage.waitForConfiguredField(fieldName);
 
       const countBefore = await fieldTypesPage.getConfiguredCount();
-      const dismissDialogPromise = page.waitForEvent('dialog');
-      await fieldTypesPage.deleteFieldType(fieldName);
-      const dismissDialog = await dismissDialogPromise;
-      await dismissDialog.dismiss();
+      await dismissDialog(page, () => fieldTypesPage.deleteFieldType(fieldName));
 
       await expect(fieldTypesPage.configuredRows).toHaveCount(countBefore);
       expect(await fieldTypesPage.hasConfiguredField(fieldName)).toBe(true);
 
       // Cleanup
-      const acceptDialogPromise = page.waitForEvent('dialog');
-      await fieldTypesPage.deleteFieldType(fieldName);
-      const acceptDialog = await acceptDialogPromise;
-      await acceptDialog.accept();
+      await acceptDialog(page, () => fieldTypesPage.deleteFieldType(fieldName));
       await fieldTypesPage.waitForConfiguredFieldRemoved(fieldName);
     });
   });

--- a/ezrules/frontend/e2e/tests/labels.spec.ts
+++ b/ezrules/frontend/e2e/tests/labels.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { LabelsPage } from '../pages/labels.page';
+import { testResourceName } from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
 /**
  * E2E tests for the Labels management page.
  */
-test.describe('Labels Page', () => {
+test.describe(`Labels Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   let labelsPage: LabelsPage;
 
   test.beforeEach(async ({ page }) => {
@@ -73,11 +75,11 @@ test.describe('Labels Page', () => {
       await expect(labelsPage.addLabelButton).toBeVisible();
     });
 
-    test('should create a new label and display it in the list', async ({ page }) => {
+    test('should create a new label and display it in the list', async ({ page }, testInfo) => {
       await labelsPage.goto();
       await labelsPage.waitForLabelsToLoad();
 
-      const uniqueLabel = `E2ETEST${Date.now()}`;
+      const uniqueLabel = testResourceName(testInfo, 'E2ETEST', { maxLength: 48, uppercase: true });
 
       await page.route('**/labels', async (route) => {
         if (route.request().method() === 'POST') {
@@ -133,12 +135,12 @@ test.describe('Labels Page', () => {
   });
 
   test.describe('Delete Label', () => {
-    test('should delete a label after confirmation', async ({ page }) => {
+    test('should delete a label after confirmation', async ({ page }, testInfo) => {
       await labelsPage.goto();
       await labelsPage.waitForLabelsToLoad();
 
       // First create a label to delete
-      const uniqueLabel = `DELTEST${Date.now()}`;
+      const uniqueLabel = testResourceName(testInfo, 'DELTEST', { maxLength: 48, uppercase: true });
       await labelsPage.addLabel(uniqueLabel);
 
       await page.waitForFunction(
@@ -176,17 +178,14 @@ test.describe('Labels Page', () => {
 
       const countBefore = await labelsPage.getLabelCount();
 
-      // Dismiss the confirmation dialog
-      page.on('dialog', dialog => dialog.dismiss());
-
       // Click delete on the first label
+      const dialogPromise = page.waitForEvent('dialog');
       const firstDeleteButton = page.locator('button:has-text("Delete")').first();
       await firstDeleteButton.click();
+      const dialog = await dialogPromise;
+      await dialog.dismiss();
 
-      // Wait briefly and check count is unchanged
-      await page.waitForTimeout(500);
-      const countAfter = await labelsPage.getLabelCount();
-      expect(countAfter).toBe(countBefore);
+      await expect(page.locator('ul li')).toHaveCount(countBefore);
     });
   });
 

--- a/ezrules/frontend/e2e/tests/labels.spec.ts
+++ b/ezrules/frontend/e2e/tests/labels.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../support/fixtures';
 import { LabelsPage } from '../pages/labels.page';
+import { acceptDialog, dismissDialog } from '../support/dialogs';
 import { testResourceName } from '../support/test-data';
 import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
@@ -104,8 +105,7 @@ test.describe(`Labels Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       await expect(await labelsPage.hasLabel(uniqueLabel)).toBe(true);
 
       // Cleanup: delete the label we created
-      page.on('dialog', dialog => dialog.accept());
-      await labelsPage.clickDelete(uniqueLabel);
+      await acceptDialog(page, () => labelsPage.clickDelete(uniqueLabel));
       await page.waitForFunction(
         (label: string) => {
           const items = document.querySelectorAll('ul li');
@@ -152,11 +152,8 @@ test.describe(`Labels Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
         { timeout: 5000 }
       );
 
-      // Accept the confirmation dialog
-      page.on('dialog', dialog => dialog.accept());
-
       const countBefore = await labelsPage.getLabelCount();
-      await labelsPage.clickDelete(uniqueLabel);
+      await acceptDialog(page, () => labelsPage.clickDelete(uniqueLabel));
 
       // Wait for the label to disappear
       await page.waitForFunction(
@@ -178,12 +175,8 @@ test.describe(`Labels Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       const countBefore = await labelsPage.getLabelCount();
 
-      // Click delete on the first label
-      const dialogPromise = page.waitForEvent('dialog');
       const firstDeleteButton = page.locator('button:has-text("Delete")').first();
-      await firstDeleteButton.click();
-      const dialog = await dialogPromise;
-      await dialog.dismiss();
+      await dismissDialog(page, () => firstDeleteButton.click());
 
       await expect(page.locator('ul li')).toHaveCount(countBefore);
     });

--- a/ezrules/frontend/e2e/tests/main-rule-execution-mode.spec.ts
+++ b/ezrules/frontend/e2e/tests/main-rule-execution-mode.spec.ts
@@ -192,13 +192,22 @@ test.describe(`Main Rule Execution Mode ${STATEFUL_TAG} ${SETTINGS_TAG} @global-
       for (const ruleId of createdRuleIds) {
         await deleteRuleById(request, ruleId);
       }
+      let restoredMainRuleIds: number[] | null = null;
       if (originalMainRuleIds.length > 0) {
-        await apiRequest(request, '/api/v2/rules/main-order', 'PUT', { ordered_r_ids: originalMainRuleIds }, authHeaders);
-        const restoredMainRuleIds = await getActiveMainRuleIds(request, authHeaders);
+        try {
+          await apiRequest(request, '/api/v2/rules/main-order', 'PUT', { ordered_r_ids: originalMainRuleIds }, authHeaders);
+          restoredMainRuleIds = await getActiveMainRuleIds(request, authHeaders);
+        } finally {
+          await restoreRuntimeSettings(request, currentSettings);
+          await expectRuntimeSettingsRestored(request, currentSettings);
+        }
+      } else {
+        await restoreRuntimeSettings(request, currentSettings);
+        await expectRuntimeSettingsRestored(request, currentSettings);
+      }
+      if (restoredMainRuleIds) {
         expect(restoredMainRuleIds).toEqual(originalMainRuleIds);
       }
-      await restoreRuntimeSettings(request, currentSettings);
-      await expectRuntimeSettingsRestored(request, currentSettings);
     }
   });
 });

--- a/ezrules/frontend/e2e/tests/main-rule-execution-mode.spec.ts
+++ b/ezrules/frontend/e2e/tests/main-rule-execution-mode.spec.ts
@@ -1,7 +1,19 @@
-import { test, expect, type APIRequestContext } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { RuleListPage } from '../pages/rule-list.page';
 import { SettingsPage } from '../pages/settings.page';
 import { getApiBaseUrl, getAuthToken } from '../support/config';
+import {
+  createRule,
+  deleteRuleById,
+  expectApiOk,
+  expectRuntimeSettingsRestored,
+  getRuntimeSettings,
+  promoteRule,
+  restoreRuntimeSettings,
+} from '../support/api-helpers';
+import { testResourceName } from '../support/test-data';
+import { SETTINGS_TAG, STATEFUL_TAG } from '../support/tags';
 
 const API_BASE = getApiBaseUrl();
 
@@ -17,55 +29,41 @@ async function apiRequest(
     headers: authHeaders,
     data,
   });
-  expect(response.ok()).toBeTruthy();
+  await expectApiOk(response, `${method} ${path}`);
   return response;
 }
 
 async function createMainRule(
   request: APIRequestContext,
-  authHeaders: Record<string, string>,
   rid: string,
   description: string,
   executionOrder: number,
 ) {
-  const response = await apiRequest(
-    request,
-    '/api/v2/rules',
-    'POST',
-    {
-      rid,
-      description,
-      logic: 'if $amount > 0:\n\treturn !HOLD',
-      execution_order: executionOrder,
-      evaluation_lane: 'main',
-    },
-    authHeaders,
-  );
-  const payload = await response.json();
-  const ruleId = payload.rule.r_id as number;
-  await apiRequest(request, `/api/v2/rules/${ruleId}/promote`, 'POST', {}, authHeaders);
+  const rule = await createRule(request, {
+    rid,
+    description,
+    logic: 'if $amount > 0:\n\treturn !HOLD',
+    evaluation_lane: 'main',
+    execution_order: executionOrder,
+  });
+  const ruleId = rule.r_id;
+  await promoteRule(request, ruleId);
   return ruleId;
 }
 
-function buildRuntimeSettingsPayload(
-  currentSettings: Record<string, unknown>,
-  overrides: Partial<Record<'main_rule_execution_mode', string>>,
-) {
-  return {
-    rule_quality_lookback_days: currentSettings.rule_quality_lookback_days,
-    auto_promote_active_rule_updates: currentSettings.auto_promote_active_rule_updates,
-    main_rule_execution_mode: overrides.main_rule_execution_mode ?? currentSettings.main_rule_execution_mode,
-    neutral_outcome: currentSettings.neutral_outcome,
-  };
+async function getActiveMainRuleIds(request: APIRequestContext, authHeaders: Record<string, string>) {
+  const rulesResponse = await request.get(`${API_BASE}/api/v2/rules`, { headers: authHeaders });
+  await expectApiOk(rulesResponse, 'List rules for order restore check');
+  const rulesPayload = await rulesResponse.json();
+  return (rulesPayload.rules as Array<{ r_id: number; evaluation_lane: string; status: string }>)
+    .filter((rule) => rule.evaluation_lane === 'main' && rule.status !== 'archived')
+    .map((rule) => rule.r_id);
 }
 
-test.describe('Main Rule Execution Mode', () => {
+test.describe(`Main Rule Execution Mode ${STATEFUL_TAG} ${SETTINGS_TAG} @global-order`, () => {
   test('should allow changing the main rule execution mode', async ({ page, request }) => {
     const settingsPage = new SettingsPage(page);
-    const authHeaders = { Authorization: `Bearer ${getAuthToken()}` };
-    const currentSettingsResponse = await request.get(`${API_BASE}/api/v2/settings/runtime`, { headers: authHeaders });
-    expect(currentSettingsResponse.ok()).toBeTruthy();
-    const currentSettings = await currentSettingsResponse.json();
+    const currentSettings = await getRuntimeSettings(request);
 
     try {
       await settingsPage.goto();
@@ -83,58 +81,48 @@ test.describe('Main Rule Execution Mode', () => {
       await expect(page.locator('text=Settings saved successfully.')).toBeVisible();
       await expect(executionModeSelect).toHaveValue(nextMode);
     } finally {
-      const restoreResponse = await request.put(`${API_BASE}/api/v2/settings/runtime`, {
-        headers: authHeaders,
-        data: buildRuntimeSettingsPayload(currentSettings, {}),
-      });
-      expect(restoreResponse.ok()).toBeTruthy();
+      await restoreRuntimeSettings(request, currentSettings);
+      await expectRuntimeSettingsRestored(request, currentSettings);
     }
   });
 
-  test('should show rule-order controls only when first-match mode is enabled', async ({ page, request }) => {
+  test('should show rule-order controls only when first-match mode is enabled', async ({ page, request }, testInfo) => {
     test.setTimeout(120000);
     const rulePage = new RuleListPage(page);
     const authHeaders = { Authorization: `Bearer ${getAuthToken()}` };
-    const currentSettingsResponse = await request.get(`${API_BASE}/api/v2/settings/runtime`, { headers: authHeaders });
-    expect(currentSettingsResponse.ok()).toBeTruthy();
-    const currentSettings = await currentSettingsResponse.json();
+    const currentSettings = await getRuntimeSettings(request);
     const createdRuleIds: number[] = [];
     let originalMainRuleIds: number[] = [];
 
     try {
-      await request.put(`${API_BASE}/api/v2/settings/runtime`, {
-        headers: authHeaders,
-        data: buildRuntimeSettingsPayload(currentSettings, { main_rule_execution_mode: 'all_matches' }),
+      await restoreRuntimeSettings(request, {
+        ...currentSettings,
+        main_rule_execution_mode: 'all_matches',
       });
 
       await page.goto('/rules');
       await expect(page.locator('th:has-text("Order")')).toHaveCount(0);
       await expect(page.getByRole('button', { name: 'Reorder Rules' })).toHaveCount(0);
 
-      await request.put(`${API_BASE}/api/v2/settings/runtime`, {
-        headers: authHeaders,
-        data: buildRuntimeSettingsPayload(currentSettings, { main_rule_execution_mode: 'first_match' }),
+      await restoreRuntimeSettings(request, {
+        ...currentSettings,
+        main_rule_execution_mode: 'first_match',
       });
 
       await page.goto('/rules');
       await expect(page.locator('th:has-text("Order")')).toBeVisible();
       await expect(page.getByRole('button', { name: 'Reorder Rules' })).toBeVisible();
 
-      const originalRulesResponse = await request.get(`${API_BASE}/api/v2/rules`, { headers: authHeaders });
-      expect(originalRulesResponse.ok()).toBeTruthy();
-      const originalRulesPayload = await originalRulesResponse.json();
-      originalMainRuleIds = (originalRulesPayload.rules as Array<{ r_id: number; evaluation_lane: string; status: string }>)
-        .filter((rule) => rule.evaluation_lane === 'main' && rule.status !== 'archived')
-        .map((rule) => rule.r_id);
+      originalMainRuleIds = await getActiveMainRuleIds(request, authHeaders);
 
-      const unique = Date.now();
-      const ruleOneRid = `E2E_ORDER_RULE_1_${unique}`;
-      const ruleTwoRid = `E2E_ORDER_RULE_2_${unique}`;
-      const ruleThreeRid = `E2E_ORDER_RULE_3_${unique}`;
+      const unique = testResourceName(testInfo, 'E2E_ORDER', { maxLength: 48, uppercase: true });
+      const ruleOneRid = `${unique}_RULE_1`;
+      const ruleTwoRid = `${unique}_RULE_2`;
+      const ruleThreeRid = `${unique}_RULE_3`;
 
-      const ruleOneId = await createMainRule(request, authHeaders, ruleOneRid, 'E2E order first', 997);
-      const ruleTwoId = await createMainRule(request, authHeaders, ruleTwoRid, 'E2E order second', 998);
-      const ruleThreeId = await createMainRule(request, authHeaders, ruleThreeRid, 'E2E order third', 999);
+      const ruleOneId = await createMainRule(request, ruleOneRid, 'E2E order first', 997);
+      const ruleTwoId = await createMainRule(request, ruleTwoRid, 'E2E order second', 998);
+      const ruleThreeId = await createMainRule(request, ruleThreeRid, 'E2E order third', 999);
       createdRuleIds.push(ruleOneId, ruleTwoId, ruleThreeId);
 
       await rulePage.goto();
@@ -202,20 +190,15 @@ test.describe('Main Rule Execution Mode', () => {
       expect(persistedRowIndexes[1]).toBeLessThan(persistedRowIndexes[0]);
     } finally {
       for (const ruleId of createdRuleIds) {
-        const deleteResponse = await request.fetch(`${API_BASE}/api/v2/rules/${ruleId}`, {
-          method: 'DELETE',
-          headers: authHeaders,
-        });
-        expect(deleteResponse.ok()).toBeTruthy();
+        await deleteRuleById(request, ruleId);
       }
       if (originalMainRuleIds.length > 0) {
         await apiRequest(request, '/api/v2/rules/main-order', 'PUT', { ordered_r_ids: originalMainRuleIds }, authHeaders);
+        const restoredMainRuleIds = await getActiveMainRuleIds(request, authHeaders);
+        expect(restoredMainRuleIds).toEqual(originalMainRuleIds);
       }
-      const restoreResponse = await request.put(`${API_BASE}/api/v2/settings/runtime`, {
-        headers: authHeaders,
-        data: buildRuntimeSettingsPayload(currentSettings, {}),
-      });
-      expect(restoreResponse.ok()).toBeTruthy();
+      await restoreRuntimeSettings(request, currentSettings);
+      await expectRuntimeSettingsRestored(request, currentSettings);
     }
   });
 });

--- a/ezrules/frontend/e2e/tests/outcomes.spec.ts
+++ b/ezrules/frontend/e2e/tests/outcomes.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { OutcomesPage } from '../pages/outcomes.page';
+import { testResourceName } from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
 /**
  * E2E tests for the Outcomes management page.
  */
-test.describe('Outcomes Page', () => {
+test.describe(`Outcomes Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   let outcomesPage: OutcomesPage;
 
   test.beforeEach(async ({ page }) => {
@@ -82,11 +84,11 @@ test.describe('Outcomes Page', () => {
       await expect(outcomesPage.addOutcomeButton).toBeVisible();
     });
 
-    test('should create a new outcome and display it in the list', async ({ page }) => {
+    test('should create a new outcome and display it in the list', async ({ page }, testInfo) => {
       await outcomesPage.goto();
       await outcomesPage.waitForOutcomesToLoad();
 
-      const uniqueOutcome = `E2ETEST${Date.now()}`;
+      const uniqueOutcome = testResourceName(testInfo, 'E2ETEST', { maxLength: 48, uppercase: true });
 
       await outcomesPage.addOutcome(uniqueOutcome);
 
@@ -130,12 +132,12 @@ test.describe('Outcomes Page', () => {
   });
 
   test.describe('Delete Outcome', () => {
-    test('should delete an outcome after confirmation', async ({ page }) => {
+    test('should delete an outcome after confirmation', async ({ page }, testInfo) => {
       await outcomesPage.goto();
       await outcomesPage.waitForOutcomesToLoad();
 
       // First create an outcome to delete
-      const uniqueOutcome = `DELTEST${Date.now()}`;
+      const uniqueOutcome = testResourceName(testInfo, 'DELTEST', { maxLength: 48, uppercase: true });
       await outcomesPage.addOutcome(uniqueOutcome);
       const upperOutcome = uniqueOutcome.toUpperCase();
 
@@ -174,17 +176,14 @@ test.describe('Outcomes Page', () => {
 
       const countBefore = await outcomesPage.getOutcomeCount();
 
-      // Dismiss the confirmation dialog
-      page.on('dialog', dialog => dialog.dismiss());
-
       // Click delete on the first outcome
+      const dialogPromise = page.waitForEvent('dialog');
       const firstDeleteButton = page.locator('button:has-text("Delete")').first();
       await firstDeleteButton.click();
+      const dialog = await dialogPromise;
+      await dialog.dismiss();
 
-      // Wait briefly and check count is unchanged
-      await page.waitForTimeout(500);
-      const countAfter = await outcomesPage.getOutcomeCount();
-      expect(countAfter).toBe(countBefore);
+      await expect(page.locator('ul li')).toHaveCount(countBefore);
     });
   });
 });

--- a/ezrules/frontend/e2e/tests/outcomes.spec.ts
+++ b/ezrules/frontend/e2e/tests/outcomes.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../support/fixtures';
 import { OutcomesPage } from '../pages/outcomes.page';
+import { acceptDialog, dismissDialog } from '../support/dialogs';
 import { testResourceName } from '../support/test-data';
 import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
@@ -106,8 +107,7 @@ test.describe(`Outcomes Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       await expect(await outcomesPage.hasOutcome(upperOutcome)).toBe(true);
 
       // Cleanup: delete the outcome we created
-      page.on('dialog', dialog => dialog.accept());
-      await outcomesPage.clickDelete(upperOutcome);
+      await acceptDialog(page, () => outcomesPage.clickDelete(upperOutcome));
       await page.waitForFunction(
         (name: string) => {
           const items = document.querySelectorAll('ul li');
@@ -150,11 +150,8 @@ test.describe(`Outcomes Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
         { timeout: 5000 }
       );
 
-      // Accept the confirmation dialog
-      page.on('dialog', dialog => dialog.accept());
-
       const countBefore = await outcomesPage.getOutcomeCount();
-      await outcomesPage.clickDelete(upperOutcome);
+      await acceptDialog(page, () => outcomesPage.clickDelete(upperOutcome));
 
       // Wait for the outcome to disappear
       await page.waitForFunction(
@@ -176,12 +173,8 @@ test.describe(`Outcomes Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       const countBefore = await outcomesPage.getOutcomeCount();
 
-      // Click delete on the first outcome
-      const dialogPromise = page.waitForEvent('dialog');
       const firstDeleteButton = page.locator('button:has-text("Delete")').first();
-      await firstDeleteButton.click();
-      const dialog = await dialogPromise;
-      await dialog.dismiss();
+      await dismissDialog(page, () => firstDeleteButton.click());
 
       await expect(page.locator('ul li')).toHaveCount(countBefore);
     });

--- a/ezrules/frontend/e2e/tests/role-management.spec.ts
+++ b/ezrules/frontend/e2e/tests/role-management.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../support/fixtures';
 import { RoleManagementPage } from '../pages/role-management.page';
+import { acceptDialog, dismissDialog } from '../support/dialogs';
 import { testResourceName } from '../support/test-data';
 import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
@@ -104,8 +105,7 @@ test.describe(`Role Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       expect(await roleManagementPage.hasRoleWithName(uniqueName)).toBe(true);
 
       // Cleanup: delete the created role
-      page.on('dialog', dialog => dialog.accept());
-      await roleManagementPage.clickDeleteRole(uniqueName);
+      await acceptDialog(page, () => roleManagementPage.clickDeleteRole(uniqueName));
       await page.waitForFunction(
         (name: string) => {
           const tables = document.querySelectorAll('table');
@@ -146,8 +146,7 @@ test.describe(`Role Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       await expect(errorText).toBeVisible();
 
       // Cleanup
-      page.on('dialog', dialog => dialog.accept());
-      await roleManagementPage.clickDeleteRole(uniqueName);
+      await acceptDialog(page, () => roleManagementPage.clickDeleteRole(uniqueName));
       await page.waitForFunction(
         (name: string) => {
           const tables = document.querySelectorAll('table');
@@ -181,11 +180,8 @@ test.describe(`Role Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
         { timeout: 5000 }
       );
 
-      // Accept the confirmation dialog
-      page.on('dialog', dialog => dialog.accept());
-
       const countBefore = await roleManagementPage.getRoleRowCount();
-      await roleManagementPage.clickDeleteRole(uniqueName);
+      await acceptDialog(page, () => roleManagementPage.clickDeleteRole(uniqueName));
 
       // Wait for the role to disappear
       await page.waitForFunction(
@@ -224,19 +220,13 @@ test.describe(`Role Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       const countBefore = await roleManagementPage.getRoleRowCount();
 
-      const dismissDialogPromise = page.waitForEvent('dialog');
-      await roleManagementPage.clickDeleteRole(uniqueName);
-      const dismissDialog = await dismissDialogPromise;
-      await dismissDialog.dismiss();
+      await dismissDialog(page, () => roleManagementPage.clickDeleteRole(uniqueName));
 
       await expect(roleManagementPage.rolesTable.locator('tbody tr')).toHaveCount(countBefore);
       expect(await roleManagementPage.hasRoleWithName(uniqueName)).toBe(true);
 
       // Cleanup
-      const acceptDialogPromise = page.waitForEvent('dialog');
-      await roleManagementPage.clickDeleteRole(uniqueName);
-      const acceptDialog = await acceptDialogPromise;
-      await acceptDialog.accept();
+      await acceptDialog(page, () => roleManagementPage.clickDeleteRole(uniqueName));
       await page.waitForFunction(
         (name: string) => {
           const tables = document.querySelectorAll('table');

--- a/ezrules/frontend/e2e/tests/role-management.spec.ts
+++ b/ezrules/frontend/e2e/tests/role-management.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { RoleManagementPage } from '../pages/role-management.page';
+import { testResourceName } from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
 /**
  * E2E tests for the Role Management page.
  */
-test.describe('Role Management Page', () => {
+test.describe(`Role Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   let roleManagementPage: RoleManagementPage;
 
   test.beforeEach(async ({ page }) => {
@@ -78,11 +80,11 @@ test.describe('Role Management Page', () => {
       await expect(roleManagementPage.createRoleButton).toBeVisible();
     });
 
-    test('should create a new role and display it in the table', async ({ page }) => {
+    test('should create a new role and display it in the table', async ({ page }, testInfo) => {
       await roleManagementPage.goto();
       await roleManagementPage.waitForPageToLoad();
 
-      const uniqueName = `e2e_role_${Date.now()}`;
+      const uniqueName = testResourceName(testInfo, 'e2e_role').toLowerCase();
 
       await roleManagementPage.createRole(uniqueName, 'Test role description');
 
@@ -116,11 +118,11 @@ test.describe('Role Management Page', () => {
       );
     });
 
-    test('should show error for duplicate role name', async ({ page }) => {
+    test('should show error for duplicate role name', async ({ page }, testInfo) => {
       await roleManagementPage.goto();
       await roleManagementPage.waitForPageToLoad();
 
-      const uniqueName = `e2e_duprole_${Date.now()}`;
+      const uniqueName = testResourceName(testInfo, 'e2e_duprole').toLowerCase();
 
       // Create role first time
       await roleManagementPage.createRole(uniqueName);
@@ -160,12 +162,12 @@ test.describe('Role Management Page', () => {
   });
 
   test.describe('Delete Role', () => {
-    test('should delete a role after confirmation', async ({ page }) => {
+    test('should delete a role after confirmation', async ({ page }, testInfo) => {
       await roleManagementPage.goto();
       await roleManagementPage.waitForPageToLoad();
 
       // Create a role to delete
-      const uniqueName = `e2e_delrole_${Date.now()}`;
+      const uniqueName = testResourceName(testInfo, 'e2e_delrole').toLowerCase();
       await roleManagementPage.createRole(uniqueName);
 
       await page.waitForFunction(
@@ -201,12 +203,12 @@ test.describe('Role Management Page', () => {
       expect(countAfter).toBe(countBefore - 1);
     });
 
-    test('should not delete a role when confirmation is dismissed', async ({ page }) => {
+    test('should not delete a role when confirmation is dismissed', async ({ page }, testInfo) => {
       await roleManagementPage.goto();
       await roleManagementPage.waitForPageToLoad();
 
       // Create a role
-      const uniqueName = `e2e_nodelrole_${Date.now()}`;
+      const uniqueName = testResourceName(testInfo, 'e2e_nodelrole').toLowerCase();
       await roleManagementPage.createRole(uniqueName);
 
       await page.waitForFunction(
@@ -222,20 +224,19 @@ test.describe('Role Management Page', () => {
 
       const countBefore = await roleManagementPage.getRoleRowCount();
 
-      // Dismiss the confirmation dialog
-      page.on('dialog', dialog => dialog.dismiss());
-
+      const dismissDialogPromise = page.waitForEvent('dialog');
       await roleManagementPage.clickDeleteRole(uniqueName);
+      const dismissDialog = await dismissDialogPromise;
+      await dismissDialog.dismiss();
 
-      // Wait briefly and check count is unchanged
-      await page.waitForTimeout(500);
-      const countAfter = await roleManagementPage.getRoleRowCount();
-      expect(countAfter).toBe(countBefore);
+      await expect(roleManagementPage.rolesTable.locator('tbody tr')).toHaveCount(countBefore);
+      expect(await roleManagementPage.hasRoleWithName(uniqueName)).toBe(true);
 
       // Cleanup
-      page.removeAllListeners('dialog');
-      page.on('dialog', dialog => dialog.accept());
+      const acceptDialogPromise = page.waitForEvent('dialog');
       await roleManagementPage.clickDeleteRole(uniqueName);
+      const acceptDialog = await acceptDialogPromise;
+      await acceptDialog.accept();
       await page.waitForFunction(
         (name: string) => {
           const tables = document.querySelectorAll('table');

--- a/ezrules/frontend/e2e/tests/rule-create.spec.ts
+++ b/ezrules/frontend/e2e/tests/rule-create.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { RuleListPage } from '../pages/rule-list.page';
 import { RuleCreatePage } from '../pages/rule-create.page';
 import { RuleDetailPage } from '../pages/rule-detail.page';
-import { getApiBaseUrl, getAuthToken } from '../support/config';
-
-const API_BASE = getApiBaseUrl();
+import { deleteRuleById } from '../support/api-helpers';
+import { testResourceName } from '../support/test-data';
+import { TEST_DATA_TAG } from '../support/tags';
 
 /**
  * E2E tests for the Create Rule page.
@@ -14,7 +14,7 @@ const API_BASE = getApiBaseUrl();
  * and delete it in afterEach, keeping the DB clean across parallel runs.
  */
 
-test.describe('Rule Create Page', () => {
+test.describe(`Rule Create Page ${TEST_DATA_TAG}`, () => {
   let ruleListPage: RuleListPage;
   let ruleCreatePage: RuleCreatePage;
   let ruleDetailPage: RuleDetailPage;
@@ -29,9 +29,7 @@ test.describe('Rule Create Page', () => {
 
   test.afterEach(async ({ request }) => {
     if (testRuleId) {
-      await request.delete(`${API_BASE}/api/v2/rules/${testRuleId}`, {
-        headers: { Authorization: `Bearer ${getAuthToken()}` },
-      });
+      await deleteRuleById(request, testRuleId);
       testRuleId = 0;
     }
   });
@@ -141,11 +139,10 @@ test.describe('Rule Create Page', () => {
       await ruleCreatePage.goto();
 
       // Fill in logic with a rule that uses $amount parameter
+      const verifyResponsePromise = ruleCreatePage.waitForVerifyResponse();
       await ruleCreatePage.fillLogic("if $amount > 100:\n\treturn !HOLD");
-
-      // Wait for the verify API call to complete and populate testJson
-      await page.waitForResponse(resp => resp.url().includes('/api/v2/rules/verify'));
-      await page.waitForTimeout(500);
+      await verifyResponsePromise;
+      await ruleCreatePage.waitForTestJsonToContain('amount');
 
       const testJsonValue = await ruleCreatePage.getTestJsonValue();
       expect(testJsonValue).toContain('amount');
@@ -155,11 +152,10 @@ test.describe('Rule Create Page', () => {
       await ruleCreatePage.goto();
 
       // Fill in logic
+      const verifyResponsePromise = ruleCreatePage.waitForVerifyResponse();
       await ruleCreatePage.fillLogic("if $amount > 100:\n\treturn !HOLD");
-
-      // Wait for params to populate
-      await page.waitForResponse(resp => resp.url().includes('/api/v2/rules/verify'));
-      await page.waitForTimeout(500);
+      await verifyResponsePromise;
+      await ruleCreatePage.waitForTestJsonToContain('amount');
 
       // Fill in test JSON with a value that triggers HOLD
       await ruleCreatePage.fillTestJson('{"amount": 500}');
@@ -184,11 +180,11 @@ test.describe('Rule Create Page', () => {
   });
 
   test.describe('Rule Creation', () => {
-    test('should create a rule and navigate to the detail page', async ({ page }) => {
+    test('should create a rule and navigate to the detail page', async ({ page }, testInfo) => {
       await ruleCreatePage.goto();
 
-      const uniqueRid = 'E2E_CREATE_' + Date.now();
-      const description = 'E2E test rule created at ' + Date.now();
+      const uniqueRid = testResourceName(testInfo, 'E2E_CREATE', { uppercase: true });
+      const description = `E2E test rule for ${uniqueRid}`;
       const logic = "if $amount > 100:\n\treturn !HOLD";
 
       await ruleCreatePage.fillRuleId(uniqueRid);
@@ -214,10 +210,10 @@ test.describe('Rule Create Page', () => {
       expect(displayedRuleId).toBe(uniqueRid);
     });
 
-    test('should display error for invalid logic syntax', async ({ page }) => {
+    test('should display error for invalid logic syntax', async ({ page }, testInfo) => {
       await ruleCreatePage.goto();
 
-      await ruleCreatePage.fillRuleId('INVALID_LOGIC_TEST');
+      await ruleCreatePage.fillRuleId(testResourceName(testInfo, 'INVALID_LOGIC', { uppercase: true }));
       await ruleCreatePage.fillDescription('Test with bad logic');
       await ruleCreatePage.fillLogic('this is not valid python syntax !!!');
 
@@ -246,7 +242,7 @@ test.describe('Rule Create Page', () => {
       await expect(page).toHaveURL(/\/rules\/create/);
     });
 
-    test('should send POST request with correct body to /api/v2/rules', async ({ page }) => {
+    test('should send POST request with correct body to /api/v2/rules', async ({ page }, testInfo) => {
       let postRequestBody: any = null;
 
       page.on('request', request => {
@@ -257,7 +253,7 @@ test.describe('Rule Create Page', () => {
 
       await ruleCreatePage.goto();
 
-      const uniqueRid = 'E2E_POST_CHECK_' + Date.now();
+      const uniqueRid = testResourceName(testInfo, 'E2E_POST_CHECK', { uppercase: true });
       const description = 'POST body test';
       const logic = "if $amount > 50:\n\treturn !RELEASE";
 

--- a/ezrules/frontend/e2e/tests/rule-detail.spec.ts
+++ b/ezrules/frontend/e2e/tests/rule-detail.spec.ts
@@ -1,8 +1,11 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { RuleListPage } from '../pages/rule-list.page';
 import { RuleDetailPage } from '../pages/rule-detail.page';
 import { BacktestingPage } from '../pages/backtesting.page';
 import { getApiBaseUrl, getAuthToken } from '../support/config';
+import { createRule, deleteRuleById, expectApiOk } from '../support/api-helpers';
+import { deterministicUnixTimestamp, testResourceName } from '../support/test-data';
+import { TEST_DATA_TAG } from '../support/tags';
 
 const API_BASE = getApiBaseUrl();
 
@@ -54,38 +57,29 @@ function buildEvaluatedEventData(eventId: string, amount: number) {
  * in parallel with other files.
  */
 
-test.describe('Rule Detail Page', () => {
+test.describe(`Rule Detail Page ${TEST_DATA_TAG}`, () => {
   let ruleListPage: RuleListPage;
   let ruleDetailPage: RuleDetailPage;
   let backtestingPage: BacktestingPage;
   let testRuleId: number;
 
-  test.beforeEach(async ({ page, request }) => {
+  test.beforeEach(async ({ page, request }, testInfo) => {
     ruleListPage = new RuleListPage(page);
     ruleDetailPage = new RuleDetailPage(page);
     backtestingPage = new BacktestingPage(page);
 
     // Create a dedicated rule via Node.js request context (no browser/CORS involved)
-    const resp = await request.post(`${API_BASE}/api/v2/rules`, {
-      headers: { Authorization: `Bearer ${getAuthToken()}` },
-      data: {
-        rid: `E2E_DETAIL_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-        description: 'E2E test rule for rule detail tests',
-        logic: "if $amount > 100:\n\treturn !HOLD",
-      },
+    const rule = await createRule(request, {
+      rid: testResourceName(testInfo, 'E2E_DETAIL', { uppercase: true }),
+      description: 'E2E test rule for rule detail tests',
+      logic: "if $amount > 100:\n\treturn !HOLD",
     });
-    const data = await resp.json();
-    if (!data.success || !data.rule?.r_id) {
-      throw new Error(`Failed to create test rule: ${JSON.stringify(data)}`);
-    }
-    testRuleId = data.rule.r_id;
+    testRuleId = rule.r_id;
   });
 
   test.afterEach(async ({ request }) => {
     if (testRuleId) {
-      await request.delete(`${API_BASE}/api/v2/rules/${testRuleId}`, {
-        headers: { Authorization: `Bearer ${getAuthToken()}` },
-      });
+      await deleteRuleById(request, testRuleId);
       testRuleId = 0;
     }
   });
@@ -222,12 +216,10 @@ test.describe('Rule Detail Page', () => {
       await ruleDetailPage.goto(testRuleId);
       await ruleDetailPage.waitForRuleToLoad();
 
-      // Wait a bit for the fillInExampleParams to execute
-      await ruleDetailPage.page.waitForTimeout(1000);
+      await ruleDetailPage.waitForTestJsonToContain('amount');
 
       const testJson = await ruleDetailPage.testJsonTextarea.inputValue();
-      // Should have some JSON (could be empty object or populated with params)
-      expect(testJson.length).toBeGreaterThanOrEqual(0);
+      expect(testJson).toContain('amount');
     });
 
     test('should allow entering custom test JSON', async () => {
@@ -279,11 +271,12 @@ test.describe('Rule Detail Page', () => {
   });
 
   test.describe('Backtesting', () => {
-    test('should refresh completed backtest status without expanding the result card', async ({ page, request }) => {
-      const timestamp = Math.floor(Date.now() / 1000);
+    test('should refresh completed backtest status without expanding the result card', async ({ page, request }, testInfo) => {
+      const timestamp = deterministicUnixTimestamp(testInfo);
+      const eventIdPrefix = testResourceName(testInfo, `e2e_backtest_${testRuleId}`);
 
       for (const [index, amount] of [90, 180, 260].entries()) {
-        const eventId = `e2e-backtest-${testRuleId}-${Date.now()}-${index}`;
+        const eventId = `${eventIdPrefix}_${index}`;
         const evaluateResponse = await request.post(`${API_BASE}/api/v2/evaluate`, {
           headers: { Authorization: `Bearer ${getAuthToken()}` },
           data: {
@@ -292,7 +285,7 @@ test.describe('Rule Detail Page', () => {
             event_data: buildEvaluatedEventData(eventId, amount),
           },
         });
-        expect(evaluateResponse.ok()).toBeTruthy();
+        await expectApiOk(evaluateResponse, `Seed evaluated event ${eventId}`);
       }
 
       await ruleDetailPage.goto(testRuleId);

--- a/ezrules/frontend/e2e/tests/runtime-settings-auto-promote.spec.ts
+++ b/ezrules/frontend/e2e/tests/runtime-settings-auto-promote.spec.ts
@@ -1,8 +1,11 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { SettingsPage } from '../pages/settings.page';
+import { expectRuntimeSettingsRestored, getRuntimeSettings } from '../support/api-helpers';
+import { SETTINGS_TAG, STATEFUL_TAG } from '../support/tags';
 
-test.describe('Runtime Settings Auto-Promote', () => {
-  test('shows the active-rule auto-promotion control and saves current values', async ({ page }) => {
+test.describe(`Runtime Settings Auto-Promote ${STATEFUL_TAG} ${SETTINGS_TAG}`, () => {
+  test('shows the active-rule auto-promotion control and saves current values', async ({ page, request }) => {
+    const originalSettings = await getRuntimeSettings(request);
     const settingsPage = new SettingsPage(page);
     await settingsPage.goto();
     await settingsPage.waitForPageToLoad();
@@ -17,5 +20,6 @@ test.describe('Runtime Settings Auto-Promote', () => {
     await settingsPage.save();
 
     await expect(settingsPage.successMessage).toBeVisible();
+    await expectRuntimeSettingsRestored(request, originalSettings);
   });
 });

--- a/ezrules/frontend/e2e/tests/runtime-settings-auto-promote.spec.ts
+++ b/ezrules/frontend/e2e/tests/runtime-settings-auto-promote.spec.ts
@@ -1,25 +1,29 @@
 import { test, expect } from '../support/fixtures';
 import { SettingsPage } from '../pages/settings.page';
-import { expectRuntimeSettingsRestored, getRuntimeSettings } from '../support/api-helpers';
+import { expectRuntimeSettingsRestored, getRuntimeSettings, restoreRuntimeSettings } from '../support/api-helpers';
 import { SETTINGS_TAG, STATEFUL_TAG } from '../support/tags';
 
 test.describe(`Runtime Settings Auto-Promote ${STATEFUL_TAG} ${SETTINGS_TAG}`, () => {
   test('shows the active-rule auto-promotion control and saves current values', async ({ page, request }) => {
     const originalSettings = await getRuntimeSettings(request);
     const settingsPage = new SettingsPage(page);
-    await settingsPage.goto();
-    await settingsPage.waitForPageToLoad();
+    try {
+      await settingsPage.goto();
+      await settingsPage.waitForPageToLoad();
 
-    await expect(settingsPage.autoPromoteActiveRuleUpdatesCheckbox).toBeVisible();
+      await expect(settingsPage.autoPromoteActiveRuleUpdatesCheckbox).toBeVisible();
 
-    const currentLookback = await settingsPage.getLookbackDays();
-    const currentAutoPromoteValue = await settingsPage.isAutoPromoteActiveRuleUpdatesEnabled();
+      const currentLookback = await settingsPage.getLookbackDays();
+      const currentAutoPromoteValue = await settingsPage.isAutoPromoteActiveRuleUpdatesEnabled();
 
-    await settingsPage.setLookbackDays(currentLookback);
-    await settingsPage.setAutoPromoteActiveRuleUpdates(currentAutoPromoteValue);
-    await settingsPage.save();
+      await settingsPage.setLookbackDays(currentLookback);
+      await settingsPage.setAutoPromoteActiveRuleUpdates(currentAutoPromoteValue);
+      await settingsPage.save();
 
-    await expect(settingsPage.successMessage).toBeVisible();
-    await expectRuntimeSettingsRestored(request, originalSettings);
+      await expect(settingsPage.successMessage).toBeVisible();
+    } finally {
+      await restoreRuntimeSettings(request, originalSettings);
+      await expectRuntimeSettingsRestored(request, originalSettings);
+    }
   });
 });

--- a/ezrules/frontend/e2e/tests/settings.spec.ts
+++ b/ezrules/frontend/e2e/tests/settings.spec.ts
@@ -1,10 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { SettingsPage } from '../pages/settings.page';
-import { getApiBaseUrl, getAuthToken } from '../support/config';
+import {
+  expectRuntimeSettingsRestored,
+  getAIAuthoringSettings,
+  getOutcomeHierarchy,
+  getRuntimeSettings,
+  restoreAIAuthoringSettings,
+  restoreOutcomeHierarchy,
+  restoreRuntimeSettings,
+} from '../support/api-helpers';
+import { SETTINGS_TAG, STATEFUL_TAG } from '../support/tags';
 
-const API_BASE = getApiBaseUrl();
-
-test.describe('Settings Page', () => {
+test.describe(`Settings Page ${STATEFUL_TAG} ${SETTINGS_TAG}`, () => {
   let settingsPage: SettingsPage;
 
   test.beforeEach(async ({ page }) => {
@@ -39,10 +46,7 @@ test.describe('Settings Page', () => {
   });
 
   test('should allow choosing a neutral outcome and surface it in allowlist helper text', async ({ page, request }) => {
-    const authHeaders = { Authorization: `Bearer ${getAuthToken()}` };
-    const currentSettingsResponse = await request.get(`${API_BASE}/api/v2/settings/runtime`, { headers: authHeaders });
-    expect(currentSettingsResponse.ok()).toBeTruthy();
-    const currentSettings = await currentSettingsResponse.json();
+    const currentSettings = await getRuntimeSettings(request);
     try {
       await settingsPage.goto();
       await settingsPage.waitForPageToLoad();
@@ -60,15 +64,8 @@ test.describe('Settings Page', () => {
         `They must return !${nextNeutralOutcome}.`
       );
     } finally {
-      const restoreResponse = await request.put(`${API_BASE}/api/v2/settings/runtime`, {
-        headers: authHeaders,
-        data: {
-          rule_quality_lookback_days: currentSettings.rule_quality_lookback_days,
-          auto_promote_active_rule_updates: currentSettings.auto_promote_active_rule_updates,
-          neutral_outcome: currentSettings.neutral_outcome,
-        },
-      });
-      expect(restoreResponse.ok()).toBeTruthy();
+      await restoreRuntimeSettings(request, currentSettings);
+      await expectRuntimeSettingsRestored(request, currentSettings);
     }
   });
 
@@ -95,30 +92,37 @@ test.describe('Settings Page', () => {
 
     await targetRow.locator('button:has-text("Delete")').click();
     await expect(page.locator('text=Pair deleted successfully.')).toBeVisible();
+    await expect(targetRow).toHaveCount(0);
   });
 
-  test('should allow reordering the outcome hierarchy', async ({ page }) => {
-    await settingsPage.goto();
-    await settingsPage.waitForPageToLoad();
+  test('should allow reordering the outcome hierarchy', async ({ page, request }) => {
+    const originalHierarchy = await getOutcomeHierarchy(request);
+    try {
+      await settingsPage.goto();
+      await settingsPage.waitForPageToLoad();
 
-    const initialHierarchy = await settingsPage.getOutcomeHierarchy();
-    expect(initialHierarchy.length).toBeGreaterThan(1);
+      const initialHierarchy = await settingsPage.getOutcomeHierarchy();
+      expect(initialHierarchy.length).toBeGreaterThan(1);
 
-    const targetOutcome = initialHierarchy[0].trim();
-    await settingsPage.moveOutcomeDownByName(targetOutcome);
-    await settingsPage.saveOutcomeHierarchy();
+      const targetOutcome = initialHierarchy[0].trim();
+      await settingsPage.moveOutcomeDownByName(targetOutcome);
+      await settingsPage.saveOutcomeHierarchy();
 
-    await expect(page.locator('text=Outcome hierarchy saved successfully.')).toBeVisible();
+      await expect(page.locator('text=Outcome hierarchy saved successfully.')).toBeVisible();
 
-    const updatedHierarchy = (await settingsPage.getOutcomeHierarchy()).map(item => item.trim());
-    expect(updatedHierarchy[1]).toBe(targetOutcome);
+      const updatedHierarchy = (await settingsPage.getOutcomeHierarchy()).map(item => item.trim());
+      expect(updatedHierarchy[1]).toBe(targetOutcome);
+    } finally {
+      await restoreOutcomeHierarchy(request, originalHierarchy);
+      const restoredHierarchy = await getOutcomeHierarchy(request);
+      expect(restoredHierarchy.outcomes.map(outcome => outcome.ao_id)).toEqual(
+        originalHierarchy.outcomes.map(outcome => outcome.ao_id)
+      );
+    }
   });
 
   test('should allow configuring OpenAI AI authoring settings', async ({ request, page }) => {
-    const authHeaders = { Authorization: `Bearer ${getAuthToken()}` };
-    const currentSettingsResponse = await request.get(`${API_BASE}/api/v2/settings/ai-authoring`, { headers: authHeaders });
-    expect(currentSettingsResponse.ok()).toBeTruthy();
-    const currentSettings = await currentSettingsResponse.json();
+    const currentSettings = await getAIAuthoringSettings(request);
 
     try {
       await settingsPage.goto();
@@ -136,16 +140,11 @@ test.describe('Settings Page', () => {
       await expect(settingsPage.aiProviderSelect).toHaveValue('openai');
       await expect(settingsPage.aiModelInput).toHaveValue('gpt-4.1-mini');
     } finally {
-      const restoreResponse = await request.put(`${API_BASE}/api/v2/settings/ai-authoring`, {
-        headers: authHeaders,
-        data: {
-          provider: currentSettings.provider,
-          enabled: currentSettings.api_key_configured ? currentSettings.enabled : false,
-          model: currentSettings.model,
-          clear_api_key: currentSettings.api_key_configured ? undefined : true,
-        },
-      });
-      expect(restoreResponse.ok()).toBeTruthy();
+      const restoredSettings = await restoreAIAuthoringSettings(request, currentSettings);
+      expect(restoredSettings.provider).toBe(currentSettings.provider);
+      expect(restoredSettings.enabled).toBe(currentSettings.api_key_configured ? currentSettings.enabled : false);
+      expect(restoredSettings.model).toBe(currentSettings.model);
+      expect(restoredSettings.api_key_configured).toBe(currentSettings.api_key_configured);
     }
   });
 });

--- a/ezrules/frontend/e2e/tests/user-lists.spec.ts
+++ b/ezrules/frontend/e2e/tests/user-lists.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import { test, expect } from '../support/fixtures';
 import { UserListsPage } from '../pages/user-lists.page';
 import { deleteUserListByName } from '../support/api-helpers';
+import { acceptDialog, dismissDialog } from '../support/dialogs';
 import { testResourceName } from '../support/test-data';
 import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
@@ -19,10 +20,7 @@ test.describe(`User Lists Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   }
 
   async function deleteListAndWait(page: Page, name: string) {
-    const dialogPromise = page.waitForEvent('dialog');
-    await userListsPage.clickDeleteList(name);
-    const dialog = await dialogPromise;
-    await dialog.accept();
+    await acceptDialog(page, () => userListsPage.clickDeleteList(name));
     await userListsPage.waitForListRemoved(name);
   }
 
@@ -32,10 +30,7 @@ test.describe(`User Lists Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   }
 
   async function deleteEntryAndWait(page: Page, value: string) {
-    const dialogPromise = page.waitForEvent('dialog');
-    await userListsPage.clickDeleteEntry(value);
-    const dialog = await dialogPromise;
-    await dialog.accept();
+    await acceptDialog(page, () => userListsPage.clickDeleteEntry(value));
     await userListsPage.waitForEntryRemoved(value);
   }
 
@@ -146,10 +141,7 @@ test.describe(`User Lists Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       const countBefore = await userListsPage.getListCount();
 
-      const dialogPromise = page.waitForEvent('dialog');
-      await userListsPage.clickDeleteList(uniqueName);
-      const dialog = await dialogPromise;
-      await dialog.dismiss();
+      await dismissDialog(page, () => userListsPage.clickDeleteList(uniqueName));
 
       await expect(userListsPage.listItems).toHaveCount(countBefore);
       await expect(userListsPage.listItem(uniqueName)).toBeVisible();

--- a/ezrules/frontend/e2e/tests/user-lists.spec.ts
+++ b/ezrules/frontend/e2e/tests/user-lists.spec.ts
@@ -1,14 +1,53 @@
-import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { UserListsPage } from '../pages/user-lists.page';
+import { deleteUserListByName } from '../support/api-helpers';
+import { testResourceName } from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
 /**
  * E2E tests for the User Lists management page.
  */
-test.describe('User Lists Page', () => {
+test.describe(`User Lists Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   let userListsPage: UserListsPage;
+  let createdListNames: string[];
+
+  async function createListAndWait(name: string) {
+    await userListsPage.createList(name);
+    await userListsPage.waitForList(name);
+    createdListNames.push(name);
+  }
+
+  async function deleteListAndWait(page: Page, name: string) {
+    const dialogPromise = page.waitForEvent('dialog');
+    await userListsPage.clickDeleteList(name);
+    const dialog = await dialogPromise;
+    await dialog.accept();
+    await userListsPage.waitForListRemoved(name);
+  }
+
+  async function addEntryAndWait(value: string) {
+    await userListsPage.addEntry(value);
+    await userListsPage.waitForEntry(value);
+  }
+
+  async function deleteEntryAndWait(page: Page, value: string) {
+    const dialogPromise = page.waitForEvent('dialog');
+    await userListsPage.clickDeleteEntry(value);
+    const dialog = await dialogPromise;
+    await dialog.accept();
+    await userListsPage.waitForEntryRemoved(value);
+  }
 
   test.beforeEach(async ({ page }) => {
     userListsPage = new UserListsPage(page);
+    createdListNames = [];
+  });
+
+  test.afterEach(async ({ request }) => {
+    for (const listName of createdListNames) {
+      await deleteUserListByName(request, listName);
+    }
   });
 
   test.describe('Page Structure', () => {
@@ -54,55 +93,25 @@ test.describe('User Lists Page', () => {
       await expect(userListsPage.createListButton).toBeVisible();
     });
 
-    test('should create a new list and display it', async ({ page }) => {
+    test('should create a new list and display it', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      const uniqueName = `E2ELIST${Date.now()}`;
-
-      await userListsPage.createList(uniqueName);
-
-      // Wait for the list to appear
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      const uniqueName = testResourceName(testInfo, 'E2ELIST', { uppercase: true });
+      await createListAndWait(uniqueName);
 
       expect(await userListsPage.hasListWithName(uniqueName)).toBe(true);
 
       // Cleanup: delete the list we created
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteList(uniqueName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      await deleteListAndWait(page, uniqueName);
     });
 
-    test('should show error for duplicate list name', async ({ page }) => {
+    test('should show error for duplicate list name', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a unique list first
-      const uniqueName = `DUPTEST${Date.now()}`;
-      await userListsPage.createList(uniqueName);
-
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      const uniqueName = testResourceName(testInfo, 'DUPTEST', { uppercase: true });
+      await createListAndWait(uniqueName);
 
       // Try to create the same list again
       await userListsPage.createList(uniqueName);
@@ -112,96 +121,41 @@ test.describe('User Lists Page', () => {
       await expect(errorText).toBeVisible();
 
       // Cleanup
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteList(uniqueName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      await deleteListAndWait(page, uniqueName);
     });
 
-    test('should delete a list after confirmation', async ({ page }) => {
+    test('should delete a list after confirmation', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a list to delete
-      const uniqueName = `DELLIST${Date.now()}`;
-      await userListsPage.createList(uniqueName);
-
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
-
-      // Accept the confirmation dialog
-      page.on('dialog', dialog => dialog.accept());
+      const uniqueName = testResourceName(testInfo, 'DELLIST', { uppercase: true });
+      await createListAndWait(uniqueName);
 
       const countBefore = await userListsPage.getListCount();
-      await userListsPage.clickDeleteList(uniqueName);
+      await deleteListAndWait(page, uniqueName);
 
-      // Wait for the list to disappear
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
-
-      const countAfter = await userListsPage.getListCount();
-      expect(countAfter).toBe(countBefore - 1);
+      await expect(userListsPage.listItems).toHaveCount(countBefore - 1);
     });
 
-    test('should not delete a list when confirmation is dismissed', async ({ page }) => {
+    test('should not delete a list when confirmation is dismissed', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a list to test with
-      const uniqueName = `NODELL${Date.now()}`;
-      await userListsPage.createList(uniqueName);
-
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      const uniqueName = testResourceName(testInfo, 'NODELL', { uppercase: true });
+      await createListAndWait(uniqueName);
 
       const countBefore = await userListsPage.getListCount();
 
-      // Dismiss the confirmation dialog
-      page.on('dialog', dialog => dialog.dismiss());
-
+      const dialogPromise = page.waitForEvent('dialog');
       await userListsPage.clickDeleteList(uniqueName);
+      const dialog = await dialogPromise;
+      await dialog.dismiss();
 
-      // Wait briefly and check count is unchanged
-      await page.waitForTimeout(500);
-      const countAfter = await userListsPage.getListCount();
-      expect(countAfter).toBe(countBefore);
+      await expect(userListsPage.listItems).toHaveCount(countBefore);
+      await expect(userListsPage.listItem(uniqueName)).toBeVisible();
 
-      // Cleanup: need to re-register with accept
-      page.removeAllListeners('dialog');
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteList(uniqueName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      // Cleanup
+      await deleteListAndWait(page, uniqueName);
     });
   });
 
@@ -214,29 +168,18 @@ test.describe('User Lists Page', () => {
       await expect(emptyState).toBeVisible();
     });
 
-    test('should show entries panel when a list is selected', async ({ page }) => {
+    test('should show entries panel when a list is selected', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a list to select
-      const uniqueName = `ENTRYTEST${Date.now()}`;
-      await userListsPage.createList(uniqueName);
+      const uniqueName = testResourceName(testInfo, 'ENTRYTEST', { uppercase: true });
+      await createListAndWait(uniqueName);
 
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
-
-      // Select the list
       await userListsPage.selectList(uniqueName);
       await userListsPage.waitForEntriesToLoad();
 
       // Should show the list name as heading in right panel
-      const listHeading = page.locator('.w-2\\/3 h2:has-text("' + uniqueName + '")');
+      const listHeading = page.locator('.w-2\\/3 h2').filter({ hasText: uniqueName });
       await expect(listHeading).toBeVisible();
 
       // Should show Add Entry form
@@ -244,99 +187,40 @@ test.describe('User Lists Page', () => {
       await expect(userListsPage.addEntryButton).toBeVisible();
 
       // Cleanup
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteList(uniqueName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        uniqueName,
-        { timeout: 5000 }
-      );
+      await deleteListAndWait(page, uniqueName);
     });
 
-    test('should add an entry to a list', async ({ page }) => {
+    test('should add an entry to a list', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a list
-      const listName = `ADDENTRY${Date.now()}`;
-      await userListsPage.createList(listName);
+      const listName = testResourceName(testInfo, 'ADDENTRY', { uppercase: true });
+      await createListAndWait(listName);
 
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        listName,
-        { timeout: 5000 }
-      );
-
-      // Select the list
       await userListsPage.selectList(listName);
       await userListsPage.waitForEntriesToLoad();
 
-      // Add an entry
-      const entryValue = `VAL${Date.now()}`;
-      await userListsPage.addEntry(entryValue);
-
-      // Wait for the entry to appear
-      await page.waitForFunction(
-        (val: string) => {
-          const items = document.querySelectorAll('.w-2\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(val));
-        },
-        entryValue,
-        { timeout: 5000 }
-      );
+      const entryValue = testResourceName(testInfo, 'VAL', { uppercase: true });
+      await addEntryAndWait(entryValue);
 
       expect(await userListsPage.hasEntry(entryValue)).toBe(true);
 
       // Cleanup
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteList(listName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        listName,
-        { timeout: 5000 }
-      );
+      await deleteListAndWait(page, listName);
     });
 
-    test('should show error for duplicate entry', async ({ page }) => {
+    test('should show error for duplicate entry', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a list and add an entry
-      const listName = `DUPENTRY${Date.now()}`;
-      await userListsPage.createList(listName);
-
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        listName,
-        { timeout: 5000 }
-      );
+      const listName = testResourceName(testInfo, 'DUPENTRY', { uppercase: true });
+      await createListAndWait(listName);
 
       await userListsPage.selectList(listName);
       await userListsPage.waitForEntriesToLoad();
 
-      const entryValue = `DUP${Date.now()}`;
-      await userListsPage.addEntry(entryValue);
-
-      await page.waitForFunction(
-        (val: string) => {
-          const items = document.querySelectorAll('.w-2\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(val));
-        },
-        entryValue,
-        { timeout: 5000 }
-      );
+      const entryValue = testResourceName(testInfo, 'DUP', { uppercase: true });
+      await addEntryAndWait(entryValue);
 
       // Try to add the same entry again
       await userListsPage.addEntry(entryValue);
@@ -346,76 +230,28 @@ test.describe('User Lists Page', () => {
       await expect(errorText).toBeVisible();
 
       // Cleanup
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteList(listName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        listName,
-        { timeout: 5000 }
-      );
+      await deleteListAndWait(page, listName);
     });
 
-    test('should delete an entry after confirmation', async ({ page }) => {
+    test('should delete an entry after confirmation', async ({ page }, testInfo) => {
       await userListsPage.goto();
       await userListsPage.waitForListsToLoad();
 
-      // Create a list and add an entry
-      const listName = `DELENTRY${Date.now()}`;
-      await userListsPage.createList(listName);
-
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        listName,
-        { timeout: 5000 }
-      );
+      const listName = testResourceName(testInfo, 'DELENTRY', { uppercase: true });
+      await createListAndWait(listName);
 
       await userListsPage.selectList(listName);
       await userListsPage.waitForEntriesToLoad();
 
-      const entryValue = `TODEL${Date.now()}`;
-      await userListsPage.addEntry(entryValue);
+      const entryValue = testResourceName(testInfo, 'TODEL', { uppercase: true });
+      await addEntryAndWait(entryValue);
 
-      await page.waitForFunction(
-        (val: string) => {
-          const items = document.querySelectorAll('.w-2\\/3 ul li');
-          return Array.from(items).some(item => item.textContent?.includes(val));
-        },
-        entryValue,
-        { timeout: 5000 }
-      );
-
-      // Accept the confirmation dialog and delete the entry
-      page.on('dialog', dialog => dialog.accept());
-      await userListsPage.clickDeleteEntry(entryValue);
-
-      // Wait for the entry to disappear
-      await page.waitForFunction(
-        (val: string) => {
-          const items = document.querySelectorAll('.w-2\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(val));
-        },
-        entryValue,
-        { timeout: 5000 }
-      );
+      await deleteEntryAndWait(page, entryValue);
 
       expect(await userListsPage.hasEntry(entryValue)).toBe(false);
 
       // Cleanup: delete the list
-      await userListsPage.clickDeleteList(listName);
-      await page.waitForFunction(
-        (name: string) => {
-          const items = document.querySelectorAll('.w-1\\/3 ul li');
-          return !Array.from(items).some(item => item.textContent?.includes(name));
-        },
-        listName,
-        { timeout: 5000 }
-      );
+      await deleteListAndWait(page, listName);
     });
   });
 });

--- a/ezrules/frontend/e2e/tests/user-management.spec.ts
+++ b/ezrules/frontend/e2e/tests/user-management.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../support/fixtures';
 import { UserManagementPage } from '../pages/user-management.page';
+import { acceptDialog, dismissDialog } from '../support/dialogs';
 import { testResourceName } from '../support/test-data';
 import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
@@ -99,8 +100,7 @@ test.describe(`User Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       expect(await userMgmtPage.hasUserWithEmail(uniqueEmail)).toBe(true);
 
       // Cleanup: delete the created user
-      page.on('dialog', dialog => dialog.accept());
-      await userMgmtPage.clickDeleteUser(uniqueEmail);
+      await acceptDialog(page, () => userMgmtPage.clickDeleteUser(uniqueEmail));
       await page.waitForFunction(
         (email: string) => {
           const rows = document.querySelectorAll('table tbody tr');
@@ -137,8 +137,7 @@ test.describe(`User Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
       await expect(errorText).toBeVisible();
 
       // Cleanup
-      page.on('dialog', dialog => dialog.accept());
-      await userMgmtPage.clickDeleteUser(uniqueEmail);
+      await acceptDialog(page, () => userMgmtPage.clickDeleteUser(uniqueEmail));
       await page.waitForFunction(
         (email: string) => {
           const rows = document.querySelectorAll('table tbody tr');
@@ -168,11 +167,8 @@ test.describe(`User Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
         { timeout: 5000 }
       );
 
-      // Accept the confirmation dialog
-      page.on('dialog', dialog => dialog.accept());
-
       const countBefore = await userMgmtPage.getUserRowCount();
-      await userMgmtPage.clickDeleteUser(uniqueEmail);
+      await acceptDialog(page, () => userMgmtPage.clickDeleteUser(uniqueEmail));
 
       // Wait for the user to disappear
       await page.waitForFunction(
@@ -207,19 +203,13 @@ test.describe(`User Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
 
       const countBefore = await userMgmtPage.getUserRowCount();
 
-      const dismissDialogPromise = page.waitForEvent('dialog');
-      await userMgmtPage.clickDeleteUser(uniqueEmail);
-      const dismissDialog = await dismissDialogPromise;
-      await dismissDialog.dismiss();
+      await dismissDialog(page, () => userMgmtPage.clickDeleteUser(uniqueEmail));
 
       await expect(page.locator('table tbody tr')).toHaveCount(countBefore);
       expect(await userMgmtPage.hasUserWithEmail(uniqueEmail)).toBe(true);
 
       // Cleanup
-      const acceptDialogPromise = page.waitForEvent('dialog');
-      await userMgmtPage.clickDeleteUser(uniqueEmail);
-      const acceptDialog = await acceptDialogPromise;
-      await acceptDialog.accept();
+      await acceptDialog(page, () => userMgmtPage.clickDeleteUser(uniqueEmail));
       await page.waitForFunction(
         (email: string) => {
           const rows = document.querySelectorAll('table tbody tr');

--- a/ezrules/frontend/e2e/tests/user-management.spec.ts
+++ b/ezrules/frontend/e2e/tests/user-management.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '../support/fixtures';
 import { UserManagementPage } from '../pages/user-management.page';
+import { testResourceName } from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
 
 /**
  * E2E tests for the User Management page.
  */
-test.describe('User Management Page', () => {
+test.describe(`User Management Page ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
   let userMgmtPage: UserManagementPage;
 
   test.beforeEach(async ({ page }) => {
@@ -76,11 +78,11 @@ test.describe('User Management Page', () => {
       await expect(userMgmtPage.createUserButton).toBeVisible();
     });
 
-    test('should create a new user and display it in the table', async ({ page }) => {
+    test('should create a new user and display it in the table', async ({ page }, testInfo) => {
       await userMgmtPage.goto();
       await userMgmtPage.waitForUsersToLoad();
 
-      const uniqueEmail = `e2e_test_${Date.now()}@example.com`;
+      const uniqueEmail = `${testResourceName(testInfo, 'e2e_test', { maxLength: 48 }).toLowerCase()}@example.com`;
 
       await userMgmtPage.createUser(uniqueEmail, 'testpass123');
 
@@ -109,11 +111,11 @@ test.describe('User Management Page', () => {
       );
     });
 
-    test('should show error for duplicate email', async ({ page }) => {
+    test('should show error for duplicate email', async ({ page }, testInfo) => {
       await userMgmtPage.goto();
       await userMgmtPage.waitForUsersToLoad();
 
-      const uniqueEmail = `e2e_dup_${Date.now()}@example.com`;
+      const uniqueEmail = `${testResourceName(testInfo, 'e2e_dup', { maxLength: 48 }).toLowerCase()}@example.com`;
 
       // Create user first time
       await userMgmtPage.createUser(uniqueEmail, 'testpass123');
@@ -149,12 +151,12 @@ test.describe('User Management Page', () => {
   });
 
   test.describe('Delete User', () => {
-    test('should delete a user after confirmation', async ({ page }) => {
+    test('should delete a user after confirmation', async ({ page }, testInfo) => {
       await userMgmtPage.goto();
       await userMgmtPage.waitForUsersToLoad();
 
       // Create a user to delete
-      const uniqueEmail = `e2e_del_${Date.now()}@example.com`;
+      const uniqueEmail = `${testResourceName(testInfo, 'e2e_del', { maxLength: 48 }).toLowerCase()}@example.com`;
       await userMgmtPage.createUser(uniqueEmail, 'testpass123');
 
       await page.waitForFunction(
@@ -186,12 +188,12 @@ test.describe('User Management Page', () => {
       expect(countAfter).toBe(countBefore - 1);
     });
 
-    test('should not delete a user when confirmation is dismissed', async ({ page }) => {
+    test('should not delete a user when confirmation is dismissed', async ({ page }, testInfo) => {
       await userMgmtPage.goto();
       await userMgmtPage.waitForUsersToLoad();
 
       // Create a user to test with
-      const uniqueEmail = `e2e_nodel_${Date.now()}@example.com`;
+      const uniqueEmail = `${testResourceName(testInfo, 'e2e_nodel', { maxLength: 48 }).toLowerCase()}@example.com`;
       await userMgmtPage.createUser(uniqueEmail, 'testpass123');
 
       await page.waitForFunction(
@@ -205,20 +207,19 @@ test.describe('User Management Page', () => {
 
       const countBefore = await userMgmtPage.getUserRowCount();
 
-      // Dismiss the confirmation dialog
-      page.on('dialog', dialog => dialog.dismiss());
-
+      const dismissDialogPromise = page.waitForEvent('dialog');
       await userMgmtPage.clickDeleteUser(uniqueEmail);
+      const dismissDialog = await dismissDialogPromise;
+      await dismissDialog.dismiss();
 
-      // Wait briefly and check count is unchanged
-      await page.waitForTimeout(500);
-      const countAfter = await userMgmtPage.getUserRowCount();
-      expect(countAfter).toBe(countBefore);
+      await expect(page.locator('table tbody tr')).toHaveCount(countBefore);
+      expect(await userMgmtPage.hasUserWithEmail(uniqueEmail)).toBe(true);
 
       // Cleanup
-      page.removeAllListeners('dialog');
-      page.on('dialog', dialog => dialog.accept());
+      const acceptDialogPromise = page.waitForEvent('dialog');
       await userMgmtPage.clickDeleteUser(uniqueEmail);
+      const acceptDialog = await acceptDialogPromise;
+      await acceptDialog.accept();
       await page.waitForFunction(
         (email: string) => {
           const rows = document.querySelectorAll('table tbody tr');

--- a/ezrules/frontend/playwright.config.ts
+++ b/ezrules/frontend/playwright.config.ts
@@ -31,8 +31,8 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:4200',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Keep a trace for failed tests even in local no-retry runs. */
+    trace: 'retain-on-failure',
 
     /* Screenshot only on failure */
     screenshot: 'only-on-failure',

--- a/ezrules/frontend/playwright.config.ts
+++ b/ezrules/frontend/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
 
   /* Keep local runs aligned with CI's single-worker invocation to avoid
    * overloading the dev API/database pool during full-suite browser runs. */
-  workers: process.env.CI ? 4 : 1,
+  workers: 1,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.6"
+version = "1.28.7"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.6"
+version = "1.28.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Added shared Playwright support for deterministic test data, API setup/cleanup, state restoration, and failure diagnostics.
- Replaced all remaining `page.waitForTimeout(...)` usages with event/count/state-based waits.
- Hardened the cited field types, user lists, rule create, and rule detail specs, plus stateful settings/order/user/role/label/outcome specs with tags and restoration checks.
- Updated E2E docs and retained Playwright traces on failure for local no-retry runs.

## Verification
- `uv run poe check`
- `npx tsc --noEmit --skipLibCheck --types node,@playwright/test --moduleResolution bundler --target ES2022 --module ES2022 ...` over touched E2E support/page/spec files
- `npx playwright test --list --project=chromium`
- `git diff --check`
- `rg waitForTimeout ezrules/frontend/e2e/tests ezrules/frontend/e2e/pages ezrules/frontend/e2e/support -g '*.ts'`

## Known gaps
- Local Playwright spec execution was not run; per repo policy, GitHub Actions/PR checks are the source of truth for full E2E execution.
- No clean-slate database compatibility note applies; this change is test infrastructure only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E tests, Playwright config, and release notes; no production application or API behavior is modified.
> 
> **Overview**
> **Playwright E2E infrastructure** gains a new `e2e/support/` layer: custom `fixtures` (failure diagnostics attachment), `testResourceName` / `deterministicUnixTimestamp`, shared `acceptDialog`/`dismissDialog`, and `api-helpers` for rule/user-list/field-type CRUD plus runtime, AI authoring, and outcome-hierarchy restore/assert helpers.
> 
> **Specs and page objects** switch from `@playwright/test` to the custom fixtures, replace `Date.now()` names with deterministic resources, drop `waitForTimeout` and ad-hoc `page.on('dialog')` in favor of event/count waits and dialog helpers, and tag mutating suites with `@stateful` / `@settings` / `@test-data`. Settings and main-rule-order tests now snapshot and restore shared org state via API with explicit restoration assertions; field types and user lists add `afterEach` API cleanup.
> 
> **Playwright config** uses **1 worker** everywhere and **retain-on-failure** traces. **Docs** (`e2e/README.md`, `whatsnew.md`) and version bump to **v1.28.7** document the patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc718af53651876f9ec452d6524e4dd4e304b14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->