### PR TITLE
Encrypt AI authoring provider credentials at rest

### DIFF
--- a/alembic/versions/20260713_0039_encrypt_ai_authoring_api_keys.py
+++ b/alembic/versions/20260713_0039_encrypt_ai_authoring_api_keys.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 
 from alembic import op
-from ezrules.core.secret_encryption import decrypt_secret, encrypt_secret
+from ezrules.core.secret_encryption import SECRET_ENCRYPTION_PREFIX, decrypt_secret, encrypt_secret
 from ezrules.settings import app_settings
 
 revision: str = "20260713_0039"
@@ -44,7 +44,7 @@ def upgrade() -> None:
             {
                 "key": _AI_AUTHORING_API_KEY,
                 "o_id": row["o_id"],
-                "value": encrypt_secret(str(row["value"])),
+                "value": _encrypt_legacy_value(str(row["value"])),
             },
         )
 
@@ -79,3 +79,10 @@ def downgrade() -> None:
 def _require_real_app_secret(rows: Sequence[object]) -> None:
     if rows and app_settings.APP_SECRET == _ALEMBIC_PLACEHOLDER_SECRET:
         raise RuntimeError("EZRULES_APP_SECRET must be set to migrate stored AI authoring API keys")
+
+
+def _encrypt_legacy_value(value: str) -> str:
+    if value.startswith(SECRET_ENCRYPTION_PREFIX):
+        decrypt_secret(value)
+        return value
+    return encrypt_secret(value)

--- a/alembic/versions/20260713_0039_encrypt_ai_authoring_api_keys.py
+++ b/alembic/versions/20260713_0039_encrypt_ai_authoring_api_keys.py
@@ -1,0 +1,81 @@
+"""Encrypt AI authoring API keys.
+
+Revision ID: 20260713_0039
+Revises: 20260710_0038
+Create Date: 2026-07-13
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from ezrules.core.secret_encryption import decrypt_secret, encrypt_secret
+from ezrules.settings import app_settings
+
+revision: str = "20260713_0039"
+down_revision: str | None = "20260710_0038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_AI_AUTHORING_API_KEY = "ai_authoring_api_key"
+_ALEMBIC_PLACEHOLDER_SECRET = "alembic-placeholder-secret"
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    rows = list(
+        connection.execute(
+            sa.text("SELECT o_id, value FROM runtime_settings WHERE key = :key"),
+            {"key": _AI_AUTHORING_API_KEY},
+        ).mappings()
+    )
+    _require_real_app_secret(rows)
+
+    for row in rows:
+        connection.execute(
+            sa.text(
+                """
+                UPDATE runtime_settings
+                SET value = :value, value_type = 'secret'
+                WHERE key = :key AND o_id = :o_id
+                """
+            ),
+            {
+                "key": _AI_AUTHORING_API_KEY,
+                "o_id": row["o_id"],
+                "value": encrypt_secret(str(row["value"])),
+            },
+        )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    rows = list(
+        connection.execute(
+            sa.text("SELECT o_id, value FROM runtime_settings WHERE key = :key"),
+            {"key": _AI_AUTHORING_API_KEY},
+        ).mappings()
+    )
+    _require_real_app_secret(rows)
+
+    for row in rows:
+        connection.execute(
+            sa.text(
+                """
+                UPDATE runtime_settings
+                SET value = :value, value_type = 'string'
+                WHERE key = :key AND o_id = :o_id
+                """
+            ),
+            {
+                "key": _AI_AUTHORING_API_KEY,
+                "o_id": row["o_id"],
+                "value": decrypt_secret(str(row["value"])),
+            },
+        )
+
+
+def _require_real_app_secret(rows: Sequence[object]) -> None:
+    if rows and app_settings.APP_SECRET == _ALEMBIC_PLACEHOLDER_SECRET:
+        raise RuntimeError("EZRULES_APP_SECRET must be set to migrate stored AI authoring API keys")

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -341,6 +341,7 @@ AI authoring settings notes:
 - `enabled` defaults to `true` for orgs that have not saved an AI authoring setting.
 - `GET /api/v2/settings/ai-authoring` returns `provider`, `supported_providers`, `enabled`, `model`, and `api_key_configured`.
 - `PUT /api/v2/settings/ai-authoring` accepts `provider`, `enabled`, `model`, optional `api_key`, and `clear_api_key`.
+- Organisation-specific provider API keys are encrypted at rest using `EZRULES_APP_SECRET`. The API reports only whether a key is configured and never returns the credential.
 
 ### Users and Roles
 

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -79,6 +79,8 @@ Minimum environment inputs:
 - optional `EZRULES_AI_AUTHORING_MODEL`, `EZRULES_AI_AUTHORING_BASE_URL`, and `EZRULES_AI_AUTHORING_API_KEY` if AI-assisted draft generation should work without per-org Settings configuration
 - optional `EZRULES_CORS_ALLOWED_ORIGINS` / `EZRULES_CORS_ALLOW_ORIGIN_REGEX` only for split-origin deployments
 
+Use one stable `EZRULES_APP_SECRET` across the API, workers, and `init` task. The `init` task must receive the real value during upgrades because migrations use it to encrypt existing organisation-specific AI credentials; rotating it without migrating stored secrets makes those credentials and notification-channel configuration unreadable.
+
 Recommended production rollout sequence:
 
 1. Run the `init` task against the target database.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -136,6 +136,9 @@ Supported options:
 ### Secrets
 
 - Use strong unique values for `EZRULES_APP_SECRET`
+- Keep `EZRULES_APP_SECRET` stable across deployments and back it up securely. It encrypts stored notification-channel configuration and organisation-specific AI provider credentials; changing it without migrating those values makes them unreadable.
+- Export the real `EZRULES_APP_SECRET` into the migration process before upgrading a database that contains stored credentials; migrations refuse to encrypt existing AI provider keys with the Alembic metadata placeholder.
+- Database backups created before upgrading to v1.29.1 can still contain plaintext organisation-specific AI provider credentials and should be rotated or removed according to your retention policy.
 - Never commit real secrets
 
 ### Database Transport Security

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,6 +62,7 @@ docker compose -f docker-compose.prod.yml up --build
 The database is initialised empty. Login with the credentials you set in `.env`.
 By default, SMTP is routed to local Mailpit (`http://localhost:8025`) unless SMTP env vars override it.
 Re-running the same command later keeps the existing Docker volume and applies pending migrations before the stack starts.
+Keep the same `EZRULES_APP_SECRET` for every upgrade. Stored notification and organisation-specific AI credentials are encrypted with it, and the migration process must receive the real value rather than a generated replacement.
 
 Use this single-host stack to validate the production images locally. If you want an AWS-oriented deployment example, follow [Deployment Guide](../architecture/deployment.md) for the documented ECS/Fargate topology.
 
@@ -118,7 +119,7 @@ uv run ezrules bootstrap-org --name your-org --admin-email admin@example.com --a
 `init-db` creates the target database (if missing), applies Alembic migrations, and initializes the global permission action catalogue.
 `bootstrap-org` creates the organisation, seeds default roles and user lists, and creates the first admin user.
 It does not create any outcomes or labels; add those through the UI or API for each environment.
-After pulling future schema changes, run `uv run alembic upgrade head` on existing databases.
+After pulling future schema changes, export the deployment's stable `EZRULES_APP_SECRET` and run `uv run alembic upgrade head` on existing databases.
 
 ### 5) Start API and frontend
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.29.1
+
+* **Encrypted AI provider credentials**: Organisation-specific AI authoring API keys are now encrypted at rest with the application secret, including explicit cleared-key records, so database dumps no longer contain usable provider credentials.
+* **Fail-closed secret handling**: Invalid or undecryptable stored credentials no longer fall back to a deployment-wide provider key, while organisations without an override continue to use the configured environment default.
+
 ## v1.29.0
 
 * **Alert-backed case review**: Outcome-spike incidents now attach every contributing current evaluation to its existing case, preserving one assignment, notes, disposition, and audit workflow instead of introducing a parallel alert queue.

--- a/ezrules/backend/runtime_settings.py
+++ b/ezrules/backend/runtime_settings.py
@@ -37,6 +37,7 @@ _RUNTIME_VALUE_TYPE_INT = "int"
 _RUNTIME_VALUE_TYPE_FLOAT = "float"
 _RUNTIME_VALUE_TYPE_BOOL = "bool"
 _RUNTIME_VALUE_TYPE_STRING = "string"
+_RUNTIME_VALUE_TYPE_SECRET = "secret"
 _RUNTIME_VALUE_TYPE_JSON = "json"
 
 
@@ -109,7 +110,7 @@ _RUNTIME_SETTING_SPECS: dict[str, RuntimeSettingSpec] = {
     ),
     AI_AUTHORING_API_KEY_KEY: RuntimeSettingSpec(
         key=AI_AUTHORING_API_KEY_KEY,
-        value_type=_RUNTIME_VALUE_TYPE_STRING,
+        value_type=_RUNTIME_VALUE_TYPE_SECRET,
         default=AI_AUTHORING_API_KEY_DEFAULT,
     ),
 }
@@ -122,7 +123,7 @@ def _serialize_value(value_type: str, value: Any) -> str:
         return str(float(value))
     if value_type == _RUNTIME_VALUE_TYPE_BOOL:
         return "true" if bool(value) else "false"
-    if value_type == _RUNTIME_VALUE_TYPE_STRING:
+    if value_type in {_RUNTIME_VALUE_TYPE_STRING, _RUNTIME_VALUE_TYPE_SECRET}:
         return str(value)
     if value_type == _RUNTIME_VALUE_TYPE_JSON:
         return json.dumps(value, separators=(",", ":"), sort_keys=True)
@@ -141,7 +142,7 @@ def _parse_value(value_type: str, raw: str) -> Any:
         if lowered in {"false", "0", "no", "off"}:
             return False
         raise ValueError(f"Invalid boolean runtime setting value: {raw!r}")
-    if value_type == _RUNTIME_VALUE_TYPE_STRING:
+    if value_type in {_RUNTIME_VALUE_TYPE_STRING, _RUNTIME_VALUE_TYPE_SECRET}:
         return raw
     if value_type == _RUNTIME_VALUE_TYPE_JSON:
         return json.loads(raw)
@@ -169,7 +170,7 @@ def _coerce_to_spec(spec: RuntimeSettingSpec, value: Any) -> Any:
             return bool(value)
         raise ValueError(f"{spec.key} must be a boolean-compatible value")
 
-    if spec.value_type == _RUNTIME_VALUE_TYPE_STRING:
+    if spec.value_type in {_RUNTIME_VALUE_TYPE_STRING, _RUNTIME_VALUE_TYPE_SECRET}:
         normalized = str(value).strip()
         if spec.allowed_values is not None and normalized not in spec.allowed_values:
             allowed = ", ".join(str(item) for item in spec.allowed_values)
@@ -199,7 +200,7 @@ def get_runtime_setting(db: Any, key: str, org_id: int) -> Any:
         parsed = _parse_value(setting.value_type, setting.value)
         return _coerce_to_spec(spec, parsed)
     except Exception:
-        return spec.default
+        return "" if spec.value_type == _RUNTIME_VALUE_TYPE_SECRET else spec.default
 
 
 def set_runtime_setting(db: Any, key: str, value: Any, org_id: int) -> None:

--- a/ezrules/core/notification_channel_config.py
+++ b/ezrules/core/notification_channel_config.py
@@ -1,5 +1,3 @@
-import base64
-import hashlib
 import json
 import re
 from collections.abc import Mapping
@@ -7,11 +5,9 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-from cryptography.fernet import Fernet, InvalidToken
+from ezrules.core.secret_encryption import SECRET_ENCRYPTION_PREFIX, decrypt_secret, encrypt_secret
 
-from ezrules.settings import app_settings
-
-CONFIG_ENCRYPTION_PREFIX = "fernet:v1:"
+CONFIG_ENCRYPTION_PREFIX = SECRET_ENCRYPTION_PREFIX
 REDACTED_VALUE = "[redacted]"
 
 
@@ -92,8 +88,8 @@ def validate_notification_channel_config(channel_type: str, config: Mapping[str,
 
 def encrypt_notification_channel_config(channel_type: str, config: Mapping[str, Any] | None) -> str:
     validated_config = validate_notification_channel_config(channel_type, config)
-    payload = json.dumps(validated_config, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return CONFIG_ENCRYPTION_PREFIX + _fernet().encrypt(payload).decode("utf-8")
+    payload = json.dumps(validated_config, sort_keys=True, separators=(",", ":"))
+    return encrypt_secret(payload)
 
 
 def decrypt_notification_channel_config(channel_type: str, encrypted_config: str | None) -> dict[str, Any]:
@@ -102,14 +98,13 @@ def decrypt_notification_channel_config(channel_type: str, encrypted_config: str
     if not encrypted_config.startswith(CONFIG_ENCRYPTION_PREFIX):
         raise ValueError("Notification channel config is not encrypted with a supported format")
 
-    token = encrypted_config.removeprefix(CONFIG_ENCRYPTION_PREFIX).encode("utf-8")
     try:
-        payload = _fernet().decrypt(token)
-    except InvalidToken as exc:
+        payload = decrypt_secret(encrypted_config)
+    except ValueError as exc:
         raise ValueError("Notification channel config could not be decrypted") from exc
 
     try:
-        decoded = json.loads(payload.decode("utf-8"))
+        decoded = json.loads(payload)
     except json.JSONDecodeError as exc:
         raise ValueError("Notification channel config decrypted to invalid JSON") from exc
     return validate_notification_channel_config(channel_type, decoded)
@@ -136,11 +131,6 @@ def redact_notification_channel_error(
     for pattern, replacement in _SECRET_TEXT_PATTERNS:
         redacted_message = pattern.sub(replacement, redacted_message)
     return redacted_message
-
-
-def _fernet() -> Fernet:
-    digest = hashlib.sha256(app_settings.APP_SECRET.encode("utf-8")).digest()
-    return Fernet(base64.urlsafe_b64encode(digest))
 
 
 def _is_empty_value(value: Any) -> bool:

--- a/ezrules/core/secret_encryption.py
+++ b/ezrules/core/secret_encryption.py
@@ -1,0 +1,31 @@
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from ezrules.settings import app_settings
+
+SECRET_ENCRYPTION_PREFIX = "fernet:v1:"
+
+
+def encrypt_secret(value: str) -> str:
+    """Encrypt a recoverable application secret with the configured app secret."""
+    token = _fernet().encrypt(value.encode("utf-8")).decode("utf-8")
+    return SECRET_ENCRYPTION_PREFIX + token
+
+
+def decrypt_secret(encrypted_value: str) -> str:
+    """Decrypt a versioned application secret, rejecting plaintext and tampering."""
+    if not encrypted_value.startswith(SECRET_ENCRYPTION_PREFIX):
+        raise ValueError("Secret is not encrypted with a supported format")
+
+    token = encrypted_value.removeprefix(SECRET_ENCRYPTION_PREFIX).encode("utf-8")
+    try:
+        return _fernet().decrypt(token).decode("utf-8")
+    except (InvalidToken, UnicodeDecodeError) as exc:
+        raise ValueError("Secret could not be decrypted") from exc
+
+
+def _fernet() -> Fernet:
+    digest = hashlib.sha256(app_settings.APP_SECRET.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))

--- a/ezrules/models/backend_core.py
+++ b/ezrules/models/backend_core.py
@@ -31,6 +31,7 @@ from ezrules.core.notification_channel_config import (
     encrypt_notification_channel_config,
     redact_notification_channel_config,
 )
+from ezrules.core.secret_encryption import decrypt_secret, encrypt_secret
 from ezrules.models.database import Base
 
 
@@ -228,18 +229,40 @@ class Organisation(Base):
         return f"ID:{self.o_id}, {self.name=}, {len(self.rules)=}"
 
 
+_RUNTIME_SETTING_VALUE_NOT_PROVIDED = object()
+
+
 class RuntimeSetting(Base):
     __tablename__ = "runtime_settings"
 
     key = Column(String(100), primary_key=True)
     o_id: Mapped[int] = mapped_column(ForeignKey("organisation.o_id"), primary_key=True)
     value_type = Column(String(20), nullable=False)
-    value = Column(Text, nullable=False)
+    _stored_value = Column("value", Text, nullable=False)
     created_at = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
 
+    def __init__(self, **kwargs: Any) -> None:
+        value = kwargs.pop("value", _RUNTIME_SETTING_VALUE_NOT_PROVIDED)
+        super().__init__(**kwargs)
+        if value is not _RUNTIME_SETTING_VALUE_NOT_PROVIDED:
+            self.value = str(value)
+
+    @property
+    def value(self) -> str:
+        stored_value = str(self._stored_value or "")
+        if str(self.value_type) == "secret":
+            return decrypt_secret(stored_value)
+        return stored_value
+
+    @value.setter
+    def value(self, value: str) -> None:
+        normalized = str(value)
+        self._stored_value = encrypt_secret(normalized) if str(self.value_type) == "secret" else normalized
+
     def __repr__(self):
-        return f"<RuntimeSetting key={self.key} o_id={self.o_id} value_type={self.value_type} value={self.value}>"
+        value = "[redacted]" if str(self.value_type) == "secret" else self.value
+        return f"<RuntimeSetting key={self.key} o_id={self.o_id} value_type={self.value_type} value={value}>"
 
 
 class RuleEngineConfig(Base):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.29.0"
+version = "1.29.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_ai_authoring_secret_storage.py
+++ b/tests/test_ai_authoring_secret_storage.py
@@ -120,16 +120,26 @@ def test_ai_authoring_secret_preserves_fallback_clear_and_fail_closed_semantics(
 def test_ai_authoring_secret_migration_round_trip_and_placeholder_refusal(session, monkeypatch):
     migration = runpy.run_path(str(_MIGRATION_PATH))
     org = Organisation(name="AI Secret Migration Org")
-    session.add(org)
+    already_encrypted_org = Organisation(name="AI Secret Already Encrypted Migration Org")
+    session.add_all([org, already_encrypted_org])
     session.commit()
+    already_encrypted_value = encrypt_secret("sk-already-encrypted-secret")
     session.execute(
         sa.text(
             """
             INSERT INTO runtime_settings (key, o_id, value_type, value, created_at, updated_at)
-            VALUES (:key, :o_id, 'string', :value, NOW(), NOW())
+            VALUES
+                (:key, :plaintext_o_id, 'string', :plaintext_value, NOW(), NOW()),
+                (:key, :encrypted_o_id, 'secret', :encrypted_value, NOW(), NOW())
             """
         ),
-        {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(org.o_id), "value": "sk-migration-secret"},
+        {
+            "key": AI_AUTHORING_API_KEY_KEY,
+            "plaintext_o_id": int(org.o_id),
+            "plaintext_value": "sk-migration-secret",
+            "encrypted_o_id": int(already_encrypted_org.o_id),
+            "encrypted_value": already_encrypted_value,
+        },
     )
     session.flush()
 
@@ -157,6 +167,19 @@ def test_ai_authoring_secret_migration_round_trip_and_placeholder_refusal(sessio
     assert upgraded["value_type"] == "secret"
     assert str(upgraded["value"]).startswith(SECRET_ENCRYPTION_PREFIX)
     assert decrypt_secret(str(upgraded["value"])) == "sk-migration-secret"
+    assert (
+        session.execute(
+            sa.text(
+                """
+            SELECT value
+            FROM runtime_settings
+            WHERE key = :key AND o_id = :o_id
+            """
+            ),
+            {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(already_encrypted_org.o_id)},
+        ).scalar_one()
+        == already_encrypted_value
+    )
 
     migration["downgrade"]()
     downgraded = (

--- a/tests/test_ai_authoring_secret_storage.py
+++ b/tests/test_ai_authoring_secret_storage.py
@@ -1,0 +1,178 @@
+import runpy
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from ezrules.backend import runtime_settings
+from ezrules.backend.runtime_settings import (
+    AI_AUTHORING_API_KEY_KEY,
+    get_ai_authoring_api_key,
+    has_ai_authoring_api_key,
+    set_ai_authoring_api_key,
+)
+from ezrules.core.secret_encryption import SECRET_ENCRYPTION_PREFIX, decrypt_secret, encrypt_secret
+from ezrules.models.backend_core import Organisation, RuntimeSetting
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1] / "alembic" / "versions" / "20260713_0039_encrypt_ai_authoring_api_keys.py"
+)
+
+
+def test_secret_encryption_round_trip_and_tamper_rejection():
+    encrypted = encrypt_secret("sk-provider-secret")
+
+    assert encrypted.startswith(SECRET_ENCRYPTION_PREFIX)
+    assert "sk-provider-secret" not in encrypted
+    assert decrypt_secret(encrypted) == "sk-provider-secret"
+
+    with pytest.raises(ValueError, match="could not be decrypted"):
+        decrypt_secret(encrypted[:-1] + ("A" if encrypted[-1] != "A" else "B"))
+
+
+def test_ai_authoring_api_key_is_encrypted_in_raw_database_storage(session):
+    org = Organisation(name="Encrypted AI Secret Org")
+    session.add(org)
+    session.commit()
+
+    set_ai_authoring_api_key(session, "sk-provider-secret", int(org.o_id))
+    session.commit()
+
+    stored = (
+        session.execute(
+            sa.text(
+                """
+            SELECT value, value_type
+            FROM runtime_settings
+            WHERE key = :key AND o_id = :o_id
+            """
+            ),
+            {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(org.o_id)},
+        )
+        .mappings()
+        .one()
+    )
+    assert stored["value_type"] == "secret"
+    assert str(stored["value"]).startswith(SECRET_ENCRYPTION_PREFIX)
+    assert "sk-provider-secret" not in str(stored["value"])
+
+    session.expire_all()
+    setting = (
+        session.query(RuntimeSetting)
+        .filter(RuntimeSetting.key == AI_AUTHORING_API_KEY_KEY, RuntimeSetting.o_id == int(org.o_id))
+        .one()
+    )
+    assert setting.value == "sk-provider-secret"
+    assert "sk-provider-secret" not in repr(setting)
+    assert get_ai_authoring_api_key(session, int(org.o_id)) == "sk-provider-secret"
+
+
+def test_ai_authoring_secret_preserves_fallback_clear_and_fail_closed_semantics(session, monkeypatch):
+    spec = runtime_settings._RUNTIME_SETTING_SPECS[AI_AUTHORING_API_KEY_KEY]
+    monkeypatch.setitem(
+        runtime_settings._RUNTIME_SETTING_SPECS,
+        AI_AUTHORING_API_KEY_KEY,
+        replace(spec, default="sk-environment-default"),
+    )
+
+    fallback_org = Organisation(name="AI Secret Fallback Org")
+    corrupt_org = Organisation(name="AI Secret Corrupt Org")
+    session.add_all([fallback_org, corrupt_org])
+    session.commit()
+
+    assert get_ai_authoring_api_key(session, int(fallback_org.o_id)) == "sk-environment-default"
+
+    set_ai_authoring_api_key(session, "", int(fallback_org.o_id))
+    session.commit()
+    assert get_ai_authoring_api_key(session, int(fallback_org.o_id)) == ""
+    assert has_ai_authoring_api_key(session, int(fallback_org.o_id)) is False
+
+    cleared_raw_value = session.execute(
+        sa.text(
+            """
+            SELECT value
+            FROM runtime_settings
+            WHERE key = :key AND o_id = :o_id
+            """
+        ),
+        {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(fallback_org.o_id)},
+    ).scalar_one()
+    assert str(cleared_raw_value).startswith(SECRET_ENCRYPTION_PREFIX)
+    assert cleared_raw_value != ""
+
+    session.execute(
+        sa.text(
+            """
+            INSERT INTO runtime_settings (key, o_id, value_type, value, created_at, updated_at)
+            VALUES (:key, :o_id, 'secret', 'plaintext-or-corrupt', NOW(), NOW())
+            """
+        ),
+        {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(corrupt_org.o_id)},
+    )
+    session.commit()
+    session.expire_all()
+
+    assert get_ai_authoring_api_key(session, int(corrupt_org.o_id)) == ""
+    assert has_ai_authoring_api_key(session, int(corrupt_org.o_id)) is False
+
+
+def test_ai_authoring_secret_migration_round_trip_and_placeholder_refusal(session, monkeypatch):
+    migration = runpy.run_path(str(_MIGRATION_PATH))
+    org = Organisation(name="AI Secret Migration Org")
+    session.add(org)
+    session.commit()
+    session.execute(
+        sa.text(
+            """
+            INSERT INTO runtime_settings (key, o_id, value_type, value, created_at, updated_at)
+            VALUES (:key, :o_id, 'string', :value, NOW(), NOW())
+            """
+        ),
+        {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(org.o_id), "value": "sk-migration-secret"},
+    )
+    session.flush()
+
+    monkeypatch.setattr(migration["op"], "get_bind", session.connection)
+    with monkeypatch.context() as placeholder_patch:
+        placeholder_patch.setattr(migration["app_settings"], "APP_SECRET", "alembic-placeholder-secret")
+        with pytest.raises(RuntimeError, match="EZRULES_APP_SECRET must be set"):
+            migration["upgrade"]()
+
+    migration["upgrade"]()
+    upgraded = (
+        session.execute(
+            sa.text(
+                """
+            SELECT value, value_type
+            FROM runtime_settings
+            WHERE key = :key AND o_id = :o_id
+            """
+            ),
+            {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(org.o_id)},
+        )
+        .mappings()
+        .one()
+    )
+    assert upgraded["value_type"] == "secret"
+    assert str(upgraded["value"]).startswith(SECRET_ENCRYPTION_PREFIX)
+    assert decrypt_secret(str(upgraded["value"])) == "sk-migration-secret"
+
+    migration["downgrade"]()
+    downgraded = (
+        session.execute(
+            sa.text(
+                """
+            SELECT value, value_type
+            FROM runtime_settings
+            WHERE key = :key AND o_id = :o_id
+            """
+            ),
+            {"key": AI_AUTHORING_API_KEY_KEY, "o_id": int(org.o_id)},
+        )
+        .mappings()
+        .one()
+    )
+    assert dict(downgraded) == {"value": "sk-migration-secret", "value_type": "string"}
+
+    migration["upgrade"]()

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.29.0"
+version = "1.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Asana: https://app.asana.com/1/106415343104513/project/1211443964065287/task/1214171985612882

## Summary
- encrypt organisation-specific AI authoring API keys at rest with versioned Fernet storage derived from `EZRULES_APP_SECRET`
- preserve environment fallback, explicit clear, org scoping, and the existing `api_key_configured` response contract
- fail closed for plaintext, corrupt, or wrong-key stored values instead of silently using the environment credential
- migrate existing runtime-setting values in place and refuse to encrypt them with Alembic metadata placeholder credentials
- document secret lifecycle requirements and release the fix as v1.29.1

## Verification
- `uv run poe check`
- `uv run mkdocs build --strict`
- `uv run alembic heads`
- focused encrypted ORM round-trip diagnostic
- focused security review of encryption, migration, fallback, clear, and notification-config compatibility

## Clean-slate note
Not applicable. The migration intentionally preserves and encrypts existing organisation-specific credentials.

## Known gaps
- Postgres-backed pytest was not run locally under the repository GitHub-hosted verification policy; GitHub Actions is the source of truth for migration and backend integration coverage.
- Database backups created before this migration may still contain plaintext provider credentials and must be handled under the deployment retention policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches secret encryption, data migration, and AI credential resolution; wrong or rotated APP_SECRET during upgrade can make stored keys unreadable until operators follow the documented secret lifecycle.
> 
> **Overview**
> **v1.29.1** encrypts per-organisation AI authoring provider keys at rest and tightens how stored secrets are read.
> 
> A shared **`encrypt_secret` / `decrypt_secret`** helper (Fernet keyed from `EZRULES_APP_SECRET`) replaces ad hoc encryption in notification-channel config. **`RuntimeSetting`** now treats `value_type=secret` with transparent encrypt-on-write/decrypt-on-read, redacted `repr`, and the AI authoring key spec moves from plain `string` to **`secret`**.
> 
> An **Alembic migration** rewrites existing `ai_authoring_api_key` rows to encrypted `secret` values (idempotent for already-encrypted rows) and **aborts** if real `APP_SECRET` is missing when keys exist. **`get_runtime_setting`** returns an empty string for undecryptable secret rows instead of the environment default—**fail-closed** so corrupt or plaintext keys do not silently use the deployment-wide key; orgs without an override still use env defaults.
> 
> Docs call out stable `EZRULES_APP_SECRET` for upgrades/init and pre-v1.29.1 backup handling. Tests cover round-trip storage, clear-key semantics, migration, and tamper rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca3fa6621981834b7c1722950811ea95b8be631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->