### PR TITLE
Add API contract regression gates

### DIFF
--- a/.github/scripts/check-version-policy.sh
+++ b/.github/scripts/check-version-policy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_version="${1:-}"
+current_version="${2:-}"
+
+if [[ -z "$base_version" || -z "$current_version" ]]; then
+  echo "Could not parse the project version from the base or current pyproject.toml." >&2
+  exit 2
+fi
+
+if [[ "$base_version" != "$current_version" ]]; then
+  echo "changed=true"
+  exit 0
+fi
+
+release_relevant_files=()
+while IFS= read -r path || [[ -n "$path" ]]; do
+  [[ -z "$path" ]] && continue
+  case "$path" in
+    tests/* | docs/* | .github/* | .vscode/* | .codex/* | .omx/*)
+      ;;
+    AGENTS.md | DOCUMENTATION_MAP.md | README.md | mkdocs.yml)
+      ;;
+    *)
+      release_relevant_files+=("$path")
+      ;;
+  esac
+done
+
+if (( ${#release_relevant_files[@]} > 0 )); then
+  echo "Project version remains $current_version, but release-relevant files changed:" >&2
+  printf '  - %s\n' "${release_relevant_files[@]}" >&2
+  echo "Bump the version in pyproject.toml for shipped code, API, runtime, or product changes." >&2
+  exit 1
+fi
+
+echo "changed=false"

--- a/.github/scripts/list-pr-changes.sh
+++ b/.github/scripts/list-pr-changes.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:?base ref is required}"
+head_ref="${2:?head ref is required}"
+
+git -c core.quotePath=false diff \
+  --merge-base \
+  --name-only \
+  --diff-filter=ACMRD \
+  "$base_ref" \
+  "$head_ref"

--- a/.github/scripts/list-pr-changes.sh
+++ b/.github/scripts/list-pr-changes.sh
@@ -6,6 +6,7 @@ head_ref="${2:?head ref is required}"
 
 git -c core.quotePath=false diff \
   --merge-base \
+  --no-renames \
   --name-only \
   --diff-filter=ACMRD \
   "$base_ref" \

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -17,15 +17,15 @@ jobs:
       run: |
         base_version="$(git show "${{ github.event.pull_request.base.sha }}:pyproject.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
         current_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
-        if [ -z "$base_version" ] || [ -z "$current_version" ]; then
-          echo "::error::Could not parse the project version from the base or current pyproject.toml."
-          exit 1
-        fi
-        if [ "$base_version" = "$current_version" ]; then
-          echo "changed=false" >> "$GITHUB_OUTPUT"
+        changed_files="$(git -c core.quotePath=false diff --name-only --diff-filter=ACMRD \
+          "${{ github.event.pull_request.base.sha }}" \
+          "${{ github.event.pull_request.head.sha }}")"
+        policy_result="$(printf '%s\n' "$changed_files" | \
+          bash .github/scripts/check-version-policy.sh "$base_version" "$current_version")"
+        echo "$policy_result" >> "$GITHUB_OUTPUT"
+        if [ "$policy_result" = "changed=false" ]; then
           echo "Project version remains $current_version; skipping the PyPI availability check."
         else
-          echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "Project version changed from $base_version to $current_version."
         fi
 

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -17,6 +17,10 @@ jobs:
       run: |
         base_version="$(git show "${{ github.event.pull_request.base.sha }}:pyproject.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
         current_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
+        if [ -z "$base_version" ] || [ -z "$current_version" ]; then
+          echo "::error::Could not parse the project version from the base or current pyproject.toml."
+          exit 1
+        fi
         if [ "$base_version" = "$current_version" ]; then
           echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "Project version remains $current_version; skipping the PyPI availability check."

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         base_version="$(git show "${{ github.event.pull_request.base.sha }}:pyproject.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
         current_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
-        changed_files="$(git -c core.quotePath=false diff --name-only --diff-filter=ACMRD \
+        changed_files="$(bash .github/scripts/list-pr-changes.sh \
           "${{ github.event.pull_request.base.sha }}" \
           "${{ github.event.pull_request.head.sha }}")"
         policy_result="$(printf '%s\n' "$changed_files" | \

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -9,13 +9,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Detect project version change
+      id: version_change
+      run: |
+        base_version="$(git show "${{ github.event.pull_request.base.sha }}:pyproject.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+        current_version="$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)"
+        if [ "$base_version" = "$current_version" ]; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "Project version remains $current_version; skipping the PyPI availability check."
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "Project version changed from $base_version to $current_version."
+        fi
 
     - name: Install UV
+      if: steps.version_change.outputs.changed == 'true'
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
 
     - name: Extract version from pyproject.toml
+      if: steps.version_change.outputs.changed == 'true'
       id: version
       run: |
         VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
@@ -23,6 +40,7 @@ jobs:
         echo "Proposed version: $VERSION"
 
     - name: Fail if version already exists on PyPI
+      if: steps.version_change.outputs.changed == 'true'
       run: |
         TMPDIR=$(mktemp -d)
         cd "$TMPDIR"

--- a/docs/api-reference/evaluator-api.md
+++ b/docs/api-reference/evaluator-api.md
@@ -16,6 +16,11 @@ It executes the active rule set against one event payload and stores results.
 `/api/v2/evaluate` requires credentials on every request.
 Two methods are accepted for live evaluation:
 
+Requests use `application/json` and are subject to the service-wide request-size limit. The default maximum
+declared body size is 1,024 KiB and can be changed with `EZRULES_MAX_BODY_SIZE_KB`. An oversized request returns
+`413` with `{"detail": "Request body too large"}`; malformed JSON and schema-validation failures return `422`
+with FastAPI's structured `detail` array.
+
 ### API Key (recommended for service-to-service)
 
 Pass the raw key in the `X-API-Key` header:

--- a/docs/api-reference/evaluator-api.md
+++ b/docs/api-reference/evaluator-api.md
@@ -34,6 +34,8 @@ curl -X POST http://localhost:8888/api/v2/evaluate \
 
 API keys are created via `POST /api/v2/api-keys` (requires `MANAGE_API_KEYS` permission).
 The raw key is shown **once** at creation time and is never retrievable again.
+The generated OpenAPI document exposes this header as the `ApiKeyAuth` security scheme and lists it as an
+alternative to OAuth bearer authentication for `POST /api/v2/evaluate`; callers send one credential type, not both.
 
 ### Bearer token (for existing user sessions)
 

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -31,6 +31,24 @@ curl -X POST http://localhost:8888/api/v2/auth/login \
 - Access tokens include an `org_id` claim. Manager requests reject tokens whose `org_id` no longer matches the authenticated user's stored organisation.
 - `POST /api/v2/evaluate` requires either an `X-API-Key` header (recommended for service-to-service) or a valid Bearer token
 
+## Cross-cutting Request Contracts
+
+- JSON request bodies use `application/json`, except `POST /api/v2/auth/login`, which uses OAuth2
+  `application/x-www-form-urlencoded`, and `POST /api/v2/labels/upload`, which uses `multipart/form-data`.
+- The default maximum declared request size is 1,024 KiB. Deployments can change it with
+  `EZRULES_MAX_BODY_SIZE_KB`; requests whose `Content-Length` exceeds the configured limit return `413`.
+- HTTP errors use a JSON object with a `detail` field. For authentication, permission, and other application
+  errors, `detail` is a string. For FastAPI request-validation failures, `detail` is an array of structured
+  validation errors.
+- Invalid JSON and payloads sent with an incompatible content type return `422` in the validation-error shape.
+- Pagination bounds and defaults are part of the generated OpenAPI schema. In particular, `limit`, `offset`,
+  cursor, and graph-bound query parameters reject values below their documented minimum; finite page-size and
+  graph bounds also reject values above their documented maximum.
+
+The test suite maintains a normalized inventory of every API v2 OpenAPI operation. Adding or changing a route,
+request content type, security declaration, parameter bound, operation ID, or success status therefore requires
+an intentional contract-snapshot update.
+
 ### Organisation scoping
 
 - Users belong to exactly one organisation.

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -30,6 +30,7 @@ curl -X POST http://localhost:8888/api/v2/auth/login \
 - Send access token as `Authorization: Bearer <access_token>`
 - Access tokens include an `org_id` claim. Manager requests reject tokens whose `org_id` no longer matches the authenticated user's stored organisation.
 - `POST /api/v2/evaluate` requires either an `X-API-Key` header (recommended for service-to-service) or a valid Bearer token
+- OpenAPI exposes those evaluator credentials as alternative `ApiKeyAuth` or OAuth2 security requirements; clients do not need to send both.
 
 ## Cross-cutting Request Contracts
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,10 @@
 # What's New
 
+## v1.29.1
+
+* **Accurate evaluator authentication schema**: OpenAPI now publishes `X-API-Key` and OAuth bearer authentication as alternatives for `POST /api/v2/evaluate`, matching the credentials accepted by the runtime and the documented service-to-service integration path.
+* **Security-alternative regression coverage**: The API contract inventory now preserves OpenAPI OR-versus-AND security semantics so future schema changes cannot silently narrow or combine supported authentication methods.
+
 ## v1.29.0
 
 * **Alert-backed case review**: Outcome-spike incidents now attach every contributing current evaluation to its existing case, preserving one assignment, notes, disposition, and audit workflow instead of introducing a parallel alert queue.

--- a/ezrules/backend/api_v2/auth/dependencies.py
+++ b/ezrules/backend/api_v2/auth/dependencies.py
@@ -32,8 +32,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from fastapi import Depends, Header, HTTPException, Request, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
 from sqlalchemy.orm import joinedload, sessionmaker
 
 from ezrules.backend.api_key_cache import load_api_key_auth_metadata
@@ -58,6 +58,11 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 # When you click it and enter credentials, Swagger POSTs to this URL.
 # auto_error=False allows unauthenticated requests (for optional auth mode)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v2/auth/login", auto_error=False)
+evaluator_api_key_scheme = APIKeyHeader(
+    name="X-API-Key",
+    scheme_name="ApiKeyAuth",
+    auto_error=False,
+)
 
 
 @dataclass(slots=True)
@@ -408,7 +413,7 @@ def require_permission(
 
 def get_evaluator_auth(
     request: Request,
-    api_key: str | None = Header(default=None, alias="X-API-Key"),
+    api_key: str | None = Depends(evaluator_api_key_scheme),
     token: str | None = Depends(oauth2_scheme),
     db: Any = Depends(get_db),
 ) -> int:

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -16,7 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from ezrules.backend import data_utils
 from ezrules.backend.alerts import enqueue_alert_detection
-from ezrules.backend.api_v2.auth.dependencies import get_current_evaluator_org_id, get_db, require_permission
+from ezrules.backend.api_v2.auth.dependencies import (
+    get_current_evaluator_org_id,
+    get_current_org_id,
+    get_db,
+    require_permission,
+)
 from ezrules.backend.api_v2.schemas.evaluator import (
     EvaluateRequest,
     EvaluateResponse,
@@ -57,11 +62,8 @@ _shadow_lre: LocalRuleExecutorSQL | None = None
 _allowlist_lre: LocalRuleExecutorSQL | None = None
 
 
-def _get_rule_executor(
-    current_org_id: int = Depends(get_current_evaluator_org_id),
-    db=Depends(get_db),  # noqa: B008
-) -> LocalRuleExecutorSQL:
-    """Return the test-injected executor or a request-scoped production executor."""
+def _build_rule_executor(current_org_id: int, db: Any) -> LocalRuleExecutorSQL:
+    """Return the test-injected executor or a request-scoped production executor for an organisation."""
     if app_settings.TESTING and _lre is not None:
         return _lre
     return LocalRuleExecutorSQL(
@@ -69,6 +71,20 @@ def _get_rule_executor(
         o_id=current_org_id,
         execution_mode=get_main_rule_execution_mode(db, current_org_id),
     )
+
+
+def _get_rule_executor(
+    current_org_id: int = Depends(get_current_evaluator_org_id),
+    db=Depends(get_db),  # noqa: B008
+) -> LocalRuleExecutorSQL:
+    return _build_rule_executor(current_org_id, db)
+
+
+def _get_event_test_rule_executor(
+    current_org_id: int = Depends(get_current_org_id),
+    db=Depends(get_db),  # noqa: B008
+) -> LocalRuleExecutorSQL:
+    return _build_rule_executor(current_org_id, db)
 
 
 def _get_shadow_executor(
@@ -86,14 +102,25 @@ def _get_shadow_executor(
     )
 
 
+def _build_allowlist_executor(current_org_id: int, db: Any) -> LocalRuleExecutorSQL:
+    """Return the test-injected allowlist executor or a request-scoped executor for an organisation."""
+    if app_settings.TESTING and _allowlist_lre is not None:
+        return _allowlist_lre
+    return LocalRuleExecutorSQL(db=db, o_id=current_org_id, label=ALLOWLIST_CONFIG_LABEL)
+
+
 def _get_allowlist_executor(
     current_org_id: int = Depends(get_current_evaluator_org_id),
     db=Depends(get_db),  # noqa: B008
 ) -> LocalRuleExecutorSQL:
-    """Return the test-injected allowlist executor or a request-scoped executor."""
-    if app_settings.TESTING and _allowlist_lre is not None:
-        return _allowlist_lre
-    return LocalRuleExecutorSQL(db=db, o_id=current_org_id, label=ALLOWLIST_CONFIG_LABEL)
+    return _build_allowlist_executor(current_org_id, db)
+
+
+def _get_event_test_allowlist_executor(
+    current_org_id: int = Depends(get_current_org_id),
+    db=Depends(get_db),  # noqa: B008
+) -> LocalRuleExecutorSQL:
+    return _build_allowlist_executor(current_org_id, db)
 
 
 def _get_assignment_key(event: Event) -> str:
@@ -476,8 +503,8 @@ def evaluate(
 @router.post("/event-tests", response_model=EventTestResponse)
 def test_event(
     request_data: EvaluateRequest,
-    lre: LocalRuleExecutorSQL = Depends(_get_rule_executor),
-    allowlist_lre: LocalRuleExecutorSQL = Depends(_get_allowlist_executor),
+    lre: LocalRuleExecutorSQL = Depends(_get_event_test_rule_executor),
+    allowlist_lre: LocalRuleExecutorSQL = Depends(_get_event_test_allowlist_executor),
     db: Any = Depends(get_db),
     _: None = Depends(require_permission(PermissionAction.SUBMIT_TEST_EVENTS)),
 ) -> EventTestResponse:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.29.0"
+version = "1.29.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/contracts/api_v2_openapi_inventory.json
+++ b/tests/contracts/api_v2_openapi_inventory.json
@@ -1,0 +1,3633 @@
+[
+  {
+    "method": "GET",
+    "operation_id": "root__get",
+    "parameters": [],
+    "path": "/",
+    "request_content": [],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "simulate_rule_blast_radius_api_v2_agent_tools_rule_blast_radius_post",
+    "parameters": [],
+    "path": "/api/v2/agent-tools/rule-blast-radius",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "find_rule_counterexamples_api_v2_agent_tools_rule_counterexamples_post",
+    "parameters": [],
+    "path": "/api/v2/agent-tools/rule-counterexamples",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_alert_incidents_api_v2_alerts_incidents_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/alerts/incidents",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "acknowledge_alert_incident_api_v2_alerts_incidents__incident_id__acknowledge_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "incident_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/alerts/incidents/{incident_id}/acknowledge",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_alert_rules_api_v2_alerts_rules_get",
+    "parameters": [],
+    "path": "/api/v2/alerts/rules",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_alert_rule_api_v2_alerts_rules_post",
+    "parameters": [],
+    "path": "/api/v2/alerts/rules",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "PATCH",
+    "operation_id": "update_alert_rule_api_v2_alerts_rules__rule_id__patch",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/alerts/rules/{rule_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_labeled_transaction_volume_api_v2_analytics_labeled_transaction_volume_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "aggregation",
+        "required": false,
+        "schema": {
+          "default": "1h",
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/labeled-transaction-volume",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_labels_distribution_api_v2_analytics_labels_distribution_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "aggregation",
+        "required": false,
+        "schema": {
+          "default": "1h",
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/labels-distribution",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_labels_summary_api_v2_analytics_labels_summary_get",
+    "parameters": [],
+    "path": "/api/v2/analytics/labels-summary",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_outcomes_distribution_api_v2_analytics_outcomes_distribution_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "aggregation",
+        "required": false,
+        "schema": {
+          "default": "1h",
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/outcomes-distribution",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_activity_api_v2_analytics_rule_activity_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "aggregation",
+        "required": false,
+        "schema": {
+          "default": "6h",
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 5,
+          "maximum": 50,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/rule-activity",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_quality_api_v2_analytics_rule_quality_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "lookback_days",
+        "required": false,
+        "schema": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "min_support",
+        "required": false,
+        "schema": {
+          "default": 1,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/rule-quality",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "request_rule_quality_report_api_v2_analytics_rule_quality_reports_post",
+    "parameters": [],
+    "path": "/api/v2/analytics/rule-quality/reports",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_quality_report_api_v2_analytics_rule_quality_reports__report_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "report_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/rule-quality/reports/{report_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_outcomes_distribution_api_v2_analytics_rules__rule_id__outcomes_distribution_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "aggregation",
+        "required": false,
+        "schema": {
+          "default": "6h",
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/rules/{rule_id}/outcomes-distribution",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_transaction_volume_api_v2_analytics_transaction_volume_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "aggregation",
+        "required": false,
+        "schema": {
+          "default": "1h",
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/analytics/transaction-volume",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_api_keys_api_v2_api_keys_get",
+    "parameters": [],
+    "path": "/api/v2/api-keys",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_api_key_api_v2_api_keys_post",
+    "parameters": [],
+    "path": "/api/v2/api-keys",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "revoke_api_key_api_v2_api_keys__gid__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "gid",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/api-keys/{gid}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "204"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_audit_summary_api_v2_audit_get",
+    "parameters": [],
+    "path": "/api/v2/audit",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_ai_rule_authoring_history_api_v2_audit_ai_rule_authoring_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "action",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/ai-rule-authoring",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_api_key_history_api_v2_audit_api_keys_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/api-keys",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_config_history_api_v2_audit_config_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "config_id",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/config",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_feature_definition_history_api_v2_audit_features_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "fd_id",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/features",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_field_type_history_api_v2_audit_field_types_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "field_name",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/field-types",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_label_history_api_v2_audit_labels_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/labels",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_outcome_history_api_v2_audit_outcomes_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/outcomes",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_role_permission_history_api_v2_audit_roles_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "role_id",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/roles",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_rule_history_api_v2_audit_rules_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "rule_id",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/rules",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_audit_api_v2_audit_rules__rule_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/rules/{rule_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_strict_mode_history_api_v2_audit_strict_mode_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/strict-mode",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_user_list_history_api_v2_audit_user_lists_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "list_id",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/user-lists",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_user_account_history_api_v2_audit_users_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "end_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "start_date",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "user_id",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/audit/users",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "accept_invite_api_v2_auth_accept_invite_post",
+    "parameters": [],
+    "path": "/api/v2/auth/accept-invite",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "forgot_password_api_v2_auth_forgot_password_post",
+    "parameters": [],
+    "path": "/api/v2/auth/forgot-password",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "login_api_v2_auth_login_post",
+    "parameters": [],
+    "path": "/api/v2/auth/login",
+    "request_content": [
+      "application/x-www-form-urlencoded"
+    ],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "logout_api_v2_auth_logout_post",
+    "parameters": [],
+    "path": "/api/v2/auth/logout",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_current_user_info_api_v2_auth_me_get",
+    "parameters": [],
+    "path": "/api/v2/auth/me",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "refresh_token_api_v2_auth_refresh_post",
+    "parameters": [],
+    "path": "/api/v2/auth/refresh",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "reset_password_api_v2_auth_reset_password_post",
+    "parameters": [],
+    "path": "/api/v2/auth/reset-password",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "trigger_backtest_api_v2_backtesting_post",
+    "parameters": [],
+    "path": "/api/v2/backtesting",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_task_result_api_v2_backtesting_task__task_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "task_id",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/backtesting/task/{task_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_backtest_results_api_v2_backtesting__rule_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/backtesting/{rule_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "cancel_backtest_api_v2_backtesting__task_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "task_id",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/backtesting/{task_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "retry_backtest_api_v2_backtesting__task_id__retry_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "task_id",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/backtesting/{task_id}/retry",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_cases_api_v2_cases_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "alert_incident_id",
+        "required": false,
+        "schema": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "alert_rule_id",
+        "required": false,
+        "schema": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "alert_severity",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "alerted_from",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "alerted_to",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "assigned_to",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "created_from",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "created_to",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "decision_state",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "outcome",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "priority_min",
+        "required": false,
+        "schema": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "q",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "status",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "transaction_id",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "updated_from",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "updated_to",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/cases",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_case_assignees_api_v2_cases_assignees_get",
+    "parameters": [],
+    "path": "/api/v2/cases/assignees",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_case_api_v2_cases__case_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "case_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/cases/{case_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PATCH",
+    "operation_id": "update_case_api_v2_cases__case_id__patch",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "case_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/cases/{case_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "add_case_note_route_api_v2_cases__case_id__notes_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "case_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/cases/{case_id}/notes",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "resolve_case_route_api_v2_cases__case_id__resolve_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "case_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/cases/{case_id}/resolve",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "evaluate_api_v2_evaluate_post",
+    "parameters": [],
+    "path": "/api/v2/evaluate",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "test_event_api_v2_event_tests_post",
+    "parameters": [],
+    "path": "/api/v2/event-tests",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_features_api_v2_features_get",
+    "parameters": [],
+    "path": "/api/v2/features",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_feature_api_v2_features_post",
+    "parameters": [],
+    "path": "/api/v2/features",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_feature_api_v2_features__feature_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "feature_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/features/{feature_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_feature_api_v2_features__feature_id__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "feature_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/features/{feature_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "activate_feature_api_v2_features__feature_id__activate_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "feature_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/features/{feature_id}/activate",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "feature_dependencies_api_v2_features__feature_id__dependencies_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "feature_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/features/{feature_id}/dependencies",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "deprecate_feature_api_v2_features__feature_id__deprecate_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "feature_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/features/{feature_id}/deprecate",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "preview_feature_api_v2_features__feature_id__preview_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "feature_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/features/{feature_id}/preview",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_field_type_configs_api_v2_field_types_get",
+    "parameters": [],
+    "path": "/api/v2/field-types",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "upsert_field_type_config_api_v2_field_types_post",
+    "parameters": [],
+    "path": "/api/v2/field-types",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_field_observations_api_v2_field_types_observations_get",
+    "parameters": [],
+    "path": "/api/v2/field-types/observations",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_field_type_config_api_v2_field_types__field_name__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "field_name",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/field-types/{field_name}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_field_type_config_api_v2_field_types__field_name__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "field_name",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/field-types/{field_name}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_events_api_v2_integration_events_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "cursor",
+        "required": false,
+        "schema": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "event_type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 100,
+          "maximum": 500,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/integration-events",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_subscriptions_api_v2_integration_subscriptions_get",
+    "parameters": [],
+    "path": "/api/v2/integration-subscriptions",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_subscription_api_v2_integration_subscriptions_post",
+    "parameters": [],
+    "path": "/api/v2/integration-subscriptions",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "PATCH",
+    "operation_id": "update_subscription_api_v2_integration_subscriptions__subscription_id__patch",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "subscription_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/integration-subscriptions/{subscription_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_labels_api_v2_labels_get",
+    "parameters": [],
+    "path": "/api/v2/labels",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_label_api_v2_labels_post",
+    "parameters": [],
+    "path": "/api/v2/labels",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_labels_bulk_api_v2_labels_bulk_post",
+    "parameters": [],
+    "path": "/api/v2/labels/bulk",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "mark_event_api_v2_labels_mark_event_post",
+    "parameters": [],
+    "path": "/api/v2/labels/mark-event",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "upload_labels_api_v2_labels_upload_post",
+    "parameters": [],
+    "path": "/api/v2/labels/upload",
+    "request_content": [
+      "multipart/form-data"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_label_api_v2_labels__label_name__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "label_name",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/labels/{label_name}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_notifications_api_v2_notifications_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 10,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "unread_only",
+        "required": false,
+        "schema": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    ],
+    "path": "/api/v2/notifications",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "mark_all_notifications_read_api_v2_notifications_read_all_post",
+    "parameters": [],
+    "path": "/api/v2/notifications/read-all",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_unread_notification_count_api_v2_notifications_unread_count_get",
+    "parameters": [],
+    "path": "/api/v2/notifications/unread-count",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "mark_notification_read_api_v2_notifications__notification_id__read_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "notification_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/notifications/{notification_id}/read",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_outcomes_api_v2_outcomes_get",
+    "parameters": [],
+    "path": "/api/v2/outcomes",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_outcome_api_v2_outcomes_post",
+    "parameters": [],
+    "path": "/api/v2/outcomes",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_outcome_api_v2_outcomes__outcome_name__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "outcome_name",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
+    ],
+    "path": "/api/v2/outcomes/{outcome_name}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_roles_api_v2_roles_get",
+    "parameters": [],
+    "path": "/api/v2/roles",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_role_api_v2_roles_post",
+    "parameters": [],
+    "path": "/api/v2/roles",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_permissions_api_v2_roles_permissions_get",
+    "parameters": [],
+    "path": "/api/v2/roles/permissions",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_role_api_v2_roles__role_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "role_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/roles/{role_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_role_api_v2_roles__role_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "role_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/roles/{role_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_role_api_v2_roles__role_id__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "role_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/roles/{role_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_role_permissions_endpoint_api_v2_roles__role_id__permissions_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "role_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/roles/{role_id}/permissions",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_role_permissions_api_v2_roles__role_id__permissions_put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "role_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/roles/{role_id}/permissions",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rollout_config_api_v2_rollouts_get",
+    "parameters": [],
+    "path": "/api/v2/rollouts",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rollout_results_api_v2_rollouts_results_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rollouts/results",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rollout_stats_api_v2_rollouts_stats_get",
+    "parameters": [],
+    "path": "/api/v2/rollouts/stats",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_rules_api_v2_rules_get",
+    "parameters": [],
+    "path": "/api/v2/rules",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_rule_api_v2_rules_post",
+    "parameters": [],
+    "path": "/api/v2/rules",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "record_ai_rule_draft_applied_api_v2_rules_ai_apply_post",
+    "parameters": [],
+    "path": "/api/v2/rules/ai/apply",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "generate_ai_rule_draft_api_v2_rules_ai_draft_post",
+    "parameters": [],
+    "path": "/api/v2/rules/ai/draft",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_main_rule_order_api_v2_rules_main_order_put",
+    "parameters": [],
+    "path": "/api/v2/rules/main-order",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "test_rule_api_v2_rules_test_post",
+    "parameters": [],
+    "path": "/api/v2/rules/test",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "verify_rule_api_v2_rules_verify_post",
+    "parameters": [],
+    "path": "/api/v2/rules/verify",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_rule_api_v2_rules__rule_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "204"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_api_v2_rules__rule_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_rule_api_v2_rules__rule_id__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "archive_rule_api_v2_rules__rule_id__archive_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/archive",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_history_api_v2_rules__rule_id__history_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 10,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/history",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "pause_rule_api_v2_rules__rule_id__pause_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/pause",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "promote_rule_api_v2_rules__rule_id__promote_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/promote",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "resume_rule_api_v2_rules__rule_id__resume_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/resume",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_revision_api_v2_rules__rule_id__revisions__revision_number__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "revision_number",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/revisions/{revision_number}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "rollback_rule_api_v2_rules__rule_id__rollback_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/rollback",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "remove_from_rollout_api_v2_rules__rule_id__rollout_delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/rollout",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "deploy_to_rollout_api_v2_rules__rule_id__rollout_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/rollout",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "promote_rollout_to_production_api_v2_rules__rule_id__rollout_promote_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/rollout/promote",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "remove_from_shadow_api_v2_rules__rule_id__shadow_delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/shadow",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "deploy_to_shadow_api_v2_rules__rule_id__shadow_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/shadow",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "promote_to_production_api_v2_rules__rule_id__shadow_promote_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/shadow/promote",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_triggered_events_api_v2_rules__rule_id__triggered_events_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "rule_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 10,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "default": 0,
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/rules/{rule_id}/triggered-events",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_ai_authoring_settings_api_v2_settings_ai_authoring_get",
+    "parameters": [],
+    "path": "/api/v2/settings/ai-authoring",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_ai_authoring_settings_api_v2_settings_ai_authoring_put",
+    "parameters": [],
+    "path": "/api/v2/settings/ai-authoring",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_outcome_hierarchy_api_v2_settings_outcome_hierarchy_get",
+    "parameters": [],
+    "path": "/api/v2/settings/outcome-hierarchy",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_outcome_hierarchy_api_v2_settings_outcome_hierarchy_put",
+    "parameters": [],
+    "path": "/api/v2/settings/outcome-hierarchy",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_rule_quality_pairs_api_v2_settings_rule_quality_pairs_get",
+    "parameters": [],
+    "path": "/api/v2/settings/rule-quality-pairs",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_rule_quality_pair_api_v2_settings_rule_quality_pairs_post",
+    "parameters": [],
+    "path": "/api/v2/settings/rule-quality-pairs",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_rule_quality_pair_options_api_v2_settings_rule_quality_pairs_options_get",
+    "parameters": [],
+    "path": "/api/v2/settings/rule-quality-pairs/options",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_rule_quality_pair_api_v2_settings_rule_quality_pairs__pair_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "pair_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/settings/rule-quality-pairs/{pair_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "204"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_rule_quality_pair_api_v2_settings_rule_quality_pairs__pair_id__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "pair_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/settings/rule-quality-pairs/{pair_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_runtime_settings_api_v2_settings_runtime_get",
+    "parameters": [],
+    "path": "/api/v2/settings/runtime",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_runtime_settings_api_v2_settings_runtime_put",
+    "parameters": [],
+    "path": "/api/v2/settings/runtime",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_shadow_config_api_v2_shadow_get",
+    "parameters": [],
+    "path": "/api/v2/shadow",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_shadow_results_api_v2_shadow_results_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/shadow/results",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_shadow_stats_api_v2_shadow_stats_get",
+    "parameters": [],
+    "path": "/api/v2/shadow/stats",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_tested_events_api_v2_tested_events_get",
+    "parameters": [
+      {
+        "in": "query",
+        "name": "include_referenced_fields",
+        "required": false,
+        "schema": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "default": 50,
+          "maximum": 200,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/tested-events",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "tested_event_graph_api_v2_tested_events__evaluation_decision_id__graph_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "evaluation_decision_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "expand_entity_type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "expand_entity_value_hash",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      {
+        "in": "query",
+        "name": "max_events",
+        "required": false,
+        "schema": {
+          "default": 25,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      {
+        "in": "query",
+        "name": "max_hops",
+        "required": false,
+        "schema": {
+          "default": 3,
+          "maximum": 5,
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/tested-events/{evaluation_decision_id}/graph",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_user_lists_api_v2_user_lists_get",
+    "parameters": [],
+    "path": "/api/v2/user-lists",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_user_list_api_v2_user_lists_post",
+    "parameters": [],
+    "path": "/api/v2/user-lists",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_user_list_api_v2_user_lists__list_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_user_list_api_v2_user_lists__list_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_user_list_api_v2_user_lists__list_id__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_list_entries_api_v2_user_lists__list_id__entries_get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}/entries",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "add_entry_api_v2_user_lists__list_id__entries_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}/entries",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "bulk_add_entries_api_v2_user_lists__list_id__entries_bulk_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}/entries/bulk",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_entry_api_v2_user_lists__list_id__entries__entry_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "entry_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "path",
+        "name": "list_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/user-lists/{list_id}/entries/{entry_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "list_users_api_v2_users_get",
+    "parameters": [],
+    "path": "/api/v2/users",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "create_user_api_v2_users_post",
+    "parameters": [],
+    "path": "/api/v2/users",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "201"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "invite_user_api_v2_users_invite_post",
+    "parameters": [],
+    "path": "/api/v2/users/invite",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "delete_user_api_v2_users__user_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "user_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/users/{user_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "get_user_api_v2_users__user_id__get",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "user_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/users/{user_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "PUT",
+    "operation_id": "update_user_api_v2_users__user_id__put",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "user_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/users/{user_id}",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "POST",
+    "operation_id": "assign_role_api_v2_users__user_id__roles_post",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "user_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/users/{user_id}/roles",
+    "request_content": [
+      "application/json"
+    ],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "DELETE",
+    "operation_id": "remove_role_api_v2_users__user_id__roles__role_id__delete",
+    "parameters": [
+      {
+        "in": "path",
+        "name": "role_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      {
+        "in": "path",
+        "name": "user_id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    ],
+    "path": "/api/v2/users/{user_id}/roles/{role_id}",
+    "request_content": [],
+    "security": [
+      "OAuth2PasswordBearer"
+    ],
+    "success_responses": [
+      "200"
+    ]
+  },
+  {
+    "method": "GET",
+    "operation_id": "ping_ping_get",
+    "parameters": [],
+    "path": "/ping",
+    "request_content": [],
+    "security": [],
+    "success_responses": [
+      "200"
+    ]
+  }
+]

--- a/tests/contracts/api_v2_openapi_inventory.json
+++ b/tests/contracts/api_v2_openapi_inventory.json
@@ -19,7 +19,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -34,7 +36,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -59,7 +63,9 @@
     "path": "/api/v2/alerts/incidents",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -81,7 +87,9 @@
     "path": "/api/v2/alerts/incidents/{incident_id}/acknowledge",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -94,7 +102,9 @@
     "path": "/api/v2/alerts/rules",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -109,7 +119,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -133,7 +145,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -156,7 +170,9 @@
     "path": "/api/v2/analytics/labeled-transaction-volume",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -179,7 +195,9 @@
     "path": "/api/v2/analytics/labels-distribution",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -192,7 +210,9 @@
     "path": "/api/v2/analytics/labels-summary",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -215,7 +235,9 @@
     "path": "/api/v2/analytics/outcomes-distribution",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -249,7 +271,9 @@
     "path": "/api/v2/analytics/rule-activity",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -282,7 +306,9 @@
     "path": "/api/v2/analytics/rule-quality",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -297,7 +323,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -319,7 +347,9 @@
     "path": "/api/v2/analytics/rule-quality/reports/{report_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -350,7 +380,9 @@
     "path": "/api/v2/analytics/rules/{rule_id}/outcomes-distribution",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -373,7 +405,9 @@
     "path": "/api/v2/analytics/transaction-volume",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -386,7 +420,9 @@
     "path": "/api/v2/api-keys",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -401,7 +437,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -423,7 +461,9 @@
     "path": "/api/v2/api-keys/{gid}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "204"
@@ -436,7 +476,9 @@
     "path": "/api/v2/audit",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -495,7 +537,9 @@
     "path": "/api/v2/audit/ai-rule-authoring",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -546,7 +590,9 @@
     "path": "/api/v2/audit/api-keys",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -605,7 +651,9 @@
     "path": "/api/v2/audit/config",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -664,7 +712,9 @@
     "path": "/api/v2/audit/features",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -723,7 +773,9 @@
     "path": "/api/v2/audit/field-types",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -774,7 +826,9 @@
     "path": "/api/v2/audit/labels",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -825,7 +879,9 @@
     "path": "/api/v2/audit/outcomes",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -884,7 +940,9 @@
     "path": "/api/v2/audit/roles",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -943,7 +1001,9 @@
     "path": "/api/v2/audit/rules",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -965,7 +1025,9 @@
     "path": "/api/v2/audit/rules/{rule_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1016,7 +1078,9 @@
     "path": "/api/v2/audit/strict-mode",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1075,7 +1139,9 @@
     "path": "/api/v2/audit/user-lists",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1134,7 +1200,9 @@
     "path": "/api/v2/audit/users",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1188,7 +1256,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1201,7 +1271,9 @@
     "path": "/api/v2/auth/me",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1242,7 +1314,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1264,7 +1338,9 @@
     "path": "/api/v2/backtesting/task/{task_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1286,7 +1362,9 @@
     "path": "/api/v2/backtesting/{rule_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1308,7 +1386,9 @@
     "path": "/api/v2/backtesting/{task_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1330,7 +1410,9 @@
     "path": "/api/v2/backtesting/{task_id}/retry",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1496,7 +1578,9 @@
     "path": "/api/v2/cases",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1509,7 +1593,9 @@
     "path": "/api/v2/cases/assignees",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1531,7 +1617,9 @@
     "path": "/api/v2/cases/{case_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1555,7 +1643,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1579,7 +1669,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -1603,7 +1695,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1618,7 +1712,12 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "ApiKeyAuth"
+      ],
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1633,7 +1732,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1646,7 +1747,9 @@
     "path": "/api/v2/features",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1661,7 +1764,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -1683,7 +1788,9 @@
     "path": "/api/v2/features/{feature_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1707,7 +1814,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1729,7 +1838,9 @@
     "path": "/api/v2/features/{feature_id}/activate",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1751,7 +1862,9 @@
     "path": "/api/v2/features/{feature_id}/dependencies",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1773,7 +1886,9 @@
     "path": "/api/v2/features/{feature_id}/deprecate",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1797,7 +1912,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1810,7 +1927,9 @@
     "path": "/api/v2/field-types",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1825,7 +1944,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -1838,7 +1959,9 @@
     "path": "/api/v2/field-types/observations",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1860,7 +1983,9 @@
     "path": "/api/v2/field-types/{field_name}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1884,7 +2009,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1926,7 +2053,9 @@
     "path": "/api/v2/integration-events",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1939,7 +2068,9 @@
     "path": "/api/v2/integration-subscriptions",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1954,7 +2085,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -1978,7 +2111,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -1991,7 +2126,9 @@
     "path": "/api/v2/labels",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2006,7 +2143,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -2021,7 +2160,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -2036,7 +2177,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2051,7 +2194,9 @@
       "multipart/form-data"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2073,7 +2218,9 @@
     "path": "/api/v2/labels/{label_name}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2107,7 +2254,9 @@
     "path": "/api/v2/notifications",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2120,7 +2269,9 @@
     "path": "/api/v2/notifications/read-all",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2133,7 +2284,9 @@
     "path": "/api/v2/notifications/unread-count",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2155,7 +2308,9 @@
     "path": "/api/v2/notifications/{notification_id}/read",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2168,7 +2323,9 @@
     "path": "/api/v2/outcomes",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2183,7 +2340,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -2205,7 +2364,9 @@
     "path": "/api/v2/outcomes/{outcome_name}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2218,7 +2379,9 @@
     "path": "/api/v2/roles",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2233,7 +2396,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -2246,7 +2411,9 @@
     "path": "/api/v2/roles/permissions",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2268,7 +2435,9 @@
     "path": "/api/v2/roles/{role_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2290,7 +2459,9 @@
     "path": "/api/v2/roles/{role_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2314,7 +2485,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2336,7 +2509,9 @@
     "path": "/api/v2/roles/{role_id}/permissions",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2360,7 +2535,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2373,7 +2550,9 @@
     "path": "/api/v2/rollouts",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2398,7 +2577,9 @@
     "path": "/api/v2/rollouts/results",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2411,7 +2592,9 @@
     "path": "/api/v2/rollouts/stats",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2424,7 +2607,9 @@
     "path": "/api/v2/rules",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2439,7 +2624,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -2454,7 +2641,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2469,7 +2658,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2484,7 +2675,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2499,7 +2692,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2514,7 +2709,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2536,7 +2733,9 @@
     "path": "/api/v2/rules/{rule_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "204"
@@ -2558,7 +2757,9 @@
     "path": "/api/v2/rules/{rule_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2582,7 +2783,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2604,7 +2807,9 @@
     "path": "/api/v2/rules/{rule_id}/archive",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2637,7 +2842,9 @@
     "path": "/api/v2/rules/{rule_id}/history",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2659,7 +2866,9 @@
     "path": "/api/v2/rules/{rule_id}/pause",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2681,7 +2890,9 @@
     "path": "/api/v2/rules/{rule_id}/promote",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2703,7 +2914,9 @@
     "path": "/api/v2/rules/{rule_id}/resume",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2733,7 +2946,9 @@
     "path": "/api/v2/rules/{rule_id}/revisions/{revision_number}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2757,7 +2972,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2779,7 +2996,9 @@
     "path": "/api/v2/rules/{rule_id}/rollout",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2803,7 +3022,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2825,7 +3046,9 @@
     "path": "/api/v2/rules/{rule_id}/rollout/promote",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2847,7 +3070,9 @@
     "path": "/api/v2/rules/{rule_id}/shadow",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2871,7 +3096,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2893,7 +3120,9 @@
     "path": "/api/v2/rules/{rule_id}/shadow/promote",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2936,7 +3165,9 @@
     "path": "/api/v2/rules/{rule_id}/triggered-events",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2949,7 +3180,9 @@
     "path": "/api/v2/settings/ai-authoring",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2964,7 +3197,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2977,7 +3212,9 @@
     "path": "/api/v2/settings/outcome-hierarchy",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -2992,7 +3229,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3005,7 +3244,9 @@
     "path": "/api/v2/settings/rule-quality-pairs",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3020,7 +3261,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3033,7 +3276,9 @@
     "path": "/api/v2/settings/rule-quality-pairs/options",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3055,7 +3300,9 @@
     "path": "/api/v2/settings/rule-quality-pairs/{pair_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "204"
@@ -3079,7 +3326,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3092,7 +3341,9 @@
     "path": "/api/v2/settings/runtime",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3107,7 +3358,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3120,7 +3373,9 @@
     "path": "/api/v2/shadow",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3145,7 +3400,9 @@
     "path": "/api/v2/shadow/results",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3158,7 +3415,9 @@
     "path": "/api/v2/shadow/stats",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3192,7 +3451,9 @@
     "path": "/api/v2/tested-events",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3252,7 +3513,9 @@
     "path": "/api/v2/tested-events/{evaluation_decision_id}/graph",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3265,7 +3528,9 @@
     "path": "/api/v2/user-lists",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3280,7 +3545,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -3302,7 +3569,9 @@
     "path": "/api/v2/user-lists/{list_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3324,7 +3593,9 @@
     "path": "/api/v2/user-lists/{list_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3348,7 +3619,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3370,7 +3643,9 @@
     "path": "/api/v2/user-lists/{list_id}/entries",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3394,7 +3669,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -3418,7 +3695,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -3448,7 +3727,9 @@
     "path": "/api/v2/user-lists/{list_id}/entries/{entry_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3461,7 +3742,9 @@
     "path": "/api/v2/users",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3476,7 +3759,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "201"
@@ -3491,7 +3776,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3513,7 +3800,9 @@
     "path": "/api/v2/users/{user_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3535,7 +3824,9 @@
     "path": "/api/v2/users/{user_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3559,7 +3850,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3583,7 +3876,9 @@
       "application/json"
     ],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"
@@ -3613,7 +3908,9 @@
     "path": "/api/v2/users/{user_id}/roles/{role_id}",
     "request_content": [],
     "security": [
-      "OAuth2PasswordBearer"
+      [
+        "OAuth2PasswordBearer"
+      ]
     ],
     "success_responses": [
       "200"

--- a/tests/test_api_v2_contract_regressions.py
+++ b/tests/test_api_v2_contract_regressions.py
@@ -1,0 +1,333 @@
+"""Cross-cutting API v2 contract regression tests.
+
+Run ``uv run python tests/test_api_v2_contract_regressions.py`` after an
+intentional API contract change to regenerate the normalized inventory.
+"""
+
+import json
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.models.backend_core import Organisation, User
+from ezrules.settings import app_settings
+
+SNAPSHOT_PATH = Path(__file__).parent / "contracts" / "api_v2_openapi_inventory.json"
+PUBLIC_OPERATIONS = {
+    ("POST", "/api/v2/auth/accept-invite"),
+    ("POST", "/api/v2/auth/forgot-password"),
+    ("POST", "/api/v2/auth/login"),
+    ("POST", "/api/v2/auth/refresh"),
+    ("POST", "/api/v2/auth/reset-password"),
+}
+REPRESENTATIVE_PROTECTED_READS = (
+    "/api/v2/alerts/rules",
+    "/api/v2/analytics/labels-summary",
+    "/api/v2/api-keys",
+    "/api/v2/audit",
+    "/api/v2/cases",
+    "/api/v2/features",
+    "/api/v2/labels",
+    "/api/v2/outcomes",
+    "/api/v2/roles",
+    "/api/v2/rules",
+    "/api/v2/settings/runtime",
+    "/api/v2/tested-events",
+    "/api/v2/user-lists",
+    "/api/v2/users",
+)
+
+
+def _operation_inventory(schema: dict[str, Any]) -> list[dict[str, Any]]:
+    operations = []
+    for path, path_item in schema["paths"].items():
+        inherited_parameters = path_item.get("parameters", [])
+        for method, operation in path_item.items():
+            if method == "parameters":
+                continue
+
+            parameters = [*inherited_parameters, *operation.get("parameters", [])]
+            tracked_parameters = []
+            for parameter in parameters:
+                if parameter["in"] not in {"path", "query"}:
+                    continue
+                parameter_schema = parameter.get("schema", {})
+                if "anyOf" in parameter_schema:
+                    parameter_schema = next(
+                        candidate for candidate in parameter_schema["anyOf"] if candidate.get("type") != "null"
+                    )
+                tracked_parameters.append(
+                    {
+                        "in": parameter["in"],
+                        "name": parameter["name"],
+                        "required": parameter.get("required", False),
+                        "schema": {
+                            key: parameter_schema[key]
+                            for key in ("default", "maximum", "minimum", "type")
+                            if key in parameter_schema
+                        },
+                    }
+                )
+
+            security = sorted(scheme for requirement in operation.get("security", []) for scheme in requirement)
+            request_content = sorted(operation.get("requestBody", {}).get("content", {}).keys())
+            operations.append(
+                {
+                    "method": method.upper(),
+                    "operation_id": operation["operationId"],
+                    "parameters": sorted(
+                        tracked_parameters,
+                        key=lambda item: (item["in"], item["name"]),
+                    ),
+                    "path": path,
+                    "request_content": request_content,
+                    "security": security,
+                    "success_responses": sorted(
+                        code for code in operation["responses"] if code.isdigit() and 200 <= int(code) < 300
+                    ),
+                }
+            )
+    return sorted(operations, key=lambda item: (item["path"], item["method"]))
+
+
+def _assert_standard_error(response, *, status_code: int, detail_type: type) -> None:
+    assert response.status_code == status_code
+    assert response.headers["content-type"].startswith("application/json")
+    payload = response.json()
+    assert set(payload) == {"detail"}
+    assert isinstance(payload["detail"], detail_type)
+
+
+@pytest.fixture
+def contract_user(session) -> User:
+    org = session.query(Organisation).one()
+    email = f"contract-{uuid.uuid4().hex}@example.com"
+    user = User(
+        email=email,
+        password="not-used",
+        active=True,
+        fs_uniquifier=email,
+        o_id=int(org.o_id),
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _access_token(user: User, *, org_id: int | None = None) -> str:
+    return create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[],
+        org_id=int(user.o_id) if org_id is None else org_id,
+    )
+
+
+def test_openapi_operation_inventory_matches_snapshot() -> None:
+    expected = json.loads(SNAPSHOT_PATH.read_text())
+
+    assert _operation_inventory(app.openapi()) == expected
+
+
+def test_openapi_has_unique_operation_ids_and_no_undeclared_public_routes() -> None:
+    operations = _operation_inventory(app.openapi())
+    operation_ids = [operation["operation_id"] for operation in operations]
+    public_operations = {
+        (operation["method"], operation["path"])
+        for operation in operations
+        if operation["path"].startswith("/api/v2") and not operation["security"]
+    }
+
+    assert len(operation_ids) == len(set(operation_ids))
+    assert public_operations == PUBLIC_OPERATIONS
+    assert all(
+        operation["security"] == ["OAuth2PasswordBearer"]
+        for operation in operations
+        if operation["path"].startswith("/api/v2") and (operation["method"], operation["path"]) not in PUBLIC_OPERATIONS
+    )
+
+
+def test_openapi_declares_validation_errors_for_validated_inputs() -> None:
+    schema = app.openapi()
+    missing_validation_response = []
+    for path, path_item in schema["paths"].items():
+        for method, operation in path_item.items():
+            if method == "parameters":
+                continue
+            has_validated_input = bool(
+                path_item.get("parameters") or operation.get("parameters") or operation.get("requestBody")
+            )
+            if has_validated_input and "422" not in operation["responses"]:
+                missing_validation_response.append(f"{method.upper()} {path}")
+
+    assert missing_validation_response == []
+
+
+@pytest.mark.parametrize("path", REPRESENTATIVE_PROTECTED_READS)
+def test_protected_route_matrix_rejects_missing_authentication(path: str) -> None:
+    with TestClient(app) as client:
+        response = client.get(path)
+
+    _assert_standard_error(response, status_code=401, detail_type=str)
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.parametrize("path", REPRESENTATIVE_PROTECTED_READS)
+def test_protected_route_matrix_rejects_mismatched_tenant_claim(
+    session,
+    contract_user: User,
+    path: str,
+) -> None:
+    token = _access_token(contract_user, org_id=int(contract_user.o_id) + 1)
+
+    with TestClient(app) as client:
+        response = client.get(path, headers={"Authorization": f"Bearer {token}"})
+
+    _assert_standard_error(response, status_code=401, detail_type=str)
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.parametrize("path", REPRESENTATIVE_PROTECTED_READS)
+def test_protected_route_matrix_rejects_missing_permissions(
+    session,
+    contract_user: User,
+    path: str,
+) -> None:
+    token = _access_token(contract_user)
+
+    with TestClient(app) as client:
+        response = client.get(path, headers={"Authorization": f"Bearer {token}"})
+
+    _assert_standard_error(response, status_code=403, detail_type=str)
+    assert response.json()["detail"] == "Permission denied"
+
+
+@pytest.mark.parametrize(
+    ("content", "content_type", "expected_error_type"),
+    (
+        (b'{"email":', "application/json", "json_invalid"),
+        (b'{"email":"user@example.com"}', "text/plain", "model_attributes_type"),
+        (b"{}", "application/json", "missing"),
+    ),
+)
+def test_json_framing_and_validation_errors_use_standard_shape(
+    content: bytes,
+    content_type: str,
+    expected_error_type: str,
+) -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/auth/forgot-password",
+            content=content,
+            headers={"Content-Type": content_type},
+        )
+
+    _assert_standard_error(response, status_code=422, detail_type=list)
+    assert expected_error_type in {error["type"] for error in response.json()["detail"]}
+
+
+def test_login_rejects_json_instead_of_oauth_form_data() -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/auth/login",
+            json={"username": "admin@example.com", "password": "secret"},
+        )
+
+    _assert_standard_error(response, status_code=422, detail_type=list)
+    missing_fields = {error["loc"][-1] for error in response.json()["detail"] if error["type"] == "missing"}
+    assert missing_fields == {"password", "username"}
+
+
+def test_body_size_limit_rejects_oversized_payload_before_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_settings, "MAX_BODY_SIZE_KB", 1)
+    oversized_body = b'{"email":"' + (b"a" * 1024) + b'"}'
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/auth/forgot-password",
+            content=oversized_body,
+            headers={"Content-Type": "application/json"},
+        )
+
+    _assert_standard_error(response, status_code=413, detail_type=str)
+    assert response.json()["detail"] == "Request body too large"
+
+
+def test_body_within_limit_reaches_schema_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_settings, "MAX_BODY_SIZE_KB", 1)
+    body = b"{" + (b" " * 1022) + b"}"
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/auth/forgot-password",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+    _assert_standard_error(response, status_code=422, detail_type=list)
+
+
+def test_evaluator_accepts_supported_nested_payload_depth_before_authentication() -> None:
+    nested: dict[str, Any] = {"value": "leaf"}
+    for index in range(32):
+        nested = {f"level_{index}": nested}
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/evaluate",
+            json={
+                "transaction_id": "nested-contract",
+                "effective_at": "2026-07-14T00:00:00Z",
+                "event_data": nested,
+            },
+        )
+
+    _assert_standard_error(response, status_code=401, detail_type=str)
+    assert response.json()["detail"] == "Authentication required"
+
+
+def test_pagination_parameters_are_bounded_in_openapi() -> None:
+    operations = _operation_inventory(app.openapi())
+    pagination_parameters = [
+        parameter
+        for operation in operations
+        for parameter in operation["parameters"]
+        if parameter["in"] == "query" and parameter["name"] in {"cursor", "limit", "max_events", "max_hops", "offset"}
+    ]
+
+    assert pagination_parameters
+    assert all(parameter["schema"].get("minimum") is not None for parameter in pagination_parameters)
+    assert all(
+        parameter["schema"].get("maximum") is not None
+        for parameter in pagination_parameters
+        if parameter["name"] in {"limit", "max_events", "max_hops"}
+    )
+    assert all(
+        parameter["schema"].get("default") is not None
+        for parameter in pagination_parameters
+        if parameter["name"] in {"limit", "max_events", "max_hops", "offset"}
+    )
+
+
+def test_path_parameter_names_match_route_templates() -> None:
+    operations = _operation_inventory(app.openapi())
+    for operation in operations:
+        declared = {parameter["name"] for parameter in operation["parameters"] if parameter["in"] == "path"}
+        templated = set(re.findall(r"{([^}]+)}", operation["path"]))
+        assert declared == templated, f"{operation['method']} {operation['path']}"
+
+
+if __name__ == "__main__":
+    inventory = _operation_inventory(app.openapi())
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_PATH.write_text(f"{json.dumps(inventory, indent=2, sort_keys=True)}\n")

--- a/tests/test_api_v2_contract_regressions.py
+++ b/tests/test_api_v2_contract_regressions.py
@@ -26,6 +26,8 @@ PUBLIC_OPERATIONS = {
     ("POST", "/api/v2/auth/refresh"),
     ("POST", "/api/v2/auth/reset-password"),
 }
+OAUTH_SECURITY = [["OAuth2PasswordBearer"]]
+EVALUATOR_SECURITY = [["ApiKeyAuth"], ["OAuth2PasswordBearer"]]
 REPRESENTATIVE_PROTECTED_READS = (
     "/api/v2/alerts/rules",
     "/api/v2/analytics/labels-summary",
@@ -76,7 +78,7 @@ def _operation_inventory(schema: dict[str, Any]) -> list[dict[str, Any]]:
                     }
                 )
 
-            security = sorted(scheme for requirement in operation.get("security", []) for scheme in requirement)
+            security = sorted(sorted(requirement) for requirement in operation.get("security", []))
             request_content = sorted(operation.get("requestBody", {}).get("content", {}).keys())
             operations.append(
                 {
@@ -177,10 +179,32 @@ def test_openapi_has_unique_operation_ids_and_no_undeclared_public_routes() -> N
     assert len(operation_ids) == len(set(operation_ids))
     assert public_operations == PUBLIC_OPERATIONS
     assert all(
-        operation["security"] == ["OAuth2PasswordBearer"]
+        operation["security"]
+        == (
+            EVALUATOR_SECURITY
+            if (operation["method"], operation["path"]) == ("POST", "/api/v2/evaluate")
+            else OAUTH_SECURITY
+        )
         for operation in operations
         if operation["path"].startswith("/api/v2") and (operation["method"], operation["path"]) not in PUBLIC_OPERATIONS
     )
+
+
+def test_evaluator_openapi_declares_api_key_or_oauth_security() -> None:
+    schema = app.openapi()
+
+    assert schema["components"]["securitySchemes"]["ApiKeyAuth"] == {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+    }
+    assert schema["paths"]["/api/v2/evaluate"]["post"]["security"] == [
+        {"ApiKeyAuth": []},
+        {"OAuth2PasswordBearer": []},
+    ]
+    assert schema["paths"]["/api/v2/event-tests"]["post"]["security"] == [
+        {"OAuth2PasswordBearer": []},
+    ]
 
 
 def test_openapi_declares_validation_errors_for_validated_inputs() -> None:

--- a/tests/test_api_v2_contract_regressions.py
+++ b/tests/test_api_v2_contract_regressions.py
@@ -60,7 +60,8 @@ def _operation_inventory(schema: dict[str, Any]) -> list[dict[str, Any]]:
                 parameter_schema = parameter.get("schema", {})
                 if "anyOf" in parameter_schema:
                     parameter_schema = next(
-                        candidate for candidate in parameter_schema["anyOf"] if candidate.get("type") != "null"
+                        (candidate for candidate in parameter_schema["anyOf"] if candidate.get("type") != "null"),
+                        parameter_schema,
                     )
                 tracked_parameters.append(
                     {
@@ -133,6 +134,35 @@ def test_openapi_operation_inventory_matches_snapshot() -> None:
     expected = json.loads(SNAPSHOT_PATH.read_text())
 
     assert _operation_inventory(app.openapi()) == expected
+
+
+def test_openapi_inventory_tolerates_null_only_any_of_parameter() -> None:
+    schema = {
+        "paths": {
+            "/example": {
+                "get": {
+                    "operationId": "example",
+                    "parameters": [
+                        {
+                            "in": "query",
+                            "name": "cursor",
+                            "schema": {"anyOf": [{"type": "null"}]},
+                        }
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        }
+    }
+
+    assert _operation_inventory(schema)[0]["parameters"] == [
+        {
+            "in": "query",
+            "name": "cursor",
+            "required": False,
+            "schema": {},
+        }
+    ]
 
 
 def test_openapi_has_unique_operation_ids_and_no_undeclared_public_routes() -> None:

--- a/tests/test_check_version_policy.py
+++ b/tests/test_check_version_policy.py
@@ -1,0 +1,78 @@
+"""Regression tests for the pull-request version classification policy."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+POLICY_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "check-version-policy.sh"
+
+
+def _run_policy(base_version: str, current_version: str, changed_paths: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(POLICY_SCRIPT), base_version, current_version],
+        input="\n".join(changed_paths),
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_unchanged_version_allows_explicit_non_release_paths() -> None:
+    result = _run_policy(
+        "1.29.0",
+        "1.29.0",
+        [
+            "tests/test_example.py",
+            "docs/api-reference/manager-api.md",
+            ".github/workflows/tests.yml",
+            ".vscode/launch.json",
+            ".codex/notes.md",
+            ".omx/plans/test-plan.md",
+            "AGENTS.md",
+            "DOCUMENTATION_MAP.md",
+            "README.md",
+            "mkdocs.yml",
+        ],
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "changed=false"
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    "release_path",
+    (
+        "ezrules/backend/api_v2/main.py",
+        "ezrules/frontend/src/app/app.component.ts",
+        "alembic/versions/20260714_contract.py",
+        "pyproject.toml",
+        "docker-compose.yml",
+        "scripts/start-agent-stack.sh",
+    ),
+)
+def test_unchanged_version_rejects_unclassified_release_paths(release_path: str) -> None:
+    result = _run_policy("1.29.0", "1.29.0", ["tests/test_example.py", release_path])
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert release_path in result.stderr
+    assert "Bump the version" in result.stderr
+
+
+def test_changed_version_runs_downstream_pypi_check_for_any_path() -> None:
+    result = _run_policy("1.29.0", "1.29.1", ["ezrules/backend/api_v2/main.py"])
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "changed=true"
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(("base_version", "current_version"), (("", "1.29.1"), ("1.29.0", "")))
+def test_missing_version_fails_closed(base_version: str, current_version: str) -> None:
+    result = _run_policy(base_version, current_version, ["tests/test_example.py"])
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "Could not parse" in result.stderr

--- a/tests/test_check_version_policy.py
+++ b/tests/test_check_version_policy.py
@@ -154,3 +154,31 @@ def test_pr_changes_include_deleted_paths_without_git_quoting(tmp_path: Path) ->
     )
 
     assert changed.stdout.splitlines() == ["ezrules/retiré.py"]
+
+
+def test_pr_changes_expand_shipped_to_docs_rename_for_version_policy(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _initialize_repo(repo)
+    _commit_file(repo, "ezrules/rule_syntax.py", "syntax = 'strict'\n", "add shipped file")
+    _git(repo, "branch", "feature")
+    base_sha = _git(repo, "rev-parse", "main")
+
+    _git(repo, "checkout", "feature")
+    (repo / "docs").mkdir()
+    _git(repo, "mv", "ezrules/rule_syntax.py", "docs/rule-syntax.py")
+    _git(repo, "commit", "-m", "move shipped file into docs")
+    head_sha = _git(repo, "rev-parse", "feature")
+
+    changed = subprocess.run(
+        ["bash", str(CHANGED_FILES_SCRIPT), base_sha, head_sha],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    changed_paths = changed.stdout.splitlines()
+    assert set(changed_paths) == {"docs/rule-syntax.py", "ezrules/rule_syntax.py"}
+    policy = _run_policy("1.29.0", "1.29.0", changed_paths)
+    assert policy.returncode == 1
+    assert "ezrules/rule_syntax.py" in policy.stderr

--- a/tests/test_check_version_policy.py
+++ b/tests/test_check_version_policy.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 POLICY_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "check-version-policy.sh"
+CHANGED_FILES_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "list-pr-changes.sh"
 
 
 def _run_policy(base_version: str, current_version: str, changed_paths: list[str]) -> subprocess.CompletedProcess[str]:
@@ -16,6 +17,33 @@ def _run_policy(base_version: str, current_version: str, changed_paths: list[str
         check=False,
         text=True,
     )
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit_file(repo: Path, path: str, content: str, message: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    _git(repo, "add", path)
+    _git(repo, "commit", "-m", message)
+
+
+def _initialize_repo(repo: Path) -> None:
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Version Policy Test")
+    _git(repo, "config", "user.email", "version-policy@example.com")
+    _commit_file(repo, "README.md", "initial\n", "initial")
 
 
 def test_unchanged_version_allows_explicit_non_release_paths() -> None:
@@ -76,3 +104,53 @@ def test_missing_version_fails_closed(base_version: str, current_version: str) -
     assert result.returncode == 2
     assert result.stdout == ""
     assert "Could not parse" in result.stderr
+
+
+def test_pr_changes_use_merge_base_when_feature_branch_is_behind_main(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _initialize_repo(repo)
+    _git(repo, "branch", "feature")
+
+    _commit_file(repo, "ezrules/main_only.py", "released = True\n", "main release")
+    base_sha = _git(repo, "rev-parse", "main")
+
+    _git(repo, "checkout", "feature")
+    _commit_file(repo, "docs/pr-only.md", "documentation\n", "docs only")
+    head_sha = _git(repo, "rev-parse", "feature")
+
+    changed = subprocess.run(
+        ["bash", str(CHANGED_FILES_SCRIPT), base_sha, head_sha],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    assert changed.stdout.splitlines() == ["docs/pr-only.md"]
+    policy = _run_policy("1.29.0", "1.29.0", changed.stdout.splitlines())
+    assert policy.returncode == 0
+    assert policy.stdout.strip() == "changed=false"
+
+
+def test_pr_changes_include_deleted_paths_without_git_quoting(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _initialize_repo(repo)
+    _commit_file(repo, "ezrules/retiré.py", "retired = True\n", "add unicode path")
+    _git(repo, "branch", "feature")
+    base_sha = _git(repo, "rev-parse", "main")
+
+    _git(repo, "checkout", "feature")
+    (repo / "ezrules" / "retiré.py").unlink()
+    _git(repo, "add", "--all")
+    _git(repo, "commit", "-m", "remove unicode path")
+    head_sha = _git(repo, "rev-parse", "feature")
+
+    changed = subprocess.run(
+        ["bash", str(CHANGED_FILES_SCRIPT), base_sha, head_sha],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    assert changed.stdout.splitlines() == ["ezrules/retiré.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.29.0"
+version = "1.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- snapshot the normalized contract of every API v2 OpenAPI operation, preserving OpenAPI security OR-versus-AND groupings alongside content types, parameters, operation IDs, and success responses
- exercise representative authentication, tenant-claim, and permission boundaries across manager domains
- publish `X-API-Key` as the `ApiKeyAuth` scheme and expose API key or OAuth as alternatives for `POST /api/v2/evaluate`; keep Event Tester OAuth-only
- lock request framing, malformed JSON, OAuth form encoding, body-size, nested-event, pagination, path-parameter, and standard error-envelope behavior
- document the cross-cutting manager and evaluator request contracts
- enforce a fail-safe release policy: unchanged versions skip PyPI only for an explicit non-release path allowlist; every unclassified path requires a bump

## Verification
- `uv run poe check`
- `uv run ruff check tests/test_api_v2_contract_regressions.py ezrules/backend/api_v2/auth/dependencies.py ezrules/backend/api_v2/routes/evaluator.py`
- `uv run pytest -q tests/test_api_v2_contract_regressions.py -k "not mismatched_tenant_claim and not missing_permissions"` (28 passed)
- `uv run pytest -q tests/test_check_version_policy.py` (10 passed)
- generated OpenAPI inspection confirms `POST /evaluate` has separate `ApiKeyAuth` and OAuth alternatives and `POST /event-tests` remains OAuth-only
- version-policy shell syntax and workflow YAML parse pass
- `uv run mkdocs build --strict`
- full database-backed validation delegated to GitHub Actions because local PostgreSQL and Docker are unavailable

## Review follow-up
- hardened nullable OpenAPI union normalization and added a focused regression test
- published evaluator API-key authentication accurately while preserving bearer-only Event Tester behavior
- replaced the unchanged-version bypass with an explicit non-release allowlist and fail-safe default, covered by deterministic path-policy tests
- all actionable review threads were answered and resolved

## Known gaps
- the inventory intentionally snapshots route-level OpenAPI metadata rather than the entire generated component-schema graph, keeping changes reviewable
- existing phase 1/2/3 organisation-scoping tests remain the detailed resource-isolation coverage; this PR adds a broad route-boundary matrix rather than duplicating every resource fixture
- local database verification is unavailable because PostgreSQL and Docker are not running; GitHub Actions is the source of truth for the complete database-backed suite

## Release artifacts
- patch version bumped once to `1.29.1`, with a matching topmost `docs/whatsnew.md` section and updated manager/evaluator API references
- README already demonstrates `X-API-Key`; screenshots and GIFs were reviewed and no captured UI workflow is affected