### PR TITLE
Correct rule-quality recall for non-firing evaluations

### DIFF
--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -203,6 +203,9 @@ Rule quality query params:
 - `force_refresh` on report requests: `false` returns existing snapshot only, `true` enqueues a new snapshot and requires `GENERATE_RULE_QUALITY_REPORTS`
 - `freeze_at` is returned in responses to indicate snapshot timestamp
 - Reports include only active curated pairs configured under Settings.
+- For an `outcome -> label` pair, `actual_positives` includes every labeled served decision in the frozen window where that rule was evaluated and the configured label was assigned, including evaluations where the rule produced no result. Those missed matches contribute to `false_negative` and recall; rules skipped by first-match execution are not treated as evaluated.
+- Legacy decisions without an `all_rule_results` evaluation snapshot are excluded because the service cannot distinguish a non-firing rule from a rule that was not evaluated.
+- `precision` is `null` when `predicted_positives` is zero, `recall` is `null` when `actual_positives` is zero, and `f1` is `null` when either input metric is undefined. When both metrics are defined and zero, `f1` is `0`.
 
 Rule activity query params:
 - `aggregation` (default `6h`; valid values `1h`, `6h`, `12h`, `24h`, `30d`)

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -118,6 +118,8 @@ Tip:
 - Configure curated pairs in **Settings → General** so reports focus only on the mappings your team tracks.
 - Use the pair table to decide which outcome-label mapping best represents each rule.
 
+For each configured `outcome -> label` pair, precision measures how often that rule outcome was attached to the configured label. Recall uses every labeled served event where the rule was evaluated in the frozen report window as ground truth, including evaluations where the rule did not fire. Such missed labeled events count as false negatives; rules skipped by first-match execution are not counted as evaluated. Legacy decisions without a complete rule-results snapshot are excluded because their rule exposure cannot be reconstructed. A metric is unavailable when its denominator is zero; when precision and recall are both defined but zero, F1 is `0`.
+
 Healthy signal:
 
 - high precision on fraud-related mappings (few false positives)
@@ -144,7 +146,7 @@ Healthy signal:
 
 Tip: responses are structured for Chart.js (`labels` + dataset series).
 
-Source-of-truth note: Dashboard volume, outcome, rule activity, per-rule performance, and labeled-transaction charts read canonical served decisions. Label analytics and rule quality use canonical `event_version_labels` linked to those served event versions.
+Source-of-truth note: Dashboard volume, outcome, rule activity, per-rule performance, and labeled-transaction charts read canonical served decisions. Label analytics and rule quality use canonical `event_version_labels` linked to those served event versions. Rule Quality joins matched rule results to each rule's evaluated labeled-decision population so non-firing evaluations still accumulate false negatives.
 
 ---
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.28.8
+
+* **Complete rule-quality recall**: Rule Quality now counts labeled events where a rule did not fire as false negatives, so recall reflects the full labeled ground-truth population rather than only matched rule results.
+* **Consistent quality metrics**: Rule Quality and backtesting now share the same precision, recall, F1, and zero-denominator semantics.
+
 ## v1.28.7
 
 * **Playwright E2E hardening**: Added shared deterministic test data, API setup/cleanup helpers, stateful-spec tags, failure diagnostics, and event-based waits so flaky runs are easier to debug.

--- a/ezrules/backend/backtesting.py
+++ b/ezrules/backend/backtesting.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Any
 
 from ezrules.backend.features import FeatureResolutionError, FeatureResolver
+from ezrules.backend.quality_metrics import compute_quality_metric_values
 from ezrules.core.rule import MissingFieldLookupError, MissingStatLookupError
 from ezrules.core.type_casting import (
     CastError,
@@ -95,32 +96,24 @@ def _build_quality_metrics(
             if actual_positives <= 0:
                 continue
 
-            true_positive = accumulator.outcome_label_counts.get((outcome, label), 0)
-            false_positive = predicted_positives - true_positive
-            false_negative = actual_positives - true_positive
-
-            precision = true_positive / predicted_positives if predicted_positives > 0 else None
-            recall = true_positive / actual_positives if actual_positives > 0 else None
-
-            f1 = None
-            if precision is not None and recall is not None:
-                if (precision + recall) > 0:
-                    f1 = 2 * precision * recall / (precision + recall)
-                else:
-                    f1 = 0.0
+            values = compute_quality_metric_values(
+                true_positive=accumulator.outcome_label_counts.get((outcome, label), 0),
+                predicted_positives=predicted_positives,
+                actual_positives=actual_positives,
+            )
 
             metrics.append(
                 {
                     "outcome": outcome,
                     "label": label,
-                    "true_positive": true_positive,
-                    "false_positive": false_positive,
-                    "false_negative": false_negative,
-                    "predicted_positives": predicted_positives,
-                    "actual_positives": actual_positives,
-                    "precision": _safe_round(precision),
-                    "recall": _safe_round(recall),
-                    "f1": _safe_round(f1),
+                    "true_positive": values["true_positive"],
+                    "false_positive": values["false_positive"],
+                    "false_negative": values["false_negative"],
+                    "predicted_positives": values["predicted_positives"],
+                    "actual_positives": values["actual_positives"],
+                    "precision": _safe_round(values["precision"]),
+                    "recall": _safe_round(values["recall"]),
+                    "f1": _safe_round(values["f1"]),
                 }
             )
 

--- a/ezrules/backend/quality_metrics.py
+++ b/ezrules/backend/quality_metrics.py
@@ -1,0 +1,52 @@
+"""Shared binary quality-metric calculations."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class QualityMetricValues(TypedDict):
+    true_positive: int
+    false_positive: int
+    false_negative: int
+    predicted_positives: int
+    actual_positives: int
+    precision: float | None
+    recall: float | None
+    f1: float | None
+
+
+def compute_quality_metric_values(
+    *,
+    true_positive: int,
+    predicted_positives: int,
+    actual_positives: int,
+) -> QualityMetricValues:
+    """Return confusion counts and precision/recall/F1 for one binary pair."""
+    if min(true_positive, predicted_positives, actual_positives) < 0:
+        raise ValueError("Quality metric counts must be non-negative")
+    if true_positive > predicted_positives:
+        raise ValueError("True positives cannot exceed predicted positives")
+    if true_positive > actual_positives:
+        raise ValueError("True positives cannot exceed actual positives")
+
+    false_positive = predicted_positives - true_positive
+    false_negative = actual_positives - true_positive
+    precision = true_positive / predicted_positives if predicted_positives > 0 else None
+    recall = true_positive / actual_positives if actual_positives > 0 else None
+
+    f1 = None
+    if precision is not None and recall is not None:
+        denominator = precision + recall
+        f1 = 0.0 if denominator == 0 else 2 * precision * recall / denominator
+
+    return {
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        "false_negative": false_negative,
+        "predicted_positives": predicted_positives,
+        "actual_positives": actual_positives,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }

--- a/ezrules/backend/rule_quality.py
+++ b/ezrules/backend/rule_quality.py
@@ -8,7 +8,9 @@ from collections import defaultdict
 from typing import Any
 
 import sqlalchemy
+from sqlalchemy.dialects.postgresql import JSONB
 
+from ezrules.backend.quality_metrics import compute_quality_metric_values
 from ezrules.models.backend_core import (
     EvaluationDecision,
     EvaluationRuleResult,
@@ -87,12 +89,19 @@ def compute_rule_quality_metrics(
     """Compute precision/recall metrics for outcome->label pairs."""
     start_time = freeze_at - datetime.timedelta(days=lookback_days)
     selected_pairs = normalize_rule_quality_pairs(curated_pairs)
+    raw_all_rule_results = sqlalchemy.cast(EvaluationDecision.all_rule_results, JSONB)
+    has_complete_rule_results = sqlalchemy.func.jsonb_typeof(raw_all_rule_results) == "object"
+    safe_all_rule_results = sqlalchemy.case(
+        (has_complete_rule_results, raw_all_rule_results),
+        else_=sqlalchemy.cast(sqlalchemy.literal("{}"), JSONB),
+    )
 
     base_filters: list[Any] = [
         EvaluationDecision.served.is_(True),
         EvaluationDecision.decision_type == "served",
         EvaluationDecision.evaluated_at >= start_time,
         EvaluationDecision.evaluated_at <= freeze_at,
+        has_complete_rule_results,
         EventVersionLabel.assigned_at <= freeze_at,
     ]
     if max_decision_id is not None and max_decision_id > 0:
@@ -100,16 +109,20 @@ def compute_rule_quality_metrics(
     if o_id is not None:
         base_filters.append(EvaluationDecision.o_id == o_id)
 
-    total_labeled_events = (
-        db.query(sqlalchemy.func.count(sqlalchemy.func.distinct(EvaluationDecision.ed_id)))
+    label_count_rows = (
+        db.query(
+            Label.label,
+            sqlalchemy.func.count(sqlalchemy.func.distinct(EvaluationDecision.ed_id)).label("count"),
+        )
         .join(EventVersionLabel, EventVersionLabel.ev_id == EvaluationDecision.ev_id)
         .join(Label, Label.el_id == EventVersionLabel.el_id)
         .filter(*base_filters)
         .filter(EventVersionLabel.o_id == o_id if o_id is not None else sqlalchemy.true())
         .filter(Label.o_id == o_id if o_id is not None else sqlalchemy.true())
-        .scalar()
-        or 0
+        .group_by(Label.label)
+        .all()
     )
+    total_labeled_events = sum(int(count) for _label_name, count in label_count_rows)
 
     if not selected_pairs:
         return {
@@ -122,6 +135,7 @@ def compute_rule_quality_metrics(
             "worst_rules": [],
         }
 
+    expanded_results = sqlalchemy.func.jsonb_each(safe_all_rule_results).table_valued("key", "value").lateral()
     grouped_rows = (
         db.query(
             EvaluationRuleResult.r_id,
@@ -129,9 +143,10 @@ def compute_rule_quality_metrics(
             RuleModel.description,
             EvaluationRuleResult.rule_result,
             Label.label,
-            sqlalchemy.func.count(EvaluationRuleResult.err_id).label("count"),
+            sqlalchemy.func.count(sqlalchemy.func.distinct(EvaluationDecision.ed_id)).label("count"),
         )
         .join(EvaluationDecision, EvaluationDecision.ed_id == EvaluationRuleResult.ed_id)
+        .join(expanded_results, sqlalchemy.cast(EvaluationRuleResult.r_id, sqlalchemy.String) == expanded_results.c.key)
         .join(EventVersionLabel, EventVersionLabel.ev_id == EvaluationDecision.ev_id)
         .join(Label, Label.el_id == EventVersionLabel.el_id)
         .join(RuleModel, RuleModel.r_id == EvaluationRuleResult.r_id)
@@ -148,10 +163,36 @@ def compute_rule_quality_metrics(
         .all()
     )
 
+    exposure_rows = (
+        db.query(
+            RuleModel.r_id,
+            RuleModel.rid,
+            RuleModel.description,
+            Label.label,
+            sqlalchemy.func.count(sqlalchemy.func.distinct(EvaluationDecision.ed_id)).label("count"),
+        )
+        .select_from(EvaluationDecision)
+        .join(expanded_results, sqlalchemy.true())
+        .join(RuleModel, sqlalchemy.cast(RuleModel.r_id, sqlalchemy.String) == expanded_results.c.key)
+        .join(EventVersionLabel, EventVersionLabel.ev_id == EvaluationDecision.ev_id)
+        .join(Label, Label.el_id == EventVersionLabel.el_id)
+        .filter(*base_filters)
+        .filter(EventVersionLabel.o_id == o_id if o_id is not None else sqlalchemy.true())
+        .filter(Label.o_id == o_id if o_id is not None else sqlalchemy.true())
+        .group_by(RuleModel.r_id, RuleModel.rid, RuleModel.description, Label.label)
+        .all()
+    )
+
     rule_meta: dict[int, tuple[str, str]] = {}
     rule_matrix: dict[int, dict[tuple[str, str], int]] = defaultdict(dict)
+    evaluated_label_totals: dict[int, dict[str, int]] = defaultdict(dict)
     outcomes_by_rule: dict[int, set[str]] = defaultdict(set)
     labels_by_rule: dict[int, set[str]] = defaultdict(set)
+
+    for r_id, rid, description, label_name, count in exposure_rows:
+        rule_meta[r_id] = (rid, description)
+        evaluated_label_totals[r_id][label_name] = count
+        labels_by_rule[r_id].add(label_name)
 
     for r_id, rid, description, outcome, label_name, count in grouped_rows:
         rule_meta[r_id] = (rid, description)
@@ -169,26 +210,18 @@ def compute_rule_quality_metrics(
         matrix = rule_matrix[r_id]
 
         outcome_totals = {outcome: sum(matrix.get((outcome, label), 0) for label in labels) for outcome in outcomes}
-        label_totals = {
-            label_name: sum(matrix.get((outcome, label_name), 0) for outcome in outcomes) for label_name in labels
-        }
-
         rule_pairs: list[dict[str, Any]] = []
         for outcome, label_name in selected_pairs:
             predicted_positives = outcome_totals.get(outcome, 0)
-            actual_positives = label_totals.get(label_name, 0)
+            actual_positives = evaluated_label_totals[r_id].get(label_name, 0)
             if predicted_positives < min_support and actual_positives < min_support:
                 continue
 
-            true_positive = matrix.get((outcome, label_name), 0)
-            false_positive = predicted_positives - true_positive
-            false_negative = actual_positives - true_positive
-
-            precision = true_positive / predicted_positives if predicted_positives > 0 else None
-            recall = true_positive / actual_positives if actual_positives > 0 else None
-            f1 = None
-            if precision is not None and recall is not None and (precision + recall) > 0:
-                f1 = 2 * precision * recall / (precision + recall)
+            values = compute_quality_metric_values(
+                true_positive=matrix.get((outcome, label_name), 0),
+                predicted_positives=predicted_positives,
+                actual_positives=actual_positives,
+            )
 
             metric = {
                 "r_id": r_id,
@@ -196,14 +229,14 @@ def compute_rule_quality_metrics(
                 "description": description,
                 "outcome": outcome,
                 "label": label_name,
-                "true_positive": true_positive,
-                "false_positive": false_positive,
-                "false_negative": false_negative,
-                "predicted_positives": predicted_positives,
-                "actual_positives": actual_positives,
-                "precision": _safe_round(precision),
-                "recall": _safe_round(recall),
-                "f1": _safe_round(f1),
+                "true_positive": values["true_positive"],
+                "false_positive": values["false_positive"],
+                "false_negative": values["false_negative"],
+                "predicted_positives": values["predicted_positives"],
+                "actual_positives": values["actual_positives"],
+                "precision": _safe_round(values["precision"]),
+                "recall": _safe_round(values["recall"]),
+                "f1": _safe_round(values["f1"]),
             }
             pair_metrics.append(metric)
             rule_pairs.append(metric)
@@ -229,7 +262,7 @@ def compute_rule_quality_metrics(
                 "r_id": r_id,
                 "rid": rid,
                 "description": description,
-                "labeled_events": sum(outcome_totals.values()),
+                "labeled_events": sum(evaluated_label_totals[r_id].values()),
                 "pair_count": len(rule_pairs),
                 "average_precision": _safe_round(average_precision),
                 "average_recall": _safe_round(average_recall),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.28.7"
+version = "1.28.8"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_quality_metrics_contract.py
+++ b/tests/test_quality_metrics_contract.py
@@ -1,0 +1,72 @@
+import pytest
+
+from ezrules.backend.quality_metrics import compute_quality_metric_values
+
+
+def test_quality_metrics_match_four_event_confusion_matrix():
+    metric = compute_quality_metric_values(
+        true_positive=1,
+        predicted_positives=2,
+        actual_positives=2,
+    )
+
+    assert metric == {
+        "true_positive": 1,
+        "false_positive": 1,
+        "false_negative": 1,
+        "predicted_positives": 2,
+        "actual_positives": 2,
+        "precision": 0.5,
+        "recall": 0.5,
+        "f1": 0.5,
+    }
+
+
+@pytest.mark.parametrize(
+    ("predicted_positives", "actual_positives", "expected_precision", "expected_recall", "expected_f1"),
+    [
+        (0, 2, None, 0.0, None),
+        (2, 0, 0.0, None, None),
+        (0, 0, None, None, None),
+        (2, 2, 0.0, 0.0, 0.0),
+    ],
+)
+def test_quality_metrics_define_zero_denominator_semantics(
+    predicted_positives,
+    actual_positives,
+    expected_precision,
+    expected_recall,
+    expected_f1,
+):
+    metric = compute_quality_metric_values(
+        true_positive=0,
+        predicted_positives=predicted_positives,
+        actual_positives=actual_positives,
+    )
+
+    assert metric["precision"] == expected_precision
+    assert metric["recall"] == expected_recall
+    assert metric["f1"] == expected_f1
+
+
+@pytest.mark.parametrize(
+    ("true_positive", "predicted_positives", "actual_positives"),
+    [
+        (-1, 0, 0),
+        (0, -1, 0),
+        (0, 0, -1),
+        (2, 1, 2),
+        (2, 2, 1),
+    ],
+)
+def test_quality_metrics_reject_impossible_counts(
+    true_positive,
+    predicted_positives,
+    actual_positives,
+):
+    with pytest.raises(ValueError):
+        compute_quality_metric_values(
+            true_positive=true_positive,
+            predicted_positives=predicted_positives,
+            actual_positives=actual_positives,
+        )

--- a/tests/test_rule_quality_confusion_matrix_contract.py
+++ b/tests/test_rule_quality_confusion_matrix_contract.py
@@ -1,0 +1,188 @@
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.api_v2.routes import evaluator as evaluator_router
+from ezrules.backend.rule_quality import compute_rule_quality_metrics
+from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager
+from ezrules.models.backend_core import AllowedOutcome, EventVersionLabel, Label, Organisation, RuleQualityPair
+from ezrules.models.backend_core import Rule as RuleModel
+from tests.canonical_helpers import add_served_decision
+
+
+def test_non_firing_labeled_event_counts_as_false_negative(session, live_api_key):
+    """Every labeled event belongs in the rule's confusion-matrix universe."""
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    rule = RuleModel(
+        rid="quality_confusion_matrix_contract",
+        logic="if $amount > 100:\n\treturn !HOLD",
+        description="Hold high-value events",
+        o_id=int(org.o_id),
+    )
+    fraud = Label(label="FRAUD", o_id=int(org.o_id))
+    normal = Label(label="NORMAL", o_id=int(org.o_id))
+    session.add_all(
+        [
+            rule,
+            fraud,
+            normal,
+            AllowedOutcome(outcome_name="HOLD", severity_rank=1, o_id=int(org.o_id)),
+        ]
+    )
+    session.flush()
+    session.add(
+        RuleQualityPair(
+            outcome="HOLD",
+            label="FRAUD",
+            active=True,
+            created_by="confusion-matrix-contract",
+            o_id=int(org.o_id),
+        )
+    )
+
+    session.commit()
+    RDBRuleEngineConfigProducer(db=session, o_id=int(org.o_id)).save_config(
+        RDBRuleManager(db=session, o_id=int(org.o_id))
+    )
+
+    now = datetime.datetime.now(datetime.UTC)
+    examples = [
+        # A: fires and is FRAUD (true positive).
+        ("quality-contract-a", 150, fraud),
+        # B: does not fire and is FRAUD (false negative).
+        ("quality-contract-b", 50, fraud),
+        # C: fires and is NORMAL (false positive).
+        ("quality-contract-c", 160, normal),
+        # D: does not fire and is NORMAL (true negative).
+        ("quality-contract-d", 40, normal),
+    ]
+    evaluator_router._lre = None
+    evaluator_router._shadow_lre = None
+    evaluator_router._allowlist_lre = None
+    try:
+        with TestClient(app) as client:
+            for offset, (transaction_id, amount, label) in enumerate(examples):
+                response = client.post(
+                    "/api/v2/evaluate",
+                    json={
+                        "transaction_id": transaction_id,
+                        "effective_at": int((now + datetime.timedelta(seconds=offset)).timestamp()),
+                        "event_data": {"amount": amount},
+                    },
+                    headers={"X-API-Key": live_api_key},
+                )
+                assert response.status_code == 200
+                session.add(
+                    EventVersionLabel(
+                        o_id=int(org.o_id),
+                        ev_id=int(response.json()["event_version_id"]),
+                        el_id=int(label.el_id),
+                        assigned_by="confusion-matrix-contract",
+                    )
+                )
+                session.commit()
+    finally:
+        evaluator_router._lre = None
+        evaluator_router._shadow_lre = None
+        evaluator_router._allowlist_lre = None
+
+    freeze_at = now + datetime.timedelta(minutes=1)
+    result = compute_rule_quality_metrics(
+        session,
+        min_support=1,
+        lookback_days=1,
+        freeze_at=freeze_at,
+        max_decision_id=None,
+        o_id=int(org.o_id),
+        curated_pairs=[("HOLD", "FRAUD")],
+    )
+
+    assert result["total_labeled_events"] == 4
+    assert len(result["pair_metrics"]) == 1
+    metric = result["pair_metrics"][0]
+    assert metric["rid"] == rule.rid
+    assert metric["true_positive"] == 1
+    assert metric["false_positive"] == 1
+    assert metric["false_negative"] == 1
+    assert metric["predicted_positives"] == 2
+    assert metric["actual_positives"] == 2
+    assert metric["precision"] == pytest.approx(0.5)
+    assert metric["recall"] == pytest.approx(0.5)
+    assert metric["f1"] == pytest.approx(0.5)
+
+    assert result["best_rules"][0]["labeled_events"] == 4
+    assert result["worst_rules"][0]["labeled_events"] == 4
+
+
+def test_rule_quality_denominator_includes_only_events_where_rule_was_evaluated(session):
+    """A first-match-skipped rule is absent, while an evaluated no-fire rule is a false negative."""
+    org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    first_rule = RuleModel(rid="quality_first", logic="return !HOLD", description="First rule", o_id=int(org.o_id))
+    later_rule = RuleModel(rid="quality_later", logic="return !HOLD", description="Later rule", o_id=int(org.o_id))
+    fraud = Label(label="FRAUD", o_id=int(org.o_id))
+    session.add_all([first_rule, later_rule, fraud])
+    session.flush()
+
+    now = datetime.datetime.now(datetime.UTC)
+    first_decision = add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="quality-first-match-stopped",
+        event_data={"amount": 150},
+        evaluated_at=now,
+        rule_results={int(first_rule.r_id): "HOLD"},
+        label=fraud,
+    )
+    first_decision.all_rule_results = {str(int(first_rule.r_id)): "HOLD"}
+
+    second_decision = add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="quality-all-rules-no-fire",
+        event_data={"amount": 50},
+        evaluated_at=now + datetime.timedelta(seconds=1),
+        label=fraud,
+    )
+    second_decision.all_rule_results = {
+        str(int(first_rule.r_id)): None,
+        str(int(later_rule.r_id)): None,
+    }
+
+    legacy_decision = add_served_decision(
+        session,
+        org_id=int(org.o_id),
+        transaction_id="quality-missing-exposure-snapshot",
+        event_data={"amount": 75},
+        evaluated_at=now + datetime.timedelta(seconds=2),
+        label=fraud,
+    )
+    legacy_decision.all_rule_results = None
+    session.commit()
+
+    result = compute_rule_quality_metrics(
+        session,
+        min_support=1,
+        lookback_days=1,
+        freeze_at=now + datetime.timedelta(minutes=1),
+        max_decision_id=None,
+        o_id=int(org.o_id),
+        curated_pairs=[("HOLD", "FRAUD")],
+    )
+    metrics = {metric["rid"]: metric for metric in result["pair_metrics"]}
+
+    assert result["total_labeled_events"] == 2
+    assert metrics[first_rule.rid]["actual_positives"] == 2
+    assert metrics[first_rule.rid]["false_negative"] == 1
+
+    assert metrics[later_rule.rid]["actual_positives"] == 1
+    assert metrics[later_rule.rid]["predicted_positives"] == 0
+    assert metrics[later_rule.rid]["false_negative"] == 1
+    assert metrics[later_rule.rid]["precision"] is None
+    assert metrics[later_rule.rid]["recall"] == pytest.approx(0.0)
+    assert metrics[later_rule.rid]["f1"] is None
+
+    summaries = {summary["rid"]: summary for summary in result["best_rules"] + result["worst_rules"]}
+    assert summaries[first_rule.rid]["labeled_events"] == 2
+    assert later_rule.rid not in summaries

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.28.7"
+version = "1.28.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- count labeled evaluations where a rule returned no outcome as false negatives
- derive each rule's denominator from its complete evaluation snapshot, preserving first-match skipped-rule semantics
- share precision, recall, and F1 calculations with backtesting
- document the corrected metric contract and bump the release to 1.28.8

## Verification
- `uv run poe check`
- 61 targeted PostgreSQL tests covering Rule Quality, backtesting metrics, analytics, and canonical management journeys
- `uv run mkdocs build --strict`
- independent final diff review

## Known gaps
- full backend and Playwright suites were not run locally; GitHub Actions is the source of truth
- legacy decisions without a complete `all_rule_results` snapshot are intentionally excluded because rule exposure cannot be reconstructed

## Merge
The repository owner will perform the final merge after CI and review are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics semantics and SQL aggregation for rule-quality reports; recall and rankings can shift for existing orgs, though legacy rows without `all_rule_results` are explicitly excluded.
> 
> **Overview**
> **Rule Quality recall** now treats labeled served decisions where a rule was evaluated but did not fire as **false negatives**, so `actual_positives` and recall reflect the rule’s full evaluated ground-truth set—not only rows with a matching `evaluation_rule_results` outcome.
> 
> The backend builds that population from each decision’s **`all_rule_results`** snapshot (via JSONB expansion), keeps **first-match skipped** rules out of the denominator, and **drops legacy decisions** missing a complete object snapshot. Pair metrics and rule summaries route through a new shared **`compute_quality_metric_values`** helper so **backtesting** uses the same TP/FP/FN and **null precision/recall/F1** rules when denominators are zero.
> 
> Docs and **v1.28.8** release notes describe the contract; new contract tests lock the four-event confusion matrix and evaluation-exposure edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6fe843120a83748cde4adc7628b91f091c44f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->