### PR TITLE
Enforce rule outcome and engine result contracts

### DIFF
--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -86,7 +86,7 @@ Each call to `POST /api/v2/auth/refresh` deletes the submitted refresh token and
 | `POST` | `/api/v2/rules/{rule_id}/resume` | Bearer + `PROMOTE_RULES` | Resume paused rule to active |
 | `POST` | `/api/v2/rules/{rule_id}/archive` | Bearer + `MODIFY_RULE` | Archive rule |
 | `POST` | `/api/v2/rules/{rule_id}/rollback` | Bearer + `MODIFY_RULE` | Create a new draft version from a historical revision (`revision_number` in body) |
-| `POST` | `/api/v2/rules/verify` | Bearer + permission | Verify rule source, extracted params, and advisory warnings for unseen fields |
+| `POST` | `/api/v2/rules/verify` | Bearer + permission | Verify rule source, the `None`/direct-`!OUTCOME` return contract, extracted params, and advisory warnings for unseen fields |
 | `POST` | `/api/v2/rules/ai/draft` | Bearer + `CREATE_RULE` or `MODIFY_RULE` | Generate an AI-assisted rule draft (`mode=create|edit`) |
 | `POST` | `/api/v2/rules/ai/apply` | Bearer + `CREATE_RULE` or `MODIFY_RULE` | Record that an AI draft was explicitly applied in the editor |
 | `POST` | `/api/v2/rules/test` | Bearer + permission | Test rule payload |

--- a/docs/user-guide/creating-rules.md
+++ b/docs/user-guide/creating-rules.md
@@ -51,7 +51,8 @@ Notes:
 - Use `$field_name` to read event fields (for example `$amount`, `$country`)
 - Use dotted paths for nested JSON values (for example `$customer.profile.age`, `$device.location.country`)
 - Use `stat[entity.feature_name]` to read active computed historical features from **Features**
-- If no condition matches, return nothing
+- A rule may return only a configured outcome with direct `return !OUTCOME` syntax, or no result with `return None`, a bare `return`, or by reaching the end of the rule
+- Boolean, numeric, quoted or dynamically computed strings, containers, and other Python expressions are rejected as rule results
 - If the rule is in the allowlist lane, it must return the configured neutral outcome using `!OUTCOME`
 
 Checkpoint:
@@ -179,6 +180,7 @@ if 2 <= $hour <= 5 and $amount > 1000:
 ## Step 5: Avoid Common Mistakes
 
 - Returning an outcome that is not configured in **Outcomes**
+- Returning a predicate such as `return $amount > 100`; put the predicate in an `if` statement and return a configured `!OUTCOME` from the matching branch
 - Using field names that do not exist in event payloads
 - Packing too many unrelated conditions into one rule
 - Running expensive lookups per event inside rule logic

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -2,8 +2,8 @@
 
 ## v1.29.1
 
-* **Strict rule authoring results**: Rule verification, save, backtesting, and agent-tool proposal flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics before metrics run.
-* **Fail-fast rule outcome contract**: Rule-set evaluation now rejects malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions.
+* **Strict rule authoring results**: Rule verification, save, rollout deployment, backtesting, and agent-tool proposal flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics before deployment or metrics run.
+* **Fail-fast rule outcome contract**: Rule-set and split-rollout evaluation now reject malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions; invalid legacy rollout candidates fall back to their validated control result.
 * **Stable rule-engine results**: Empty and non-matching rule sets retain one documented result shape, zero-valued database rule identifiers remain intact, duplicate identifiers fail before execution, and unsupported execution modes can no longer silently fall back to all-matches behavior.
 
 ## v1.29.0

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -2,7 +2,7 @@
 
 ## v1.29.1
 
-* **Strict rule authoring results**: Rule verification and save flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, and other expressions are rejected with source diagnostics.
+* **Strict rule authoring results**: Rule verification and save flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics.
 * **Fail-fast rule outcome contract**: Rule-set evaluation now rejects malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions.
 * **Stable rule-engine results**: Empty and non-matching rule sets retain one documented result shape, zero-valued database rule identifiers remain intact, duplicate identifiers fail before execution, and unsupported execution modes can no longer silently fall back to all-matches behavior.
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -2,8 +2,8 @@
 
 ## v1.29.1
 
-* **Strict rule authoring results**: Rule verification, save, rollout deployment, backtesting, and agent-tool proposal flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics before deployment or metrics run.
-* **Fail-fast rule outcome contract**: Rule-set and split-rollout evaluation now reject malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions; invalid legacy rollout candidates fall back to their validated control result.
+* **Strict rule authoring results**: Rule verification, save, shadow and rollout deployment, backtesting, and agent-tool proposal flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics before deployment or metrics run, including revalidation immediately before candidate promotion.
+* **Fail-fast rule outcome contract**: Rule-set and split-rollout evaluation now reject malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions; invalid legacy rollout candidates fall back to their validated control result, while invalid queued shadow snapshots are isolated so later work can continue.
 * **Stable rule-engine results**: Empty and non-matching rule sets retain one documented result shape, zero-valued database rule identifiers remain intact, duplicate identifiers fail before execution, and unsupported execution modes can no longer silently fall back to all-matches behavior.
 
 ## v1.29.0

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -2,7 +2,7 @@
 
 ## v1.29.1
 
-* **Strict rule authoring results**: Rule verification and save flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics.
+* **Strict rule authoring results**: Rule verification, save, backtesting, and agent-tool proposal flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, generator syntax, reserved internal helpers, and other expressions are rejected with source diagnostics before metrics run.
 * **Fail-fast rule outcome contract**: Rule-set evaluation now rejects malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions.
 * **Stable rule-engine results**: Empty and non-matching rule sets retain one documented result shape, zero-valued database rule identifiers remain intact, duplicate identifiers fail before execution, and unsupported execution modes can no longer silently fall back to all-matches behavior.
 

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.29.1
+
+* **Strict rule authoring results**: Rule verification and save flows now accept only no result (`None`, a bare return, or fall-through) or a direct configured `return !OUTCOME`; predicates, numbers, containers, dynamic strings, and other expressions are rejected with source diagnostics.
+* **Fail-fast rule outcome contract**: Rule-set evaluation now rejects malformed boolean, numeric, empty, container, and callable results before aggregation instead of producing corrupt counters or partial decisions.
+* **Stable rule-engine results**: Empty and non-matching rule sets retain one documented result shape, zero-valued database rule identifiers remain intact, duplicate identifiers fail before execution, and unsupported execution modes can no longer silently fall back to all-matches behavior.
+
 ## v1.29.0
 
 * **Alert-backed case review**: Outcome-spike incidents now attach every contributing current evaluation to its existing case, preserving one assignment, notes, disposition, and audit workflow instead of introducing a parallel alert queue.

--- a/ezrules/backend/agent_tools.py
+++ b/ezrules/backend/agent_tools.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from ezrules.backend.features import FeatureResolutionError, FeatureResolver
+from ezrules.backend.rule_validation import compile_validated_rule_source
 from ezrules.backend.utils import load_cast_configs
 from ezrules.core.field_paths import get_field_value
 from ezrules.core.rule import MissingFieldLookupError, MissingStatLookupError, Rule, RuleFactory
@@ -116,7 +117,7 @@ def _compile_rules(
     stored_rule = RuleFactory.from_json(rule_model.__dict__, list_values_provider=list_provider)
     proposed_rule = None
     if proposed_logic is not None:
-        proposed_rule = Rule(rid="", logic=proposed_logic, list_values_provider=list_provider)
+        proposed_rule = compile_validated_rule_source(db, org_id, proposed_logic)
     return stored_rule, proposed_rule
 
 

--- a/ezrules/backend/api_v2/routes/agent_tools.py
+++ b/ezrules/backend/api_v2/routes/agent_tools.py
@@ -15,9 +15,8 @@ from ezrules.backend.api_v2.schemas.agent_tools import (
     RuleCounterexamplesRequest,
     RuleCounterexamplesResponse,
 )
+from ezrules.backend.rule_validation import compile_validated_rule_source
 from ezrules.core.permissions_constants import PermissionAction
-from ezrules.core.rule import Rule
-from ezrules.core.user_lists import PersistentUserListManager
 from ezrules.models.backend_core import User
 
 router = APIRouter(prefix="/api/v2/agent-tools", tags=["Agent Tools"])
@@ -25,7 +24,7 @@ router = APIRouter(prefix="/api/v2/agent-tools", tags=["Agent Tools"])
 
 def _validate_rule_logic(db: Any, org_id: int, logic: str) -> None:
     try:
-        Rule(rid="", logic=logic, list_values_provider=PersistentUserListManager(db, org_id))
+        compile_validated_rule_source(db, org_id, logic)
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/ezrules/backend/api_v2/routes/backtesting.py
+++ b/ezrules/backend/api_v2/routes/backtesting.py
@@ -27,11 +27,10 @@ from ezrules.backend.backtesting import (
     BACKTEST_QUEUE_PENDING,
     BACKTEST_QUEUE_RUNNING,
 )
+from ezrules.backend.rule_validation import compile_validated_rule_source
 from ezrules.backend.tasks import app as celery_app
 from ezrules.backend.tasks import backtest_rule_change, execute_backtest_rule_change
 from ezrules.core.permissions_constants import PermissionAction
-from ezrules.core.rule import Rule
-from ezrules.core.user_lists import PersistentUserListManager
 from ezrules.models.backend_core import Rule as RuleModel
 from ezrules.models.backend_core import RuleBackTestingResult, User
 
@@ -215,11 +214,7 @@ def trigger_backtest(
         )
 
     try:
-        Rule(
-            rid="",
-            logic=request.new_rule_logic,
-            list_values_provider=PersistentUserListManager(db, current_org_id),
-        )
+        compile_validated_rule_source(db, current_org_id, request.new_rule_logic)
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/ezrules/backend/api_v2/routes/evaluator.py
+++ b/ezrules/backend/api_v2/routes/evaluator.py
@@ -34,7 +34,7 @@ from ezrules.backend.utils import load_cast_configs, record_observations
 from ezrules.core.outcomes import DatabaseOutcome
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.core.rule import MissingFieldLookupError, MissingStatLookupError, RuleFactory
-from ezrules.core.rule_engine import RULE_EXECUTION_MODE_FIRST_MATCH
+from ezrules.core.rule_engine import RULE_EXECUTION_MODE_FIRST_MATCH, validate_rule_result
 from ezrules.core.rule_updater import (
     ALLOWLIST_CONFIG_LABEL,
     DEPLOYMENT_MODE_SPLIT,
@@ -203,12 +203,12 @@ def _evaluate_rollout_result(
     ordered_rules = list(lre.rule_engine.rules if lre.rule_engine is not None else [])
     rollout_by_rule_id = {int(entry["r_id"]): entry for entry in rollout_entries if "r_id" in entry}
     rule_metadata_by_id = data_utils.build_rule_metadata_from_rules(ordered_rules)
-    all_rule_results: dict[int, Any] = {}
+    all_rule_results: dict[int, str | None] = {}
     rollout_logs: list[dict[str, Any]] = []
 
     for control_rule in ordered_rules:
         rule_id = int(control_rule.r_id)
-        control_result = control_rule(event_data, stats=stats)
+        control_result = validate_rule_result(rule_id, control_rule(event_data, stats=stats))
         returned_result = control_result
 
         entry = rollout_by_rule_id.get(rule_id)
@@ -219,7 +219,7 @@ def _evaluate_rollout_result(
             candidate_succeeded = False
             try:
                 candidate_rule = RuleFactory.from_json(entry, list_values_provider=list_provider)
-                candidate_result = candidate_rule(event_data, stats=stats)
+                candidate_result = validate_rule_result(rule_id, candidate_rule(event_data, stats=stats))
                 candidate_succeeded = True
             except Exception:
                 candidate_result = None
@@ -357,6 +357,21 @@ def evaluate(
             list_provider=list_provider,
         )
         production_result = lre.evaluate_rules(event.event_data, as_of=event.effective_at, stats=stats)
+        rollout_logs: list[dict[str, Any]] = []
+        if rollout_entries:
+            assert list_provider is not None
+            assignment_key = _get_assignment_key(event)
+            result, rollout_logs, rule_metadata_by_id = _evaluate_rollout_result(
+                event_data=event.event_data,
+                lre=lre,
+                rollout_entries=rollout_entries,
+                assignment_key=assignment_key,
+                list_provider=list_provider,
+                stats=stats,
+            )
+            result["_rule_metadata_by_id"] = rule_metadata_by_id
+        else:
+            result = production_result
     except (FeatureResolutionError, MissingFieldLookupError, MissingStatLookupError) as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -367,22 +382,6 @@ def evaluate(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Evaluation failed",
         ) from exc
-
-    rollout_logs: list[dict[str, Any]] = []
-    if rollout_entries:
-        assert list_provider is not None
-        assignment_key = _get_assignment_key(event)
-        result, rollout_logs, rule_metadata_by_id = _evaluate_rollout_result(
-            event_data=event.event_data,
-            lre=lre,
-            rollout_entries=rollout_entries,
-            assignment_key=assignment_key,
-            list_provider=list_provider,
-            stats=stats,
-        )
-        result["_rule_metadata_by_id"] = rule_metadata_by_id
-    else:
-        result = production_result
 
     try:
         # `result` already contains the merged served outcome; passing it avoids a second rule evaluation.

--- a/ezrules/backend/api_v2/routes/rules.py
+++ b/ezrules/backend/api_v2/routes/rules.py
@@ -1425,10 +1425,18 @@ def deploy_to_shadow(
         RULE_EVALUATION_LANE_ALLOWLIST
     ):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Allowlist rules cannot be deployed")
-    if request.logic is not None:
-        outcome_errors = build_outcome_notation_errors(db, current_org_id, request.logic)
-        if outcome_errors:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=outcome_errors[0].message)
+    candidate_logic = request.logic if request.logic is not None else str(rule.logic)
+    candidate_description = request.description if request.description is not None else str(rule.description)
+    try:
+        compile_validated_rule_source(
+            db,
+            current_org_id,
+            candidate_logic,
+            rid=str(rule.rid),
+            description=candidate_description,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     try:
         deploy_rule_to_shadow(
@@ -1478,6 +1486,15 @@ def promote_to_production(
     """Promote a rule from shadow config into the production config."""
     from ezrules.backend.api_v2.routes import evaluator as evaluator_module
 
+    def validate_stored_candidate(deployment_entry: dict[str, Any]) -> None:
+        compile_validated_rule_source(
+            db,
+            current_org_id,
+            str(deployment_entry["logic"]),
+            rid=str(deployment_entry.get("rid") or rule_id),
+            description=str(deployment_entry.get("description") or ""),
+        )
+
     try:
         promote_shadow_rule_to_production(
             db,
@@ -1485,6 +1502,7 @@ def promote_to_production(
             r_id=rule_id,
             changed_by=str(user.email),
             approved_by=int(user.id),
+            validate_candidate=validate_stored_candidate,
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e

--- a/ezrules/backend/api_v2/routes/rules.py
+++ b/ezrules/backend/api_v2/routes/rules.py
@@ -1589,6 +1589,15 @@ def promote_rollout_to_production(
 ) -> RolloutDeployResponse:
     from ezrules.backend.api_v2.routes import evaluator as evaluator_module
 
+    def validate_stored_candidate(deployment_entry: dict[str, Any]) -> None:
+        compile_validated_rule_source(
+            db,
+            current_org_id,
+            str(deployment_entry["logic"]),
+            rid=str(deployment_entry.get("rid") or rule_id),
+            description=str(deployment_entry.get("description") or ""),
+        )
+
     try:
         promote_rollout_rule_to_production(
             db,
@@ -1596,6 +1605,7 @@ def promote_rollout_to_production(
             r_id=rule_id,
             changed_by=str(user.email),
             approved_by=int(user.id),
+            validate_candidate=validate_stored_candidate,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/ezrules/backend/api_v2/routes/rules.py
+++ b/ezrules/backend/api_v2/routes/rules.py
@@ -125,6 +125,29 @@ def is_active(rule: RuleModel) -> bool:
     return rule.status == RuleStatus.ACTIVE
 
 
+def load_rule_for_activation(db: Any, org_id: int, rule_id: int) -> RuleModel | None:
+    """Lock and refresh the exact rule row that may enter production."""
+    return (
+        db.query(RuleModel)
+        .filter(RuleModel.r_id == rule_id, RuleModel.o_id == org_id)
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+
+
+def validate_rule_for_activation(db: Any, org_id: int, rule: RuleModel) -> None:
+    """Apply the complete current organisation contract before activation."""
+    compile_validated_rule_source(
+        db,
+        org_id,
+        str(rule.logic),
+        evaluation_lane=str(rule.evaluation_lane or RULE_EVALUATION_LANE_MAIN),
+        rid=str(rule.rid),
+        description=str(rule.description),
+    )
+
+
 def delete_rule_result_references(db: Any, rule_id: int) -> None:
     """Remove canonical per-rule result rows that would otherwise block hard deletion."""
     for model in (RuleDeploymentResultsLog, ShadowResultsLog, EvaluationRuleResult):
@@ -787,7 +810,10 @@ def update_rule(
     rule.effective_from = promoted_at
     rule.approved_by = user.id if auto_promote_active_updates else None
     rule.approved_at = promoted_at
-    rule_manager.save_rule(rule)
+    if auto_promote_active_updates:
+        rule_manager.stage_rule(rule)
+    else:
+        rule_manager.save_rule(rule)
 
     # Editing an active rule either updates production in place or removes the rule until it is re-promoted.
     if was_active:
@@ -879,7 +905,7 @@ def promote_rule(
     """Promote a draft rule to active and record who activated it."""
     rule_manager = get_rule_manager(db, current_org_id)
     config_producer = get_config_producer(db, current_org_id)
-    rule = rule_manager.load_rule(rule_id)
+    rule = load_rule_for_activation(db, current_org_id, rule_id)
     if rule is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
     ensure_no_active_candidate_deployment(db, current_org_id, rule_id)
@@ -889,6 +915,10 @@ def promote_rule(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Paused rules must be resumed")
     if rule.status == RuleStatus.ACTIVE:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rule is already active")
+    try:
+        validate_rule_for_activation(db, current_org_id, rule)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     promoted_at = datetime.now(UTC)
     save_rule_history(
@@ -905,7 +935,7 @@ def promote_rule(
     rule.effective_from = promoted_at
     rule.approved_by = user.id
     rule.approved_at = promoted_at
-    rule_manager.save_rule(rule)
+    rule_manager.stage_rule(rule)
     config_producer.save_config(rule_manager, changed_by=str(user.email))
 
     return RuleMutationResponse(
@@ -969,7 +999,7 @@ def resume_rule(
     """Resume a paused rule and restore it to active status."""
     rule_manager = get_rule_manager(db, current_org_id)
     config_producer = get_config_producer(db, current_org_id)
-    rule = rule_manager.load_rule(rule_id)
+    rule = load_rule_for_activation(db, current_org_id, rule_id)
     if rule is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rule not found")
     ensure_no_active_candidate_deployment(db, current_org_id, rule_id)
@@ -979,6 +1009,10 @@ def resume_rule(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Draft rules cannot be resumed")
     if rule.status == RuleStatus.ACTIVE:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rule is already active")
+    try:
+        validate_rule_for_activation(db, current_org_id, rule)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     resumed_at = datetime.now(UTC)
     save_rule_history(
@@ -995,7 +1029,7 @@ def resume_rule(
     rule.effective_from = resumed_at
     rule.approved_by = user.id
     rule.approved_at = resumed_at
-    rule_manager.save_rule(rule)
+    rule_manager.stage_rule(rule)
     config_producer.save_config(rule_manager, changed_by=str(user.email))
 
     return RuleMutationResponse(

--- a/ezrules/backend/api_v2/routes/rules.py
+++ b/ezrules/backend/api_v2/routes/rules.py
@@ -53,6 +53,7 @@ from ezrules.backend.api_v2.schemas.shadow import ShadowDeployRequest, ShadowDep
 from ezrules.backend.features import FeatureResolutionError, FeatureResolver
 from ezrules.backend.rule_validation import (
     build_outcome_notation_errors,
+    compile_validated_rule_source,
     get_list_provider,
     validate_rule_source,
 )
@@ -1518,9 +1519,16 @@ def deploy_to_rollout(
             detail="Allowlist rules cannot be rolled out",
         )
     if request.logic is not None:
-        outcome_errors = build_outcome_notation_errors(db, current_org_id, request.logic)
-        if outcome_errors:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=outcome_errors[0].message)
+        try:
+            compile_validated_rule_source(
+                db,
+                current_org_id,
+                request.logic,
+                rid=str(rule.rid),
+                description=request.description or str(rule.description),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     try:
         deploy_rule_to_rollout(

--- a/ezrules/backend/rule_validation.py
+++ b/ezrules/backend/rule_validation.py
@@ -22,6 +22,31 @@ class RuleValidationResult:
     response: RuleVerifyResponse
 
 
+def compile_validated_rule_source(
+    db: Any,
+    org_id: int,
+    rule_source: str,
+    *,
+    evaluation_lane: str = RULE_EVALUATION_LANE_MAIN,
+    rid: str = "",
+    description: str = "",
+) -> Rule:
+    """Compile rule source only after applying the complete persisted-rule contract."""
+    result = validate_rule_source(
+        db,
+        org_id,
+        rule_source,
+        evaluation_lane=evaluation_lane,
+        rid=rid,
+        description=description,
+    )
+    if result.response.valid and result.compiled_rule is not None:
+        return result.compiled_rule
+
+    messages = [error.message for error in result.response.errors if error.message]
+    raise ValueError("; ".join(messages) or "Rule source is invalid")
+
+
 def get_list_provider(db: Any, org_id: int) -> PersistentUserListManager:
     return PersistentUserListManager(db_session=db, o_id=org_id)
 

--- a/ezrules/backend/rule_validation.py
+++ b/ezrules/backend/rule_validation.py
@@ -196,6 +196,8 @@ def validate_rule_source(
             ),
         )
 
+    params: list[str] = []
+    warnings: list[str] = []
     try:
         compiled_rule = Rule(
             rid=rid,
@@ -205,6 +207,7 @@ def validate_rule_source(
         )
         params = sorted(compiled_rule.get_rule_params(), key=str)
         warnings = build_rule_warnings(db, org_id, params)
+        compiled_rule.validate_return_contract()
         if evaluation_lane == RULE_EVALUATION_LANE_ALLOWLIST:
             allowlist_error = validate_allowlist_rule(compiled_rule, get_neutral_outcome(db, org_id))
             if allowlist_error is not None:
@@ -238,11 +241,11 @@ def validate_rule_source(
             compiled_rule=None,
             response=RuleVerifyResponse(
                 valid=False,
-                params=[],
+                params=params,
                 referenced_lists=referenced_lists,
                 referenced_outcomes=referenced_outcomes,
                 referenced_features=referenced_features,
-                warnings=[],
+                warnings=warnings,
                 errors=[
                     build_verify_error(
                         message=str(exc),

--- a/ezrules/backend/rule_validation.py
+++ b/ezrules/backend/rule_validation.py
@@ -8,7 +8,7 @@ from ezrules.backend.api_v2.schemas.rules import RuleVerifyError, RuleVerifyResp
 from ezrules.backend.features import extract_rule_stat_paths, validate_feature_reference_budget
 from ezrules.backend.runtime_settings import get_neutral_outcome
 from ezrules.core.outcomes import DatabaseOutcome
-from ezrules.core.rule import OutcomeReturnSyntaxError, Rule
+from ezrules.core.rule import OutcomeReturnSyntaxError, ReservedRuleIdentifierError, Rule
 from ezrules.core.rule_checkers import AllowedOutcomeReturnVisitor
 from ezrules.core.rule_helpers import OutcomeReferenceExtractor, UserListReferenceExtractor
 from ezrules.core.rule_updater import RULE_EVALUATION_LANE_ALLOWLIST, RULE_EVALUATION_LANE_MAIN
@@ -234,6 +234,27 @@ def validate_rule_source(
                 referenced_features=referenced_features,
                 warnings=warnings,
                 errors=[],
+            ),
+        )
+    except ReservedRuleIdentifierError as exc:
+        return RuleValidationResult(
+            compiled_rule=None,
+            response=RuleVerifyResponse(
+                valid=False,
+                params=[],
+                referenced_lists=referenced_lists,
+                referenced_outcomes=referenced_outcomes,
+                referenced_features=referenced_features,
+                warnings=[],
+                errors=[
+                    build_verify_error(
+                        message=str(exc),
+                        line=exc.lineno,
+                        column=exc.offset,
+                        end_line=exc.end_lineno,
+                        end_column=exc.end_offset,
+                    )
+                ],
             ),
         )
     except OutcomeReturnSyntaxError as exc:

--- a/ezrules/backend/shadow_evaluation_queue.py
+++ b/ezrules/backend/shadow_evaluation_queue.py
@@ -9,7 +9,7 @@ from redis import Redis
 
 from ezrules.backend.runtime_settings import get_main_rule_execution_mode
 from ezrules.core.application_context import set_organization_id, set_user_list_manager
-from ezrules.core.rule_engine import RULE_EXECUTION_MODE_ALL_MATCHES, RuleEngineFactory
+from ezrules.core.rule_engine import RULE_EXECUTION_MODE_ALL_MATCHES, InvalidRuleResultError, RuleEngineFactory
 from ezrules.core.rule_updater import (
     DEPLOYMENT_MODE_SHADOW,
     DEPLOYMENT_VARIANT_CONTROL,
@@ -230,12 +230,20 @@ def drain_shadow_evaluation_queue(
                 break
 
             max_enqueue_lag_seconds = max(max_enqueue_lag_seconds, _max_enqueue_lag_seconds(payloads))
-            try:
-                for payload in payloads:
-                    _persist_shadow_results(json.loads(payload))
-            except Exception:
-                _requeue_payloads(payloads)
-                raise
+            for index, payload in enumerate(payloads):
+                try:
+                    parsed_payload = json.loads(payload)
+                    _persist_shadow_results(parsed_payload)
+                except (InvalidRuleResultError, SyntaxError):
+                    logger.exception(
+                        "Dropping shadow evaluation with an invalid rule contract for event_id=%s org_id=%s",
+                        parsed_payload.get("event_id"),
+                        parsed_payload.get("o_id"),
+                    )
+                    continue
+                except Exception:
+                    _requeue_payloads(payloads[index:])
+                    raise
 
             drained_batches += 1
             drained_messages += len(payloads)

--- a/ezrules/backend/tasks.py
+++ b/ezrules/backend/tasks.py
@@ -21,10 +21,11 @@ from ezrules.backend.rule_quality import (
     get_active_rule_quality_pairs,
     normalize_rule_quality_pairs,
 )
+from ezrules.backend.rule_validation import compile_validated_rule_source
 from ezrules.backend.shadow_evaluation_queue import drain_shadow_evaluation_queue
 from ezrules.backend.utils import load_cast_configs
 from ezrules.core.application_context import set_organization_id, set_user_list_manager
-from ezrules.core.rule import Rule, RuleFactory
+from ezrules.core.rule import RuleFactory
 from ezrules.core.user_lists import PersistentUserListManager
 from ezrules.models.backend_core import (
     EvaluationDecision,
@@ -197,7 +198,7 @@ def execute_backtest_rule_change(
             return payload
 
         try:
-            proposed_rule = Rule(rid="", logic=proposed_logic, list_values_provider=list_provider)
+            proposed_rule = compile_validated_rule_source(db_session, org_id, proposed_logic)
         except Exception as e:
             payload = {"error": f"Failed to compile proposed rule logic: {e!s}"}
             if task_id is not None:

--- a/ezrules/core/rule.py
+++ b/ezrules/core/rule.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 import io
 import tokenize
 from collections.abc import Callable
@@ -83,10 +84,11 @@ class Rule:
     def compile_function(code: str) -> tuple[Callable, ast.Module]:
         rule_ast = ast.parse(code)
         OutcomeReturnSyntaxValidator().visit(rule_ast)
-        compiled_code = compile(rule_ast, filename="<string>", mode="exec")
+        runtime_ast = OutcomeHelperCallLowerer().visit(copy.deepcopy(rule_ast))
+        ast.fix_missing_locations(runtime_ast)
+        compiled_code = compile(runtime_ast, filename="<string>", mode="exec")
         namespace = {
             FIELD_LOOKUP_HELPER_NAME: get_field_value,
-            OUTCOME_HELPER_NAME: lambda outcome: outcome,
             STAT_LOOKUP_HELPER_NAME: get_stat_value,
         }
         exec(compiled_code, namespace)
@@ -459,3 +461,13 @@ class OutcomeReturnSyntaxValidator(ast.NodeVisitor):
     def _guess_outcome_name(self, node: ast.AST) -> str:
         inferred_value = self._infer_string_like_value(node)
         return inferred_value if isinstance(inferred_value, str) else ""
+
+
+class OutcomeHelperCallLowerer(ast.NodeTransformer):
+    """Replace validated DSL outcome calls with immutable runtime constants."""
+
+    def visit_Call(self, node: ast.Call) -> Any:
+        outcome = extract_outcome_helper_value(node)
+        if outcome is not None:
+            return ast.copy_location(ast.Constant(value=outcome), node)
+        return self.generic_visit(node)

--- a/ezrules/core/rule.py
+++ b/ezrules/core/rule.py
@@ -1,4 +1,6 @@
 import ast
+import io
+import tokenize
 from collections.abc import Callable
 from typing import Any, NamedTuple
 
@@ -93,6 +95,7 @@ class Rule:
     @logic.setter
     def logic(self, logic):
         """Compile the code."""
+        validate_reserved_rule_identifiers(logic)
         # Build a fresh converter per compilation to avoid shared parser state
         # across concurrent API requests.
         post_proc_logic = DollarNotationConverter().transform_rule(logic)
@@ -241,6 +244,50 @@ class OutcomeReturnSyntaxError(SyntaxError):
         super().__init__(message)
 
 
+class RuleGeneratorSyntaxError(OutcomeReturnSyntaxError):
+    """Raised when the outer rule body contains generator syntax."""
+
+    def __init__(self, line: int, column: int, end_column: int):
+        self.outcome_name = ""
+        self.lineno = line
+        self.offset = column
+        self.end_lineno = line
+        self.end_offset = end_column
+        SyntaxError.__init__(
+            self,
+            "Rules cannot use `yield` or `yield from`; return `None` or a direct configured `!OUTCOME`.",
+        )
+
+
+class ReservedRuleIdentifierError(SyntaxError):
+    """Raised when user source references a helper reserved for DSL conversion."""
+
+    def __init__(self, identifier: str, line: int, column: int, end_column: int):
+        self.identifier = identifier
+        self.lineno = line
+        self.offset = column
+        self.end_lineno = line
+        self.end_offset = end_column
+        super().__init__(f"Identifier '{identifier}' is reserved; use direct `return !OUTCOME` syntax.")
+
+
+def validate_reserved_rule_identifiers(rule_source: str) -> None:
+    """Reject executable references to internal helpers before DSL conversion introduces them."""
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(rule_source).readline)
+        for token in tokens:
+            if token.type == tokenize.NAME and token.string == OUTCOME_HELPER_NAME:
+                raise ReservedRuleIdentifierError(
+                    identifier=token.string,
+                    line=token.start[0],
+                    column=token.start[1] + 1,
+                    end_column=token.end[1] + 1,
+                )
+    except (IndentationError, tokenize.TokenError):
+        # Compilation reports malformed source with the existing structured diagnostics.
+        return
+
+
 class RuleReturnContractValidator(ast.NodeVisitor):
     """Validate the result boundary applied to persisted and deployed rules."""
 
@@ -277,6 +324,21 @@ class RuleReturnContractValidator(ast.NodeVisitor):
             line=node.value.lineno,
             column=node.value.col_offset + 1,
             end_column=node.value.end_col_offset or (node.value.col_offset + 1),
+        )
+
+    def visit_Yield(self, node: ast.Yield) -> Any:
+        return self._reject_outer_generator_syntax(node)
+
+    def visit_YieldFrom(self, node: ast.YieldFrom) -> Any:
+        return self._reject_outer_generator_syntax(node)
+
+    def _reject_outer_generator_syntax(self, node: ast.Yield | ast.YieldFrom) -> Any:
+        if self._function_depth != 1:
+            return node
+        raise RuleGeneratorSyntaxError(
+            line=node.lineno,
+            column=node.col_offset + 1,
+            end_column=node.end_col_offset or (node.col_offset + 1),
         )
 
 

--- a/ezrules/core/rule.py
+++ b/ezrules/core/rule.py
@@ -125,6 +125,10 @@ class Rule:
     def get_rule_stats(self):
         return set(self._rule_stats)
 
+    def validate_return_contract(self) -> None:
+        """Require every explicit result to be either ``None`` or a direct outcome."""
+        RuleReturnContractValidator().visit(self._rule_ast)
+
     def __call__(self, t, stats: dict[str, Any] | None = None) -> Any:
         """Executes rule logic."""
         try:
@@ -233,8 +237,47 @@ class OutcomeReturnSyntaxError(SyntaxError):
         if outcome_name:
             message = f"Use return !{outcome_name} instead of indirect or quoted outcome returns."
         else:
-            message = "Outcome returns must use direct `return !OUTCOME` syntax."
+            message = "Rules may return only `None` or a direct configured outcome using `return !OUTCOME`."
         super().__init__(message)
+
+
+class RuleReturnContractValidator(ast.NodeVisitor):
+    """Validate the result boundary applied to persisted and deployed rules."""
+
+    def __init__(self) -> None:
+        self._function_depth = 0
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
+        self._function_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._function_depth -= 1
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
+        self._function_depth += 1
+        try:
+            self.generic_visit(node)
+        finally:
+            self._function_depth -= 1
+        return node
+
+    def visit_Return(self, node: ast.Return) -> Any:
+        if self._function_depth != 1:
+            return node
+        if node.value is None:
+            return node
+        if isinstance(node.value, ast.Constant) and node.value.value is None:
+            return node
+        if extract_outcome_helper_value(node.value) is not None:
+            return node
+        raise OutcomeReturnSyntaxError(
+            outcome_name="",
+            line=node.value.lineno,
+            column=node.value.col_offset + 1,
+            end_column=node.value.end_col_offset or (node.value.col_offset + 1),
+        )
 
 
 class OutcomeReturnSyntaxValidator(ast.NodeVisitor):

--- a/ezrules/core/rule_engine.py
+++ b/ezrules/core/rule_engine.py
@@ -27,6 +27,22 @@ class InvalidRuleResultError(TypeError):
     """Raised when a rule returns a value that cannot represent an outcome."""
 
 
+def validate_rule_result(rule_identifier: RuleIdentifier, rule_result: Any) -> str | None:
+    """Return a valid outcome result or reject values that cannot be aggregated."""
+    if rule_result is None:
+        return None
+    if not isinstance(rule_result, str):
+        raise InvalidRuleResultError(
+            f"Rule {rule_identifier!r} returned {type(rule_result).__name__}; "
+            "expected None or a non-empty outcome string"
+        )
+    if not rule_result:
+        raise InvalidRuleResultError(
+            f"Rule {rule_identifier!r} returned an empty outcome string; expected None or a non-empty outcome string"
+        )
+    return rule_result
+
+
 class RuleEngine:
     """Main class for executing a set of :class:`core.rule.Rule` objects. It
     is defined as a set of rules and the way the results are aggregated. The ways the results are
@@ -59,22 +75,6 @@ class RuleEngine:
     def _rule_identifier(rule: Rule) -> RuleIdentifier:
         return rule.r_id if rule.r_id is not None else rule.rid
 
-    @staticmethod
-    def _validate_rule_result(rule_identifier: RuleIdentifier, rule_result: Any) -> str | None:
-        if rule_result is None:
-            return None
-        if not isinstance(rule_result, str):
-            raise InvalidRuleResultError(
-                f"Rule {rule_identifier!r} returned {type(rule_result).__name__}; "
-                "expected None or a non-empty outcome string"
-            )
-        if not rule_result:
-            raise InvalidRuleResultError(
-                f"Rule {rule_identifier!r} returned an empty outcome string; "
-                "expected None or a non-empty outcome string"
-            )
-        return rule_result
-
     def get_rule_stats(self) -> set[str]:
         stat_paths: set[str] = set()
         for rule in self.rules:
@@ -93,7 +93,7 @@ class RuleEngine:
         all_rule_results: dict[RuleIdentifier, str | None] = {}
         for rule in self.rules:
             rule_id = self._rule_identifier(rule)
-            rule_result = self._validate_rule_result(rule_id, rule(t, stats=stats))
+            rule_result = validate_rule_result(rule_id, rule(t, stats=stats))
             all_rule_results[rule_id] = rule_result
             if self.execution_mode == RULE_EXECUTION_MODE_FIRST_MATCH and rule_result is not None:
                 break

--- a/ezrules/core/rule_engine.py
+++ b/ezrules/core/rule_engine.py
@@ -1,11 +1,30 @@
 from collections import Counter
-from typing import Any
+from typing import Any, TypedDict
 
 from ezrules.core.rule import Rule, RuleFactory
 from ezrules.core.user_lists import AbstractUserListManager
 
 RULE_EXECUTION_MODE_ALL_MATCHES = "all_matches"
 RULE_EXECUTION_MODE_FIRST_MATCH = "first_match"
+RULE_EXECUTION_MODES = frozenset(
+    {
+        RULE_EXECUTION_MODE_ALL_MATCHES,
+        RULE_EXECUTION_MODE_FIRST_MATCH,
+    }
+)
+
+RuleIdentifier = int | str
+
+
+class RuleEngineResult(TypedDict):
+    rule_results: dict[RuleIdentifier, str]
+    all_rule_results: dict[RuleIdentifier, str | None]
+    outcome_counters: dict[str, int]
+    outcome_set: list[str]
+
+
+class InvalidRuleResultError(TypeError):
+    """Raised when a rule returns a value that cannot represent an outcome."""
 
 
 class RuleEngine:
@@ -23,8 +42,38 @@ class RuleEngine:
         :param rules: list of :class:`core.rule.Rule`
         :param result_aggregation: a member of :class:`core.rule_engine.ResultAggregation`
         """
+        if execution_mode not in RULE_EXECUTION_MODES:
+            raise ValueError(f"Unknown rule execution mode: {execution_mode!r}")
+
+        seen_identifiers: set[RuleIdentifier] = set()
+        for rule in rules:
+            identifier = self._rule_identifier(rule)
+            if identifier in seen_identifiers:
+                raise ValueError(f"Duplicate rule identifier: {identifier!r}")
+            seen_identifiers.add(identifier)
+
         self.rules = rules
         self.execution_mode = execution_mode
+
+    @staticmethod
+    def _rule_identifier(rule: Rule) -> RuleIdentifier:
+        return rule.r_id if rule.r_id is not None else rule.rid
+
+    @staticmethod
+    def _validate_rule_result(rule_identifier: RuleIdentifier, rule_result: Any) -> str | None:
+        if rule_result is None:
+            return None
+        if not isinstance(rule_result, str):
+            raise InvalidRuleResultError(
+                f"Rule {rule_identifier!r} returned {type(rule_result).__name__}; "
+                "expected None or a non-empty outcome string"
+            )
+        if not rule_result:
+            raise InvalidRuleResultError(
+                f"Rule {rule_identifier!r} returned an empty outcome string; "
+                "expected None or a non-empty outcome string"
+            )
+        return rule_result
 
     def get_rule_stats(self) -> set[str]:
         stat_paths: set[str] = set()
@@ -32,7 +81,7 @@ class RuleEngine:
             stat_paths.update(rule.get_rule_stats())
         return stat_paths
 
-    def __call__(self, t: dict, stats: dict[str, Any] | None = None) -> Any:
+    def __call__(self, t: dict, stats: dict[str, Any] | None = None) -> RuleEngineResult:
         """
         Execute the rules and aggregated the results.
 
@@ -41,17 +90,17 @@ class RuleEngine:
         checks will be in place.
         :return: aggregated results, either as a list of unique decisions, or a counter for each decision.
         """
-        all_rule_results: dict[Any, Any] = {}
+        all_rule_results: dict[RuleIdentifier, str | None] = {}
         for rule in self.rules:
-            rule_id = rule.r_id or rule.rid
-            rule_result = rule(t, stats=stats)
+            rule_id = self._rule_identifier(rule)
+            rule_result = self._validate_rule_result(rule_id, rule(t, stats=stats))
             all_rule_results[rule_id] = rule_result
             if self.execution_mode == RULE_EXECUTION_MODE_FIRST_MATCH and rule_result is not None:
                 break
         rule_results = {r: res for r, res in all_rule_results.items() if res is not None}
         outcome_counters = dict(Counter(rule_results.values()))
         outcome_set = sorted(set(outcome_counters.keys()))
-        results = {
+        results: RuleEngineResult = {
             "rule_results": rule_results,
             "all_rule_results": all_rule_results,
             "outcome_counters": outcome_counters,

--- a/ezrules/core/rule_updater.py
+++ b/ezrules/core/rule_updater.py
@@ -1,6 +1,7 @@
 import datetime
 from abc import ABC, abstractmethod
 from collections import namedtuple
+from collections.abc import Callable
 from typing import Any, cast
 
 from sqlalchemy.exc import NoResultFound
@@ -442,6 +443,7 @@ def promote_candidate_deployment_to_production(
     label: str,
     changed_by: str | None = None,
     approved_by: int | None = None,
+    validate_candidate: Callable[[dict[str, Any]], None] | None = None,
 ) -> None:
     config_obj = get_deployment_config(db, o_id=o_id, label=label, for_update=True)
     if config_obj is None:
@@ -454,6 +456,17 @@ def promote_candidate_deployment_to_production(
     rule = db.query(RuleModel).filter(RuleModel.r_id == r_id, RuleModel.o_id == o_id).first()
     if rule is None:
         raise ValueError(f"Rule {r_id} does not exist")
+
+    try:
+        candidate_rule = RuleFactory.from_json(
+            deployment_entry,
+            list_values_provider=PersistentUserListManager(db_session=db, o_id=o_id),
+        )
+        candidate_rule.validate_return_contract()
+    except (KeyError, SyntaxError) as exc:
+        raise ValueError(f"Invalid {label} candidate rule: {exc!s}") from exc
+    if validate_candidate is not None:
+        validate_candidate(deployment_entry)
 
     promoted_at = datetime.datetime.now(datetime.UTC)
     save_rule_history(
@@ -522,6 +535,7 @@ def promote_shadow_rule_to_production(
     r_id: int,
     changed_by: str | None = None,
     approved_by: int | None = None,
+    validate_candidate: Callable[[dict[str, Any]], None] | None = None,
 ) -> None:
     """Promote a rule from the shadow config into the production config.
 
@@ -534,6 +548,7 @@ def promote_shadow_rule_to_production(
         label=SHADOW_CONFIG_LABEL,
         changed_by=changed_by,
         approved_by=approved_by,
+        validate_candidate=validate_candidate,
     )
 
 

--- a/ezrules/core/rule_updater.py
+++ b/ezrules/core/rule_updater.py
@@ -583,6 +583,7 @@ def promote_rollout_rule_to_production(
     r_id: int,
     changed_by: str | None = None,
     approved_by: int | None = None,
+    validate_candidate: Callable[[dict[str, Any]], None] | None = None,
 ) -> None:
     promote_candidate_deployment_to_production(
         db=db,
@@ -591,6 +592,7 @@ def promote_rollout_rule_to_production(
         label=ROLLOUT_CONFIG_LABEL,
         changed_by=changed_by,
         approved_by=approved_by,
+        validate_candidate=validate_candidate,
     )
 
 

--- a/ezrules/core/rule_updater.py
+++ b/ezrules/core/rule_updater.py
@@ -120,12 +120,24 @@ class RDBRuleManager(RuleManager):
         self.db = db
         self.o_id = o_id
 
-    def _save_rule(self, rule: RuleModel) -> None:
+    def stage_rule(self, rule: RuleModel) -> None:
+        """Validate and flush a rule without committing its production config separately."""
+        if rule.status == RuleStatus.ACTIVE:
+            with self.db.no_autoflush:
+                compiled_rule = RuleFactory.from_json(
+                    rule.__dict__,
+                    list_values_provider=PersistentUserListManager(db_session=self.db, o_id=self.o_id),
+                )
+                compiled_rule.validate_return_contract()
         if rule.r_id is None:
             rule.o_id = self.o_id
             self.db.add(rule)
         else:
             rule.version += 1
+        self.db.flush()
+
+    def _save_rule(self, rule: RuleModel) -> None:
+        self.stage_rule(rule)
         self.db.commit()
 
     def get_rule_revision_list(self, rule: Rule, return_dates=False) -> list[RuleRevision]:
@@ -199,6 +211,8 @@ class RDBRuleEngineConfigProducer(AbstractRuleEngineConfigProducer):
                 key=lambda rule: (int(rule.execution_order), int(rule.r_id)),
             )
         compiled_rules = [RuleFactory.from_json(r.__dict__, list_values_provider=list_provider) for r in active_rules]
+        for compiled_rule in compiled_rules:
+            compiled_rule.validate_return_contract()
         return [RuleConverter.to_json(r) for r in compiled_rules]
 
     def _save_rules_for_label(
@@ -453,7 +467,13 @@ def promote_candidate_deployment_to_production(
     if deployment_entry is None:
         raise ValueError(f"Rule {r_id} is not in {label} config")
 
-    rule = db.query(RuleModel).filter(RuleModel.r_id == r_id, RuleModel.o_id == o_id).first()
+    rule = (
+        db.query(RuleModel)
+        .filter(RuleModel.r_id == r_id, RuleModel.o_id == o_id)
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
     if rule is None:
         raise ValueError(f"Rule {r_id} does not exist")
 

--- a/ezrules/frontend/e2e/tests/rule-logic-editor.spec.ts
+++ b/ezrules/frontend/e2e/tests/rule-logic-editor.spec.ts
@@ -25,7 +25,7 @@ test.describe('Rule Logic Editor', () => {
     await request.post(`${API_BASE}/api/v2/rules/test`, {
       headers: authHeaders,
       data: {
-        rule_source: 'return True',
+        rule_source: 'return None',
         test_json: '{"editor_amount_signal": 1250}',
       },
     });
@@ -73,7 +73,7 @@ test.describe('Rule Logic Editor', () => {
       data: {
         rid: `EDITOR_DETAIL_${Date.now()}`,
         description: 'rule editor detail validation test',
-        logic: 'return True',
+        logic: 'return None',
       },
     });
     expect(createResponse.ok()).toBeTruthy();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.29.0"
+version = "1.29.1"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/canonical_helpers.py
+++ b/tests/canonical_helpers.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 from ezrules.models.backend_core import (
+    AllowedOutcome,
     EvaluationDecision,
     EvaluationRuleResult,
     EventVersion,
@@ -11,6 +12,21 @@ from ezrules.models.backend_core import (
     Label,
     TransactionCurrentVersion,
 )
+
+
+def ensure_allowed_outcomes(session, *, org_id: int, outcome_names: list[str]) -> None:
+    existing = {
+        str(outcome.outcome_name): int(outcome.severity_rank)
+        for outcome in session.query(AllowedOutcome).filter(AllowedOutcome.o_id == org_id).all()
+    }
+    next_rank = max(existing.values(), default=0) + 1
+    for outcome_name in outcome_names:
+        if outcome_name in existing:
+            continue
+        session.add(AllowedOutcome(outcome_name=outcome_name, severity_rank=next_rank, o_id=org_id))
+        existing[outcome_name] = next_rank
+        next_rank += 1
+    session.commit()
 
 
 def _hash_payload(event_data: dict[str, Any]) -> str:

--- a/tests/test_api_v2_agent_tools.py
+++ b/tests/test_api_v2_agent_tools.py
@@ -9,12 +9,13 @@ from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import Label, Organisation, Role, User
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import add_served_decision
+from tests.canonical_helpers import add_served_decision, ensure_allowed_outcomes
 
 
 @pytest.fixture(scope="function")
 def agent_tools_client(session):
     org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD"])
     role = Role(
         name="agent_tools_viewer",
         description="Can use deterministic agent analysis tools",

--- a/tests/test_api_v2_agent_tools.py
+++ b/tests/test_api_v2_agent_tools.py
@@ -52,6 +52,7 @@ def agent_tools_client(session):
 @pytest.fixture(scope="function")
 def agent_tools_fixture(session):
     org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD"])
     fraud_label = Label(label="FRAUD", o_id=int(org.o_id))
     normal_label = Label(label="NORMAL", o_id=int(org.o_id))
     session.add_all([fraud_label, normal_label])

--- a/tests/test_api_v2_phase2_org_scope.py
+++ b/tests/test_api_v2_phase2_org_scope.py
@@ -23,13 +23,13 @@ from ezrules.models.backend_core import (
     OutcomeHistory,
     Role,
     Rule,
+    RuleDeploymentResultsLog,
     RuleEngineConfig,
     RuleEngineConfigHistory,
     RuleHistory,
     RuleQualityPair,
     RuleQualityReport,
     RuntimeSetting,
-    RuleDeploymentResultsLog,
     ShadowResultsLog,
     User,
     UserList,
@@ -170,19 +170,26 @@ def test_rules_use_auth_org_context_for_lists_and_rule_queries(session):
 
     _create_user_list(session, org_id=int(org.o_id), list_name="Phase2Countries", entries=["GB"])
     _create_user_list(session, org_id=int(other_org.o_id), list_name="Phase2Countries", entries=["US"])
+    session.add_all(
+        [
+            AllowedOutcome(outcome_name="HOLD", severity_rank=1, o_id=int(org.o_id)),
+            AllowedOutcome(outcome_name="HOLD", severity_rank=1, o_id=int(other_org.o_id)),
+        ]
+    )
+    session.commit()
 
     org_rule = _create_rule(
         session,
         org_id=int(org.o_id),
         rid="PHASE2:ORG1",
-        logic="return $amount > 10",
+        logic="if $amount > 10:\n    return !HOLD",
         description="Org 1 rule",
     )
     other_rule = _create_rule(
         session,
         org_id=int(other_org.o_id),
         rid="PHASE2:ORG2",
-        logic="return $amount > 10",
+        logic="if $amount > 10:\n    return !HOLD",
         description="Org 2 rule",
     )
 
@@ -213,7 +220,7 @@ def test_rules_use_auth_org_context_for_lists_and_rule_queries(session):
             "/api/v2/rules/test",
             headers=_auth_headers(user),
             json={
-                "rule_source": "return $country in @Phase2Countries",
+                "rule_source": "if $country in @Phase2Countries:\n    return !HOLD",
                 "test_json": '{"country": "GB"}',
             },
         )
@@ -221,7 +228,7 @@ def test_rules_use_auth_org_context_for_lists_and_rule_queries(session):
             "/api/v2/rules/test",
             headers=_auth_headers(other_user),
             json={
-                "rule_source": "return $country in @Phase2Countries",
+                "rule_source": "if $country in @Phase2Countries:\n    return !HOLD",
                 "test_json": '{"country": "GB"}',
             },
         )
@@ -230,9 +237,9 @@ def test_rules_use_auth_org_context_for_lists_and_rule_queries(session):
         history_response = client.get(f"/api/v2/rules/{org_rule.r_id}/history", headers=_auth_headers(user))
 
     assert org_test_response.status_code == 200
-    assert org_test_response.json()["rule_outcome"] == "True"
+    assert org_test_response.json()["rule_outcome"] == "HOLD"
     assert other_test_response.status_code == 200
-    assert other_test_response.json()["rule_outcome"] == "False"
+    assert other_test_response.json()["rule_outcome"] is None
 
     observations = (
         session.query(FieldObservation)
@@ -678,14 +685,14 @@ def test_audit_endpoints_only_return_current_org_history(session):
         session,
         org_id=int(org.o_id),
         rid="PHASE2:AUDIT:ORG1",
-        logic="return True",
+        logic="return None",
         description="Org 1 audit rule",
     )
     other_rule = _create_rule(
         session,
         org_id=int(other_org.o_id),
         rid="PHASE2:AUDIT:ORG2",
-        logic="return True",
+        logic="return None",
         description="Org 2 audit rule",
     )
 

--- a/tests/test_api_v2_phase2_org_scope.py
+++ b/tests/test_api_v2_phase2_org_scope.py
@@ -272,6 +272,13 @@ def test_shadow_routes_and_tested_events_are_org_scoped(session):
         email=_unique_email("phase2-shadow-admin"),
         permissions=[PermissionAction.VIEW_RULES, PermissionAction.MODIFY_RULE],
     )
+    session.add_all(
+        [
+            AllowedOutcome(outcome_name="ORG1_HOLD", severity_rank=1, o_id=int(org.o_id)),
+            AllowedOutcome(outcome_name="ORG2_REVIEW", severity_rank=1, o_id=int(other_org.o_id)),
+        ]
+    )
+    session.commit()
 
     org_rule = _create_rule(
         session,

--- a/tests/test_api_v2_rules.py
+++ b/tests/test_api_v2_rules.py
@@ -868,7 +868,7 @@ class TestTestRule:
     """Tests for POST /api/v2/rules/test."""
 
     def test_test_rule_success_true(self, rules_test_client):
-        """Should return True for matching rule."""
+        """Should return the configured outcome for a matching rule."""
         token = rules_test_client.test_data["token"]
 
         # Rules use $variable notation and need a return statement
@@ -876,7 +876,7 @@ class TestTestRule:
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": "return $amount > 100",
+                "rule_source": "if $amount > 100:\n    return !HOLD",
                 "test_json": '{"amount": 150}',
             },
         )
@@ -884,17 +884,17 @@ class TestTestRule:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
-        assert data["rule_outcome"] == "True"
+        assert data["rule_outcome"] == "HOLD"
 
     def test_test_rule_success_false(self, rules_test_client):
-        """Should return False for non-matching rule."""
+        """Should return no outcome for a non-matching rule."""
         token = rules_test_client.test_data["token"]
 
         response = rules_test_client.post(
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": "return $amount > 100",
+                "rule_source": "if $amount > 100:\n    return !HOLD",
                 "test_json": '{"amount": 50}',
             },
         )
@@ -902,7 +902,7 @@ class TestTestRule:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
-        assert data["rule_outcome"] == "False"
+        assert data["rule_outcome"] is None
 
     def test_test_rule_string_outcome(self, rules_test_client):
         """Should return string outcome for rules that return strings."""

--- a/tests/test_api_v2_shadow.py
+++ b/tests/test_api_v2_shadow.py
@@ -26,8 +26,9 @@ from ezrules.core.rule_updater import (
     RDBRuleManager,
     deploy_rule_to_shadow,
 )
-from ezrules.models.backend_core import AllowedOutcome, Organisation, Role, Rule as RuleModel
-from ezrules.models.backend_core import RuleEngineConfig, ShadowResultsLog, User
+from ezrules.models.backend_core import AllowedOutcome, Organisation, Role, RuleEngineConfig, ShadowResultsLog, User
+from ezrules.models.backend_core import Rule as RuleModel
+from tests.canonical_helpers import ensure_allowed_outcomes
 
 
 class FakeRedisLock:
@@ -89,7 +90,7 @@ class FakeRedis:
 @pytest.fixture(scope="function")
 def shadow_test_client(session):
     """Create a FastAPI test client with shadow-management and promotion permissions."""
-    hashed_password = bcrypt.hashpw("shadowpass".encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    hashed_password = bcrypt.hashpw(b"shadowpass", bcrypt.gensalt()).decode("utf-8")
 
     org = session.query(Organisation).filter(Organisation.o_id == 1).first()
     if not org:
@@ -169,6 +170,8 @@ def shadow_rule(session):
         org = Organisation(o_id=1, name="Test Org")
         session.add(org)
         session.commit()
+
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["REVIEW", "SHADOW_OUTCOME"])
 
     rule = RuleModel(
         rid="shadow_test_rule",
@@ -505,7 +508,7 @@ class TestPromoteFromShadow:
 
     def test_promote_rule_without_promote_permission_returns_403(self, session, shadow_rule):
         """MODIFY_RULE alone should not allow promoting a shadow rule."""
-        hashed_password = bcrypt.hashpw("shadownopromote".encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        hashed_password = bcrypt.hashpw(b"shadownopromote", bcrypt.gensalt()).decode("utf-8")
 
         role = session.query(Role).filter(Role.name == "shadow_modify_only").first()
         if not role:

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -191,7 +191,7 @@ class TestBacktestPostEndpoint:
             headers={"Authorization": f"Bearer {token}"},
             json={
                 "r_id": sample_rule_for_bt.r_id,
-                "new_rule_logic": "return True",
+                "new_rule_logic": "return !BLOCK",
             },
         )
 

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -10,7 +10,7 @@ from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import Organisation, Role, RuleBackTestingResult, User
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import add_served_decision
+from tests.canonical_helpers import add_served_decision, ensure_allowed_outcomes
 
 
 @pytest.fixture(scope="function")
@@ -84,6 +84,8 @@ def sample_rule_for_bt(session):
         org = Organisation(o_id=1, name="Test Org")
         session.add(org)
         session.commit()
+
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD", "BLOCK", "FLAG"])
 
     rule = RuleModel(
         rid="bt_rule_001",

--- a/tests/test_backtesting_controls.py
+++ b/tests/test_backtesting_controls.py
@@ -10,7 +10,7 @@ from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import Organisation, Role, RuleBackTestingResult, User
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import add_served_decision
+from tests.canonical_helpers import add_served_decision, ensure_allowed_outcomes
 
 
 def _ensure_org(session) -> Organisation:
@@ -19,6 +19,7 @@ def _ensure_org(session) -> Organisation:
         org = Organisation(o_id=1, name="Backtesting Controls Org")
         session.add(org)
         session.commit()
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD", "BLOCK", "IGNORE"])
     return org
 
 

--- a/tests/test_backtesting_features.py
+++ b/tests/test_backtesting_features.py
@@ -5,10 +5,10 @@ from datetime import UTC, datetime
 import pytest
 from fastapi.testclient import TestClient
 
-from ezrules.backend.backtesting import BacktestRecord, compute_backtest_metrics
-from ezrules.backend.features import FeatureResolver
 from ezrules.backend.api_v2.main import app
 from ezrules.backend.api_v2.routes import evaluator as evaluator_router
+from ezrules.backend.backtesting import BacktestRecord, compute_backtest_metrics
+from ezrules.backend.features import FeatureResolver
 from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
 from ezrules.backend.tasks import app as celery_app
 from ezrules.backend.tasks import backtest_rule_change, execute_backtest_rule_change
@@ -16,7 +16,7 @@ from ezrules.core.rule import Rule
 from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager
 from ezrules.models.backend_core import EventVersion, FeatureDefinition, FeatureSnapshotResolution, Organisation
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import _hash_payload, add_served_decision
+from tests.canonical_helpers import _hash_payload, add_served_decision, ensure_allowed_outcomes
 
 
 def _ensure_org(session) -> Organisation:
@@ -25,6 +25,7 @@ def _ensure_org(session) -> Organisation:
         org = Organisation(o_id=1, name="Test Org")
         session.add(org)
         session.commit()
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD", "PASS"])
     return org
 
 

--- a/tests/test_backtesting_guardrails.py
+++ b/tests/test_backtesting_guardrails.py
@@ -1,6 +1,6 @@
-import bcrypt
 import time
 
+import bcrypt
 import pytest
 from fastapi.testclient import TestClient
 
@@ -12,7 +12,7 @@ from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import FieldTypeConfig, Organisation, Role, User
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import add_served_decision
+from tests.canonical_helpers import add_served_decision, ensure_allowed_outcomes
 
 
 def _get_or_create_org(session):
@@ -21,6 +21,7 @@ def _get_or_create_org(session):
         org = Organisation(o_id=1, name="Test Org")
         session.add(org)
         session.commit()
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD", "BLOCK"])
     return org
 
 
@@ -48,7 +49,7 @@ def backtest_guardrail_client(session):
     celery_app.conf.task_eager_propagates = True
     celery_app.conf.task_store_eager_result = True
 
-    hashed_password = bcrypt.hashpw("guardrailpass".encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    hashed_password = bcrypt.hashpw(b"guardrailpass", bcrypt.gensalt()).decode("utf-8")
     org = _get_or_create_org(session)
 
     role = session.query(Role).filter(Role.name == "backtest_guardrail_manager").first()

--- a/tests/test_backtesting_missing_field_regression.py
+++ b/tests/test_backtesting_missing_field_regression.py
@@ -1,11 +1,12 @@
 from ezrules.backend.tasks import backtest_rule_change
 from ezrules.models.backend_core import Organisation
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import add_served_decision
+from tests.canonical_helpers import add_served_decision, ensure_allowed_outcomes
 
 
 def test_backtest_skips_records_when_proposed_score_field_never_appeared_in_history(session):
     org = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD"])
     rule = RuleModel(
         rid="BT_SCORE_REGRESSION_001",
         logic="if $amount > 100:\n\treturn !HOLD",

--- a/tests/test_backtesting_quality_metrics.py
+++ b/tests/test_backtesting_quality_metrics.py
@@ -10,7 +10,7 @@ from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.models.backend_core import Label, Organisation, Role, RuleBackTestingResult, User
 from ezrules.models.backend_core import Rule as RuleModel
-from tests.canonical_helpers import add_served_decision
+from tests.canonical_helpers import add_served_decision, ensure_allowed_outcomes
 
 
 @pytest.fixture(scope="function")
@@ -70,6 +70,8 @@ def labeled_backtest_fixture(session):
         org = Organisation(o_id=1, name="Backtesting Quality Org")
         session.add(org)
         session.commit()
+
+    ensure_allowed_outcomes(session, org_id=int(org.o_id), outcome_names=["HOLD", "BLOCK"])
 
     fraud_label = Label(label="FRAUD", o_id=int(org.o_id))
     normal_label = Label(label="NORMAL", o_id=int(org.o_id))

--- a/tests/test_cast_integration.py
+++ b/tests/test_cast_integration.py
@@ -16,8 +16,7 @@ from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
 from ezrules.core.permissions import PermissionManager
 from ezrules.core.permissions_constants import PermissionAction
 from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager
-from ezrules.models.backend_core import FieldTypeConfig, Organisation, Role, Rule, User
-
+from ezrules.models.backend_core import AllowedOutcome, FieldTypeConfig, Organisation, Role, Rule, User
 
 # =============================================================================
 # SHARED HELPERS
@@ -49,6 +48,14 @@ def rules_client(session):
     hashed = bcrypt.hashpw("castpass".encode(), bcrypt.gensalt()).decode()
 
     org = _get_or_create_org(session)
+    if (
+        session.query(AllowedOutcome)
+        .filter(AllowedOutcome.o_id == int(org.o_id), AllowedOutcome.outcome_name == "HOLD")
+        .first()
+        is None
+    ):
+        session.add(AllowedOutcome(outcome_name="HOLD", severity_rank=1, o_id=int(org.o_id)))
+        session.commit()
 
     role = session.query(Role).filter(Role.name == "cast_tester", Role.o_id == org.o_id).first()
     if not role:
@@ -173,7 +180,7 @@ class TestRulesTestCasting:
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": "return $score > 0.5",
+                "rule_source": "if $score > 0.5:\n    return !HOLD",
                 "test_json": '{"score": "0.9"}',
             },
         )
@@ -181,7 +188,7 @@ class TestRulesTestCasting:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
-        assert data["rule_outcome"] == "True"
+        assert data["rule_outcome"] == "HOLD"
 
     def test_rules_test_cast_error_returns_error_status(self, rules_client, session):
         """An unparseable value for a configured type returns status='error'."""
@@ -196,7 +203,7 @@ class TestRulesTestCasting:
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": "return $amount > 100",
+                "rule_source": "if $amount > 100:\n    return !HOLD",
                 "test_json": '{"amount": "not-a-number"}',
             },
         )
@@ -214,7 +221,7 @@ class TestRulesTestCasting:
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": "return $amount > 100",
+                "rule_source": "if $amount > 100:\n    return !HOLD",
                 "test_json": '{"amount": 150}',
             },
         )
@@ -222,4 +229,4 @@ class TestRulesTestCasting:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
-        assert data["rule_outcome"] == "True"
+        assert data["rule_outcome"] == "HOLD"

--- a/tests/test_nested_rule_paths.py
+++ b/tests/test_nested_rule_paths.py
@@ -30,7 +30,7 @@ def test_verify_rule_returns_nested_params_and_suppresses_warning_for_observed_p
     session.commit()
 
     payload = verify_rule(
-        RuleVerifyRequest(rule_source="return $customer.profile.age >= 21"),
+        RuleVerifyRequest(rule_source="if $customer.profile.age >= 21:\n    return !HOLD"),
         user=None,
         _=None,
         current_org_id=int(org.o_id),
@@ -49,7 +49,7 @@ def test_rules_test_reports_missing_nested_lookup_with_full_path(session):
 
     payload = route_test_rule(
         RuleTestRequest(
-            rule_source="return $customer.profile.age >= 21",
+            rule_source="if $customer.profile.age >= 21:\n    return !HOLD",
             test_json='{"customer":{"profile":{}}}',
         ),
         user=None,

--- a/tests/test_proposed_rule_contract.py
+++ b/tests/test_proposed_rule_contract.py
@@ -1,0 +1,103 @@
+# ruff: noqa: F811
+
+import pytest
+
+from ezrules.backend import agent_tools
+from ezrules.backend.api_v2.routes import agent_tools as agent_tools_routes
+from ezrules.backend.api_v2.routes import backtesting as backtesting_routes
+from ezrules.backend.tasks import execute_backtest_rule_change
+from ezrules.models.backend_core import RuleBackTestingResult
+from tests.test_api_v2_agent_tools import (  # noqa: F401
+    agent_tools_client,
+    agent_tools_fixture,
+)
+from tests.test_backtesting import (  # noqa: F401
+    backtesting_test_client,
+    sample_rule_for_bt,
+)
+
+INVALID_PREDICATE_RETURN = "return $amount > 100"
+
+
+def test_backtest_route_rejects_predicate_return_before_queueing(
+    backtesting_test_client,
+    sample_rule_for_bt,
+    monkeypatch,
+) -> None:
+    session = backtesting_test_client.test_data["session"]
+    token = backtesting_test_client.test_data["token"]
+    result_count = session.query(RuleBackTestingResult).count()
+
+    def fail_if_queued(*args, **kwargs):
+        raise AssertionError("invalid proposal reached the backtest queue")
+
+    monkeypatch.setattr(backtesting_routes, "_enqueue_backtest", fail_if_queued)
+
+    response = backtesting_test_client.post(
+        "/api/v2/backtesting",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "r_id": sample_rule_for_bt.r_id,
+            "new_rule_logic": INVALID_PREDICATE_RETURN,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "direct configured outcome" in response.json()["detail"]
+    assert session.query(RuleBackTestingResult).count() == result_count
+
+
+def test_backtest_worker_rejects_predicate_return_before_metrics(session, sample_rule_for_bt) -> None:
+    result = execute_backtest_rule_change(
+        int(sample_rule_for_bt.r_id),
+        INVALID_PREDICATE_RETURN,
+        int(sample_rule_for_bt.o_id),
+    )
+
+    assert set(result) == {"error"}
+    assert "direct configured outcome" in result["error"]
+
+
+def test_agent_tool_route_rejects_predicate_return_before_metrics(
+    agent_tools_client,
+    agent_tools_fixture,
+    monkeypatch,
+) -> None:
+    token = agent_tools_client.test_data["token"]
+    rule = agent_tools_fixture["rule"]
+
+    def fail_if_metrics_run(*args, **kwargs):
+        raise AssertionError("invalid proposal reached agent-tool metrics")
+
+    monkeypatch.setattr(agent_tools_routes, "build_blast_radius", fail_if_metrics_run)
+
+    response = agent_tools_client.post(
+        "/api/v2/agent-tools/rule-blast-radius",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "rule_id": int(rule.r_id),
+            "proposed_logic": INVALID_PREDICATE_RETURN,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "direct configured outcome" in response.json()["detail"]
+
+
+def test_agent_tool_internal_replay_rejects_predicate_return_before_metrics(
+    session,
+    agent_tools_fixture,
+) -> None:
+    rule = agent_tools_fixture["rule"]
+
+    with pytest.raises(ValueError, match="direct configured outcome"):
+        agent_tools.build_blast_radius(
+            session,
+            org_id=int(rule.o_id),
+            rule_id=int(rule.r_id),
+            proposed_logic=INVALID_PREDICATE_RETURN,
+            lookback_days=30,
+            group_by=[],
+            sample_limit=10,
+            max_records=100,
+        )

--- a/tests/test_rollout_rule_result_contract.py
+++ b/tests/test_rollout_rule_result_contract.py
@@ -1,0 +1,106 @@
+# ruff: noqa: F811
+
+import pytest
+
+from ezrules.backend.api_v2.routes.evaluator import _evaluate_rollout_result
+from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
+from ezrules.core.rule_engine import InvalidRuleResultError
+from ezrules.core.rule_updater import (
+    ROLLOUT_CONFIG_LABEL,
+    RDBRuleEngineConfigProducer,
+    RDBRuleManager,
+    deploy_rule_to_rollout,
+    list_candidate_deployments,
+)
+from ezrules.core.user_lists import PersistentUserListManager
+from ezrules.models.backend_core import RuleEngineConfig
+from tests.test_api_v2_rollouts import (  # noqa: F401
+    active_rollout_rule,
+    rollout_test_client,
+)
+
+
+def _evaluate_direct_rollout(session, active_rule, *, candidate_logic: str) -> tuple[dict, list[dict]]:
+    deploy_rule_to_rollout(
+        db=session,
+        o_id=int(active_rule.o_id),
+        rule_model=active_rule,
+        traffic_percent=100,
+        changed_by="contract-test",
+        logic_override=candidate_logic,
+        description_override="Candidate contract test",
+    )
+    lre = LocalRuleExecutorSQL(db=session, o_id=int(active_rule.o_id), label="production")
+    result, logs, _metadata = _evaluate_rollout_result(
+        event_data={"amount": 200},
+        lre=lre,
+        rollout_entries=list_candidate_deployments(session, int(active_rule.o_id), ROLLOUT_CONFIG_LABEL),
+        assignment_key="always-candidate",
+        list_provider=PersistentUserListManager(session, int(active_rule.o_id)),
+        stats={},
+    )
+    return result, logs
+
+
+def test_rollout_deployment_rejects_predicate_return(
+    rollout_test_client,
+    active_rollout_rule,
+) -> None:
+    token = rollout_test_client.test_data["token"]
+    session = rollout_test_client.test_data["session"]
+
+    response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout",
+        json={"logic": "return $amount > 100", "traffic_percent": 100},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400
+    assert "direct configured outcome" in response.json()["detail"]
+    rollout_config = (
+        session.query(RuleEngineConfig)
+        .filter(RuleEngineConfig.label == ROLLOUT_CONFIG_LABEL, RuleEngineConfig.o_id == active_rollout_rule.o_id)
+        .first()
+    )
+    assert rollout_config is None or rollout_config.config == []
+
+
+@pytest.mark.parametrize("candidate_logic", ["return $amount > 100", 'return ""'])
+def test_direct_rollout_invalid_candidate_result_falls_back_before_aggregation(
+    session,
+    rollout_test_client,
+    active_rollout_rule,
+    candidate_logic,
+) -> None:
+    result, logs = _evaluate_direct_rollout(session, active_rollout_rule, candidate_logic=candidate_logic)
+
+    assert result["outcome_counters"] == {"CONTROL": 1}
+    assert logs[0]["candidate_result"] is None
+    assert logs[0]["returned_result"] == "CONTROL"
+
+
+def test_direct_rollout_invalid_control_result_is_rejected(
+    session,
+    rollout_test_client,
+    active_rollout_rule,
+) -> None:
+    active_rollout_rule.logic = "return $amount > 100"
+    session.commit()
+    RDBRuleEngineConfigProducer(db=session, o_id=int(active_rollout_rule.o_id)).save_config(
+        RDBRuleManager(db=session, o_id=int(active_rollout_rule.o_id))
+    )
+
+    with pytest.raises(InvalidRuleResultError, match="returned bool"):
+        _evaluate_direct_rollout(session, active_rollout_rule, candidate_logic="return !CANDIDATE")
+
+
+def test_direct_rollout_valid_candidate_outcome_is_aggregated(
+    session,
+    rollout_test_client,
+    active_rollout_rule,
+) -> None:
+    result, logs = _evaluate_direct_rollout(session, active_rollout_rule, candidate_logic="return !CANDIDATE")
+
+    assert result["outcome_counters"] == {"CANDIDATE": 1}
+    assert logs[0]["candidate_result"] == "CANDIDATE"
+    assert logs[0]["returned_result"] == "CANDIDATE"

--- a/tests/test_rollout_rule_result_contract.py
+++ b/tests/test_rollout_rule_result_contract.py
@@ -31,6 +31,7 @@ def _evaluate_direct_rollout(session, active_rule, *, candidate_logic: str) -> t
         description_override="Candidate contract test",
     )
     lre = LocalRuleExecutorSQL(db=session, o_id=int(active_rule.o_id), label="production")
+    lre.get_rule_stats()
     result, logs, _metadata = _evaluate_rollout_result(
         event_data={"amount": 200},
         lre=lre,

--- a/tests/test_rollout_rule_result_contract.py
+++ b/tests/test_rollout_rule_result_contract.py
@@ -7,8 +7,6 @@ from ezrules.backend.rule_executors.executors import LocalRuleExecutorSQL
 from ezrules.core.rule_engine import InvalidRuleResultError
 from ezrules.core.rule_updater import (
     ROLLOUT_CONFIG_LABEL,
-    RDBRuleEngineConfigProducer,
-    RDBRuleManager,
     deploy_rule_to_rollout,
     list_candidate_deployments,
 )
@@ -85,11 +83,20 @@ def test_direct_rollout_invalid_control_result_is_rejected(
     rollout_test_client,
     active_rollout_rule,
 ) -> None:
-    active_rollout_rule.logic = "return $amount > 100"
-    session.commit()
-    RDBRuleEngineConfigProducer(db=session, o_id=int(active_rollout_rule.o_id)).save_config(
-        RDBRuleManager(db=session, o_id=int(active_rollout_rule.o_id))
+    production_config = (
+        session.query(RuleEngineConfig)
+        .filter(
+            RuleEngineConfig.label == "production",
+            RuleEngineConfig.o_id == active_rollout_rule.o_id,
+        )
+        .one()
     )
+    production_config.config = [
+        {**entry, "logic": "return $amount > 100"} if int(entry["r_id"]) == int(active_rollout_rule.r_id) else entry
+        for entry in production_config.config
+    ]
+    production_config.version += 1
+    session.commit()
 
     with pytest.raises(InvalidRuleResultError, match="returned bool"):
         _evaluate_direct_rollout(session, active_rollout_rule, candidate_logic="return !CANDIDATE")

--- a/tests/test_rule_activation_contract.py
+++ b/tests/test_rule_activation_contract.py
@@ -1,0 +1,188 @@
+# ruff: noqa: F811
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ezrules.core.rule import OutcomeReturnSyntaxError
+from ezrules.core.rule_updater import RDBRuleEngineConfigProducer, RDBRuleManager, save_rule_history
+from ezrules.models.backend_core import Rule as RuleModel
+from ezrules.models.backend_core import RuleEngineConfig, RuleHistory, RuleStatus
+from tests.test_api_v2_rules import rules_test_client  # noqa: F401
+
+
+def _auth_headers(client) -> dict[str, str]:
+    return {"Authorization": f"Bearer {client.test_data['token']}"}
+
+
+def _create_rule(session, *, rid: str, logic: str, status: RuleStatus) -> RuleModel:
+    rule = RuleModel(
+        rid=rid,
+        logic=logic,
+        description=f"Lifecycle contract for {rid}",
+        status=status,
+        effective_from=datetime.now(UTC) if status == RuleStatus.ACTIVE else None,
+        o_id=1,
+    )
+    session.add(rule)
+    session.commit()
+    return rule
+
+
+def _production_rule_ids(session) -> list[int]:
+    config = (
+        session.query(RuleEngineConfig)
+        .filter(RuleEngineConfig.label == "production", RuleEngineConfig.o_id == 1)
+        .one_or_none()
+    )
+    return [] if config is None else [int(entry["r_id"]) for entry in config.config]
+
+
+@pytest.mark.parametrize(
+    ("logic", "error_fragment"),
+    [
+        ("return $amount > 100", "direct configured outcome"),
+        ("return !LEGACY_UNKNOWN", "is not configured in Outcomes"),
+    ],
+)
+def test_legacy_invalid_draft_cannot_be_promoted(
+    rules_test_client,
+    logic: str,
+    error_fragment: str,
+) -> None:
+    session = rules_test_client.test_data["session"]
+    rule = _create_rule(session, rid="legacy_invalid_draft", logic=logic, status=RuleStatus.DRAFT)
+
+    response = rules_test_client.post(
+        f"/api/v2/rules/{rule.r_id}/promote",
+        headers=_auth_headers(rules_test_client),
+    )
+
+    assert response.status_code == 400
+    assert error_fragment in response.json()["detail"]
+    session.expire_all()
+    assert session.get(RuleModel, rule.r_id).status == RuleStatus.DRAFT
+    assert rule.r_id not in _production_rule_ids(session)
+    assert session.query(RuleHistory).filter(RuleHistory.r_id == rule.r_id).count() == 0
+
+
+def test_legacy_invalid_paused_rule_cannot_be_resumed(rules_test_client) -> None:
+    session = rules_test_client.test_data["session"]
+    rule = _create_rule(
+        session,
+        rid="legacy_invalid_paused",
+        logic="return $amount > 100",
+        status=RuleStatus.PAUSED,
+    )
+
+    response = rules_test_client.post(
+        f"/api/v2/rules/{rule.r_id}/resume",
+        headers=_auth_headers(rules_test_client),
+    )
+
+    assert response.status_code == 400
+    assert "direct configured outcome" in response.json()["detail"]
+    session.expire_all()
+    assert session.get(RuleModel, rule.r_id).status == RuleStatus.PAUSED
+    assert rule.r_id not in _production_rule_ids(session)
+    assert session.query(RuleHistory).filter(RuleHistory.r_id == rule.r_id).count() == 0
+
+
+def test_invalid_historical_revision_can_be_restored_as_draft_but_not_promoted(rules_test_client) -> None:
+    session = rules_test_client.test_data["session"]
+    rule = _create_rule(
+        session,
+        rid="legacy_invalid_history",
+        logic="return $amount > 100",
+        status=RuleStatus.ACTIVE,
+    )
+    save_rule_history(session, rule, changed_by="legacy-seed", action="updated", to_status=RuleStatus.ACTIVE)
+    rule.logic = "return !HOLD"
+    rule.version = 2
+    session.commit()
+    RDBRuleEngineConfigProducer(db=session, o_id=1).save_config(RDBRuleManager(db=session, o_id=1))
+
+    rollback_response = rules_test_client.post(
+        f"/api/v2/rules/{rule.r_id}/rollback",
+        json={"revision_number": 1},
+        headers=_auth_headers(rules_test_client),
+    )
+    promote_response = rules_test_client.post(
+        f"/api/v2/rules/{rule.r_id}/promote",
+        headers=_auth_headers(rules_test_client),
+    )
+
+    assert rollback_response.status_code == 200
+    assert promote_response.status_code == 400
+    assert "direct configured outcome" in promote_response.json()["detail"]
+    session.expire_all()
+    restored_rule = session.get(RuleModel, rule.r_id)
+    assert restored_rule.logic == "return $amount > 100"
+    assert restored_rule.status == RuleStatus.DRAFT
+    assert rule.r_id not in _production_rule_ids(session)
+
+
+@pytest.mark.parametrize(
+    ("initial_status", "endpoint"),
+    [
+        (RuleStatus.DRAFT, "promote"),
+        (RuleStatus.PAUSED, "resume"),
+    ],
+)
+def test_valid_lifecycle_activation_still_updates_production(
+    rules_test_client,
+    initial_status: RuleStatus,
+    endpoint: str,
+) -> None:
+    session = rules_test_client.test_data["session"]
+    rule = _create_rule(
+        session,
+        rid=f"valid_{endpoint}_control",
+        logic="return !HOLD",
+        status=initial_status,
+    )
+
+    response = rules_test_client.post(
+        f"/api/v2/rules/{rule.r_id}/{endpoint}",
+        headers=_auth_headers(rules_test_client),
+    )
+
+    assert response.status_code == 200
+    session.expire_all()
+    assert session.get(RuleModel, rule.r_id).status == RuleStatus.ACTIVE
+    assert rule.r_id in _production_rule_ids(session)
+
+
+def test_core_rule_manager_rejects_invalid_active_rule_before_commit(rules_test_client) -> None:
+    session = rules_test_client.test_data["session"]
+    rule = _create_rule(
+        session,
+        rid="core_activation_defense",
+        logic="return !HOLD",
+        status=RuleStatus.DRAFT,
+    )
+    rule.logic = "return $amount > 100"
+    rule.status = RuleStatus.ACTIVE
+
+    with pytest.raises(OutcomeReturnSyntaxError, match="direct configured outcome"):
+        RDBRuleManager(db=session, o_id=1).save_rule(rule)
+
+    session.rollback()
+    session.refresh(rule)
+    assert rule.logic == "return !HOLD"
+    assert rule.status == RuleStatus.DRAFT
+
+
+def test_core_config_producer_rejects_direct_legacy_active_rule(rules_test_client) -> None:
+    session = rules_test_client.test_data["session"]
+    rule = _create_rule(
+        session,
+        rid="direct_config_activation_defense",
+        logic="return $amount > 100",
+        status=RuleStatus.ACTIVE,
+    )
+
+    with pytest.raises(OutcomeReturnSyntaxError, match="direct configured outcome"):
+        RDBRuleEngineConfigProducer(db=session, o_id=1).save_config(RDBRuleManager(db=session, o_id=1))
+
+    assert rule.r_id not in _production_rule_ids(session)

--- a/tests/test_rule_engine_result_contract.py
+++ b/tests/test_rule_engine_result_contract.py
@@ -1,0 +1,156 @@
+from collections.abc import Callable
+from typing import Any, cast
+
+import pytest
+
+from ezrules.core.rule import Rule
+from ezrules.core.rule_engine import (
+    RULE_EXECUTION_MODE_FIRST_MATCH,
+    InvalidRuleResultError,
+    RuleEngine,
+)
+
+
+class StubRule:
+    def __init__(
+        self,
+        *,
+        r_id: int | None,
+        rid: str,
+        result: Any = None,
+        callback: Callable[[], Any] | None = None,
+    ) -> None:
+        self.r_id = r_id
+        self.rid = rid
+        self.result = result
+        self.callback = callback
+
+    def __call__(self, _event: dict[str, Any], *, stats: dict[str, Any] | None = None) -> Any:
+        del stats
+        return self.callback() if self.callback is not None else self.result
+
+    def get_rule_stats(self) -> set[str]:
+        return set()
+
+
+def build_engine(*rules: StubRule, execution_mode: str = "all_matches") -> RuleEngine:
+    return RuleEngine(rules=cast(list[Rule], list(rules)), execution_mode=execution_mode)
+
+
+def test_empty_rule_set_has_a_complete_stable_result_shape() -> None:
+    assert RuleEngine(rules=[])({}) == {
+        "rule_results": {},
+        "all_rule_results": {},
+        "outcome_counters": {},
+        "outcome_set": [],
+    }
+
+
+def test_all_nonmatches_are_retained_only_in_all_rule_results() -> None:
+    result = build_engine(
+        StubRule(r_id=1, rid="first", result=None),
+        StubRule(r_id=2, rid="second", result=None),
+    )({})
+
+    assert result == {
+        "rule_results": {},
+        "all_rule_results": {1: None, 2: None},
+        "outcome_counters": {},
+        "outcome_set": [],
+    }
+
+
+def test_zero_database_identifier_is_not_replaced_by_public_identifier() -> None:
+    result = build_engine(StubRule(r_id=0, rid="fallback", result="HOLD"))({})
+
+    assert result["rule_results"] == {0: "HOLD"}
+    assert result["all_rule_results"] == {0: "HOLD"}
+
+
+def test_duplicate_effective_rule_identifiers_are_rejected_before_execution() -> None:
+    calls: list[str] = []
+    rules = (
+        StubRule(r_id=7, rid="first", callback=lambda: calls.append("first")),
+        StubRule(r_id=7, rid="second", callback=lambda: calls.append("second")),
+    )
+
+    with pytest.raises(ValueError, match="Duplicate rule identifier: 7"):
+        build_engine(*rules)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("execution_mode", ["", "all", "FIRST_MATCH", "unknown"])
+def test_invalid_execution_modes_are_rejected(execution_mode: str) -> None:
+    with pytest.raises(ValueError, match=f"Unknown rule execution mode: {execution_mode!r}"):
+        build_engine(execution_mode=execution_mode)
+
+
+@pytest.mark.parametrize(
+    ("invalid_result", "rendered_type"),
+    [
+        (False, "bool"),
+        (0, "int"),
+        ([], "list"),
+        ({}, "dict"),
+        (set(), "set"),
+        (lambda: "HOLD", "function"),
+    ],
+)
+def test_non_outcome_rule_results_fail_before_aggregation(invalid_result: Any, rendered_type: str) -> None:
+    engine = build_engine(StubRule(r_id=4, rid="invalid", result=invalid_result))
+
+    with pytest.raises(
+        InvalidRuleResultError,
+        match=rf"Rule 4 returned {rendered_type}; expected None or a non-empty outcome string",
+    ):
+        engine({})
+
+
+def test_empty_string_rule_result_is_rejected() -> None:
+    engine = build_engine(StubRule(r_id=4, rid="invalid", result=""))
+
+    with pytest.raises(
+        InvalidRuleResultError,
+        match=r"Rule 4 returned an empty outcome string; expected None or a non-empty outcome string",
+    ):
+        engine({})
+
+
+def test_first_match_does_not_execute_rules_after_the_first_valid_outcome() -> None:
+    calls: list[str] = []
+    engine = build_engine(
+        StubRule(r_id=1, rid="miss", callback=lambda: calls.append("miss")),
+        StubRule(r_id=2, rid="hit", callback=lambda: calls.append("hit") or "HOLD"),
+        StubRule(r_id=3, rid="later", callback=lambda: calls.append("later") or "CANCEL"),
+        execution_mode=RULE_EXECUTION_MODE_FIRST_MATCH,
+    )
+
+    result = engine({})
+
+    assert calls == ["miss", "hit"]
+    assert result == {
+        "rule_results": {2: "HOLD"},
+        "all_rule_results": {1: None, 2: "HOLD"},
+        "outcome_counters": {"HOLD": 1},
+        "outcome_set": ["HOLD"],
+    }
+
+
+def test_rule_exception_aborts_without_executing_later_rules() -> None:
+    calls: list[str] = []
+
+    def fail() -> None:
+        calls.append("failing")
+        raise RuntimeError("rule exploded")
+
+    engine = build_engine(
+        StubRule(r_id=1, rid="first", callback=lambda: calls.append("first")),
+        StubRule(r_id=2, rid="failing", callback=fail),
+        StubRule(r_id=3, rid="later", callback=lambda: calls.append("later")),
+    )
+
+    with pytest.raises(RuntimeError, match="rule exploded"):
+        engine({})
+
+    assert calls == ["first", "failing"]

--- a/tests/test_rule_outcome_contract.py
+++ b/tests/test_rule_outcome_contract.py
@@ -1,0 +1,90 @@
+from typing import Any
+
+import pytest
+
+from ezrules.backend.rule_validation import validate_rule_source
+from ezrules.core.rule import OutcomeReturnSyntaxError, Rule
+from ezrules.models.backend_core import AllowedOutcome, FieldObservation
+
+
+@pytest.mark.parametrize(
+    ("logic", "event", "expected"),
+    [
+        ("pass", {}, None),
+        ("return", {}, None),
+        ("return None", {}, None),
+        ("return !HOLD", {}, "HOLD"),
+        ("return (!needs_review)", {}, "NEEDS_REVIEW"),
+        ("def eligible():\n    return True\nif eligible():\n    return !HOLD", {}, "HOLD"),
+        ("if $amount > 100:\n    return !HOLD\nreturn None", {"amount": 50}, None),
+        ("if $amount > 100:\n    return !HOLD\nreturn None", {"amount": 150}, "HOLD"),
+    ],
+)
+def test_rule_returns_accept_only_no_result_or_direct_outcome(
+    logic: str, event: dict[str, Any], expected: str | None
+) -> None:
+    rule = Rule(rid="contract", logic=logic)
+
+    rule.validate_return_contract()
+
+    assert rule(event) == expected
+
+
+@pytest.mark.parametrize(
+    "return_expression",
+    [
+        "True",
+        "False",
+        "0",
+        "-1",
+        "1.5",
+        '"HOLD"',
+        "[]",
+        "{}",
+        "set()",
+        'str("HOLD")',
+        't["outcome"]',
+        "f\"{t['outcome']}\"",
+        "[value for value in t.values()]",
+        "(outcome := None)",
+        "lambda: None",
+        "!HOLD if True else None",
+    ],
+)
+def test_rule_returns_reject_every_other_expression(return_expression: str) -> None:
+    with pytest.raises(OutcomeReturnSyntaxError, match="return !"):
+        Rule(rid="contract", logic=f"return {return_expression}").validate_return_contract()
+
+
+def test_rule_returns_reject_indirect_outcome_helpers() -> None:
+    with pytest.raises(OutcomeReturnSyntaxError, match="return !"):
+        Rule(rid="contract", logic="outcome = !HOLD\nreturn outcome").validate_return_contract()
+
+
+def test_persisted_rule_validation_accepts_configured_direct_outcomes(session) -> None:
+    session.add(AllowedOutcome(outcome_name="HOLD", severity_rank=1, o_id=1))
+    session.commit()
+
+    validation = validate_rule_source(session, 1, "if $amount > 100:\n    return !HOLD\nreturn None")
+
+    assert validation.compiled_rule is not None
+    assert validation.response.valid is True
+    assert validation.response.params == ["amount"]
+    assert validation.response.referenced_outcomes == ["HOLD"]
+    assert validation.response.errors == []
+
+
+def test_persisted_rule_validation_rejects_predicate_results_without_losing_diagnostics(session) -> None:
+    session.add(FieldObservation(field_name="amount", observed_json_type="int", o_id=1))
+    session.commit()
+
+    validation = validate_rule_source(session, 1, "return $amount > 100")
+
+    assert validation.compiled_rule is None
+    assert validation.response.valid is False
+    assert validation.response.params == ["amount"]
+    assert validation.response.warnings == []
+    assert len(validation.response.errors) == 1
+    assert "return !OUTCOME" in validation.response.errors[0].message
+    assert validation.response.errors[0].line == 1
+    assert validation.response.errors[0].column is not None

--- a/tests/test_rule_outcome_contract_bypasses.py
+++ b/tests/test_rule_outcome_contract_bypasses.py
@@ -1,0 +1,92 @@
+import pytest
+
+from ezrules.backend.rule_validation import validate_rule_source
+from ezrules.core.rule import ReservedRuleIdentifierError, Rule, RuleGeneratorSyntaxError
+from ezrules.models.backend_core import AllowedOutcome
+
+
+@pytest.mark.parametrize(
+    "logic",
+    [
+        "yield !HOLD",
+        "yield from (!HOLD,)",
+        "if False:\n    yield !HOLD\nreturn None",
+    ],
+)
+def test_outer_rule_generator_syntax_is_rejected(logic: str) -> None:
+    rule = Rule(rid="generator-contract", logic=logic)
+
+    with pytest.raises(RuleGeneratorSyntaxError, match="cannot use `yield`"):
+        rule.validate_return_contract()
+
+
+def test_nested_helper_generators_do_not_make_the_outer_rule_a_generator() -> None:
+    rule = Rule(
+        rid="nested-generator",
+        logic=(
+            "def values():\n    yield 1\nfor value in values():\n    if value == 1:\n        return !HOLD\nreturn None"
+        ),
+    )
+
+    rule.validate_return_contract()
+
+    assert rule({}) == "HOLD"
+
+
+@pytest.mark.parametrize(
+    "logic",
+    [
+        'return __ezrules_outcome__("NOT_CONFIGURED")',
+        'return __ezrules_outcome__("HOLD")',
+        'return __ezrules_outcome__("")',
+    ],
+)
+def test_hand_written_outcome_helpers_are_rejected_before_conversion(logic: str) -> None:
+    with pytest.raises(ReservedRuleIdentifierError, match="Identifier '__ezrules_outcome__' is reserved"):
+        Rule(rid="reserved-helper", logic=logic)
+
+
+def test_reserved_helper_text_in_comments_and_strings_is_inert() -> None:
+    rule = Rule(
+        rid="reserved-helper-text",
+        logic=(
+            "# __ezrules_outcome__ is an implementation detail\n"
+            'note = "__ezrules_outcome__"\n'
+            "if note:\n"
+            "    return !HOLD\n"
+            "return None"
+        ),
+    )
+
+    rule.validate_return_contract()
+
+    assert rule({}) == "HOLD"
+
+
+def test_bang_outcome_syntax_remains_valid() -> None:
+    rule = Rule(rid="bang-outcome", logic="return !HOLD")
+
+    rule.validate_return_contract()
+
+    assert rule({}) == "HOLD"
+
+
+@pytest.mark.parametrize(
+    ("logic", "message", "line"),
+    [
+        ("if False:\n    yield !HOLD\nreturn None", "cannot use `yield`", 2),
+        ('return __ezrules_outcome__("HOLD")', "reserved", 1),
+    ],
+)
+def test_verify_reports_contract_bypasses_as_source_diagnostics(session, logic: str, message: str, line: int) -> None:
+    session.add(AllowedOutcome(outcome_name="HOLD", severity_rank=1, o_id=1))
+    session.commit()
+
+    validation = validate_rule_source(session, 1, logic)
+
+    assert validation.compiled_rule is None
+    assert validation.response.valid is False
+    assert len(validation.response.errors) == 1
+    assert message in validation.response.errors[0].message
+    assert validation.response.errors[0].line == line
+    assert validation.response.errors[0].column is not None

--- a/tests/test_rule_outcome_contract_bypasses.py
+++ b/tests/test_rule_outcome_contract_bypasses.py
@@ -1,7 +1,10 @@
+import ast
+
 import pytest
 
 from ezrules.backend.rule_validation import validate_rule_source
 from ezrules.core.rule import ReservedRuleIdentifierError, Rule, RuleGeneratorSyntaxError
+from ezrules.core.rule_helpers import OUTCOME_HELPER_NAME, extract_outcome_helper_value
 from ezrules.models.backend_core import AllowedOutcome
 
 
@@ -65,6 +68,33 @@ def test_reserved_helper_text_in_comments_and_strings_is_inert() -> None:
 
 def test_bang_outcome_syntax_remains_valid() -> None:
     rule = Rule(rid="bang-outcome", logic="return !HOLD")
+
+    rule.validate_return_contract()
+
+    assert rule({}) == "HOLD"
+
+
+def test_outcome_helper_is_preserved_for_contract_visitors_but_absent_at_runtime() -> None:
+    rule = Rule(rid="lowered-outcome", logic="return !HOLD")
+    return_node = next(node for node in ast.walk(rule._rule_ast) if isinstance(node, ast.Return))
+
+    rule.validate_return_contract()
+
+    assert extract_outcome_helper_value(return_node.value) == "HOLD"
+    assert OUTCOME_HELPER_NAME not in rule.logic.__globals__
+    assert rule({}) == "HOLD"
+
+
+@pytest.mark.parametrize(
+    "poison_attempt",
+    [
+        'globals()["__ezrules_outcome__"] = lambda value: "NOT_CONFIGURED"',
+        'globals().update({"__ezrules_outcome__": lambda value: "NOT_CONFIGURED"})',
+        ('globals()["__ezrules_outcome__"] = lambda value: "NOT_CONFIGURED"\ndel globals()["__ezrules_outcome__"]'),
+    ],
+)
+def test_runtime_global_poisoning_cannot_change_direct_outcomes(poison_attempt: str) -> None:
+    rule = Rule(rid="poisoned-outcome", logic=f"{poison_attempt}\nreturn !HOLD")
 
     rule.validate_return_contract()
 

--- a/tests/test_rule_verify_diagnostics.py
+++ b/tests/test_rule_verify_diagnostics.py
@@ -61,14 +61,14 @@ class TestRuleVerifyDiagnostics:
             response = client.post(
                 "/api/v2/rules/verify",
                 headers={"Authorization": f"Bearer {token}"},
-                json={"rule_source": 'return "US" in @VerifyCountries and $amount > 0'},
+                json={"rule_source": 'if "US" in @VerifyCountries and $amount > 0:\n    return !HOLD'},
             )
 
             assert response.status_code == 200
             data = response.json()
             assert data["valid"] is True
             assert data["referenced_lists"] == ["VerifyCountries"]
-            assert data["referenced_outcomes"] == []
+            assert data["referenced_outcomes"] == ["HOLD"]
             assert data["errors"] == []
             assert data["params"] == ["amount"]
         finally:
@@ -126,7 +126,7 @@ class TestRuleVerifyDiagnostics:
             response = client.post(
                 "/api/v2/rules/verify",
                 headers={"Authorization": f"Bearer {token}"},
-                json={"rule_source": "# TODO switch to !REVIEW later\nreturn True"},
+                json={"rule_source": "# TODO switch to !REVIEW later\nreturn None"},
             )
 
             assert response.status_code == 200

--- a/tests/test_rules_verify_warnings.py
+++ b/tests/test_rules_verify_warnings.py
@@ -65,7 +65,7 @@ class TestRuleVerifyWarnings:
         response = client.post(
             "/api/v2/rules/verify",
             headers={"Authorization": f"Bearer {token}"},
-            json={"rule_source": "return $never_seen > 0"},
+            json={"rule_source": "if $never_seen > 0:\n    return !HOLD"},
         )
 
         client.close()
@@ -87,7 +87,7 @@ class TestRuleVerifyWarnings:
         response = client.post(
             "/api/v2/rules/verify",
             headers={"Authorization": f"Bearer {token}"},
-            json={"rule_source": "return $amount > 0"},
+            json={"rule_source": "if $amount > 0:\n    return !HOLD"},
         )
 
         client.close()
@@ -111,7 +111,7 @@ class TestRuleTestNormalizationErrors:
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": "return True",
+                "rule_source": "return None",
                 "test_json": "{}",
             },
         )
@@ -132,7 +132,7 @@ class TestRuleTestNormalizationErrors:
             "/api/v2/rules/test",
             headers={"Authorization": f"Bearer {token}"},
             json={
-                "rule_source": 'return $country == "US"',
+                "rule_source": 'if $country == "US":\n    return !HOLD',
                 "test_json": '{"amount": 100}',
             },
         )

--- a/tests/test_shadow_rule_result_contract.py
+++ b/tests/test_shadow_rule_result_contract.py
@@ -6,8 +6,13 @@ import pytest
 
 from ezrules.backend import shadow_evaluation_queue
 from ezrules.core.rule_updater import SHADOW_CONFIG_LABEL, deploy_rule_to_shadow
+from ezrules.models.backend_core import AllowedOutcome, FeatureDefinition
 from ezrules.models.backend_core import Rule as RuleModel
 from ezrules.models.backend_core import RuleEngineConfig, ShadowResultsLog
+from tests.test_api_v2_rollouts import (  # noqa: F401
+    active_rollout_rule,
+    rollout_test_client,
+)
 from tests.test_api_v2_shadow import (  # noqa: F401
     shadow_rule,
     shadow_test_client,
@@ -158,3 +163,113 @@ def test_valid_shadow_override_can_still_be_promoted(
     assert promote_response.status_code == 200
     session.expire_all()
     assert str(session.get(RuleModel, shadow_rule.r_id).logic) == "return !SHADOW_OUTCOME"
+
+
+def test_rollout_promotion_revalidates_outcome_removed_after_deployment(
+    rollout_test_client,
+    active_rollout_rule,
+) -> None:
+    token = rollout_test_client.test_data["token"]
+    session = rollout_test_client.test_data["session"]
+    original_logic = str(active_rollout_rule.logic)
+    deploy_response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout",
+        json={"logic": "return !CANDIDATE", "description": "Candidate", "traffic_percent": 25},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert deploy_response.status_code == 200
+    session.query(AllowedOutcome).filter(
+        AllowedOutcome.o_id == active_rollout_rule.o_id,
+        AllowedOutcome.outcome_name == "CANDIDATE",
+    ).delete()
+    session.commit()
+
+    promote_response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout/promote",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert promote_response.status_code == 400
+    assert "is not configured in Outcomes" in promote_response.json()["detail"]
+    session.expire_all()
+    assert str(session.get(RuleModel, active_rollout_rule.r_id).logic) == original_logic
+    rollout_config = (
+        session.query(RuleEngineConfig)
+        .filter(RuleEngineConfig.label == "rollout", RuleEngineConfig.o_id == active_rollout_rule.o_id)
+        .one()
+    )
+    assert next(entry for entry in rollout_config.config if entry["r_id"] == active_rollout_rule.r_id)["logic"] == (
+        "return !CANDIDATE"
+    )
+
+
+def test_rollout_promotion_revalidates_feature_deactivated_after_deployment(
+    rollout_test_client,
+    active_rollout_rule,
+) -> None:
+    token = rollout_test_client.test_data["token"]
+    session = rollout_test_client.test_data["session"]
+    original_logic = str(active_rollout_rule.logic)
+    feature = FeatureDefinition(
+        o_id=active_rollout_rule.o_id,
+        name="Sender sent amount 24h",
+        entity="sender",
+        feature_name="sent_amount_sum_24h",
+        entity_key="sender_id",
+        aggregation_type="sum",
+        source_field="amount",
+        window_seconds=86400,
+        filters=[],
+        status="active",
+    )
+    session.add(feature)
+    session.commit()
+    candidate_logic = "if stat[sender.sent_amount_sum_24h] > 100:\n\treturn !CANDIDATE\nreturn !CONTROL"
+    deploy_response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout",
+        json={"logic": candidate_logic, "description": "Candidate", "traffic_percent": 25},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert deploy_response.status_code == 200
+    feature.status = "draft"
+    session.commit()
+
+    promote_response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout/promote",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert promote_response.status_code == 400
+    assert "not active in Features" in promote_response.json()["detail"]
+    session.expire_all()
+    assert str(session.get(RuleModel, active_rollout_rule.r_id).logic) == original_logic
+    rollout_config = (
+        session.query(RuleEngineConfig)
+        .filter(RuleEngineConfig.label == "rollout", RuleEngineConfig.o_id == active_rollout_rule.o_id)
+        .one()
+    )
+    assert next(entry for entry in rollout_config.config if entry["r_id"] == active_rollout_rule.r_id)["logic"] == (
+        candidate_logic
+    )
+
+
+def test_valid_rollout_candidate_can_still_be_promoted(
+    rollout_test_client,
+    active_rollout_rule,
+) -> None:
+    token = rollout_test_client.test_data["token"]
+    session = rollout_test_client.test_data["session"]
+    deploy_response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout",
+        json={"logic": "return !CANDIDATE", "description": "Candidate", "traffic_percent": 25},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    promote_response = rollout_test_client.post(
+        f"/api/v2/rules/{active_rollout_rule.r_id}/rollout/promote",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert deploy_response.status_code == 200
+    assert promote_response.status_code == 200
+    session.expire_all()
+    assert str(session.get(RuleModel, active_rollout_rule.r_id).logic) == "return !CANDIDATE"

--- a/tests/test_shadow_rule_result_contract.py
+++ b/tests/test_shadow_rule_result_contract.py
@@ -1,0 +1,160 @@
+# ruff: noqa: F811
+
+import logging
+
+import pytest
+
+from ezrules.backend import shadow_evaluation_queue
+from ezrules.core.rule_updater import SHADOW_CONFIG_LABEL, deploy_rule_to_shadow
+from ezrules.models.backend_core import Rule as RuleModel
+from ezrules.models.backend_core import RuleEngineConfig, ShadowResultsLog
+from tests.test_api_v2_shadow import (  # noqa: F401
+    shadow_rule,
+    shadow_test_client,
+)
+from tests.test_shadow_evaluation_queue import (  # noqa: F401
+    FakeRedis,
+    _create_decision,
+    _create_shadow_rule,
+    fake_shadow_redis,
+)
+
+
+def test_shadow_deployment_rejects_predicate_return(
+    shadow_test_client,
+    shadow_rule,
+) -> None:
+    token = shadow_test_client.test_data["token"]
+    session = shadow_test_client.test_data["session"]
+
+    response = shadow_test_client.post(
+        f"/api/v2/rules/{shadow_rule.r_id}/shadow",
+        json={"logic": "return $amount > 100", "description": "Invalid candidate"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400
+    assert "direct configured outcome" in response.json()["detail"]
+    shadow_config = (
+        session.query(RuleEngineConfig)
+        .filter(RuleEngineConfig.label == SHADOW_CONFIG_LABEL, RuleEngineConfig.o_id == shadow_rule.o_id)
+        .first()
+    )
+    assert shadow_config is None or shadow_config.config == []
+
+
+@pytest.mark.parametrize(
+    ("legacy_logic", "error_fragment"),
+    [
+        ("return $amount > 100", "Invalid shadow candidate rule"),
+        ("return !LEGACY_UNKNOWN", "is not configured in Outcomes"),
+    ],
+)
+def test_shadow_promotion_revalidates_legacy_stored_candidate(
+    shadow_test_client,
+    shadow_rule,
+    legacy_logic,
+    error_fragment,
+) -> None:
+    token = shadow_test_client.test_data["token"]
+    session = shadow_test_client.test_data["session"]
+    original_logic = str(shadow_rule.logic)
+    deploy_rule_to_shadow(
+        db=session,
+        o_id=int(shadow_rule.o_id),
+        rule_model=shadow_rule,
+        changed_by="legacy-seed",
+        logic_override=legacy_logic,
+    )
+
+    response = shadow_test_client.post(
+        f"/api/v2/rules/{shadow_rule.r_id}/shadow/promote",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400
+    assert error_fragment in response.json()["detail"]
+    session.expire_all()
+    assert str(session.get(RuleModel, shadow_rule.r_id).logic) == original_logic
+    shadow_config = (
+        session.query(RuleEngineConfig)
+        .filter(RuleEngineConfig.label == SHADOW_CONFIG_LABEL, RuleEngineConfig.o_id == shadow_rule.o_id)
+        .one()
+    )
+    assert next(entry for entry in shadow_config.config if entry["r_id"] == shadow_rule.r_id)["logic"] == legacy_logic
+
+
+@pytest.mark.parametrize("invalid_logic", ["return $amount > 100", "invalid {{{ syntax"])
+def test_invalid_legacy_shadow_payload_is_acknowledged_without_blocking_valid_work(
+    session,
+    fake_shadow_redis: FakeRedis,
+    caplog,
+    invalid_logic,
+) -> None:
+    rule = _create_shadow_rule(session)
+    invalid_decision_id = _create_decision(session, int(rule.o_id))
+    deploy_rule_to_shadow(
+        db=session,
+        o_id=int(rule.o_id),
+        rule_model=rule,
+        changed_by="legacy-seed",
+        logic_override=invalid_logic,
+    )
+    shadow_evaluation_queue.enqueue_shadow_evaluation(
+        db=session,
+        evaluation_decision_id=invalid_decision_id,
+        o_id=int(rule.o_id),
+        transaction_id="invalid-shadow-result",
+        event_data={"amount": 200},
+        production_all_rule_results={int(rule.r_id): "HOLD"},
+    )
+
+    valid_decision_id = _create_decision(session, int(rule.o_id))
+    deploy_rule_to_shadow(
+        db=session,
+        o_id=int(rule.o_id),
+        rule_model=rule,
+        changed_by="fixed-candidate",
+        logic_override="return !REVIEW",
+    )
+    shadow_evaluation_queue.enqueue_shadow_evaluation(
+        db=session,
+        evaluation_decision_id=valid_decision_id,
+        o_id=int(rule.o_id),
+        transaction_id="valid-shadow-result",
+        event_data={"amount": 200},
+        production_all_rule_results={int(rule.r_id): "HOLD"},
+    )
+
+    with caplog.at_level(logging.ERROR, logger=shadow_evaluation_queue.__name__):
+        drained = shadow_evaluation_queue.drain_shadow_evaluation_queue(batch_size=10, max_batches=1)
+
+    assert drained["drained_messages"] == 2
+    assert fake_shadow_redis.queue_contents(shadow_evaluation_queue.app_settings.SHADOW_EVALUATION_QUEUE_KEY) == []
+    assert session.query(ShadowResultsLog).filter(ShadowResultsLog.ed_id == invalid_decision_id).count() == 0
+    valid_log = session.query(ShadowResultsLog).filter(ShadowResultsLog.ed_id == valid_decision_id).one()
+    assert str(valid_log.rule_result) == "REVIEW"
+    assert "Dropping shadow evaluation with an invalid rule contract" in caplog.text
+
+
+def test_valid_shadow_override_can_still_be_promoted(
+    shadow_test_client,
+    shadow_rule,
+) -> None:
+    token = shadow_test_client.test_data["token"]
+    session = shadow_test_client.test_data["session"]
+
+    deploy_response = shadow_test_client.post(
+        f"/api/v2/rules/{shadow_rule.r_id}/shadow",
+        json={"logic": "return !SHADOW_OUTCOME", "description": "Valid candidate"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    promote_response = shadow_test_client.post(
+        f"/api/v2/rules/{shadow_rule.r_id}/shadow/promote",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert deploy_response.status_code == 200
+    assert promote_response.status_code == 200
+    session.expire_all()
+    assert str(session.get(RuleModel, shadow_rule.r_id).logic) == "return !SHADOW_OUTCOME"

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.29.0"
+version = "1.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- restrict persisted rule results to no result or a direct configured `!OUTCOME`
- reject malformed runtime rule results before aggregation
- define stable rule-engine shapes, execution modes, identifiers, and first-match behavior
- align rule-test, casting, tenant, nested-path, and editor fixtures with the strict contract
- document the rule authoring contract and bump the patch version to 1.29.1

## Verification

- `uv run poe check`
- Ruff formatting and import checks for changed Python tests
- Python syntax compilation for the generated return-expression matrix
- `git diff --check`
- GitHub Actions run the database-backed backend suite and desktop Chromium suite

## Permissions and audit

No new permission or audit surface is introduced. Existing verify/create/update authorization and mutation audit paths remain unchanged.

## Documentation and assets

Updated the rule authoring guide, Manager API reference, and whats-new notes. README screenshots and GIFs were reviewed; no visual surface changed, so asset regeneration is not required.

## Known gaps

- Python sandboxing, imports, timeouts, memory limits, and execution budgets remain explicitly deferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core rule evaluation and aggregation on the live path; legacy rules that returned booleans or predicates will fail verification or runtime until rewritten to if/!OUTCOME form.
> 
> **Overview**
> **v1.29.1** tightens what rule source may return and how rule-set results are aggregated, with docs and tests aligned to the new contract.
> 
> **Authoring and verification** now accept only *no result* (`None`, bare `return`, fall-through) or a direct `return !OUTCOME`. Predicates, booleans, numbers, containers, dynamic strings, outer `yield`/`yield from`, and hand-written internal outcome helpers are rejected with line/column diagnostics. Verify/save flows call `validate_return_contract()`; reserved helper names are blocked before DSL conversion.
> 
> **Runtime evaluation** validates each rule result before aggregation: only `None` or a non-empty outcome string are allowed—otherwise `InvalidRuleResultError`. The engine rejects unknown execution modes and duplicate rule identifiers up front, preserves `r_id == 0`, and returns a typed `RuleEngineResult` with a stable empty shape.
> 
> Tests and E2E fixtures move from patterns like `return True` / `return $amount > 10` to `if …: return !HOLD` / `return None`. User-facing docs and the Manager API verify description document the contract; **what's new** and version bump to **1.29.1** record the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30fc7c698ee5e2af98234adc0e4b4b9d83649b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->