### PR TITLE
Protect CI/CD and version ownership boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@
 # Verification Policy
 Default to GitHub-hosted verification instead of local test execution.
 
+## Protected CI/CD Configuration
+
+- Do not modify GitHub Actions workflow files, CI/CD configuration, or action/runtime versions unless the user explicitly authorizes the exact file change. Ask before touching any such file, regardless of whether the change appears to be good technical judgment.
+- A failure from the GitHub Actions check that tests whether the package version is already published to PyPI is expected and may be ignored when that is the only cause. Do not search for an unused version, bump the project version, edit release notes, or modify CI/CD in response; another agent owns the version update.
+
 - Always run `uv run poe check` locally before pushing a branch, opening a PR, or updating a PR. Fix any failures locally first so GitHub Actions does not get noisy code-quality/type/lint failures.
 - Do not run local test suites, local Playwright runs, local backend suites, or local docs builds unless the user explicitly asks for local verification or the task is specifically about diagnosing a local-only bug.
 - For normal feature/fix work, implement the change, run `uv run poe check`, create or update the PR, push it, and use GitHub Actions/PR checks as the verification source of truth for tests and full infra validation.


### PR DESCRIPTION
## Summary
- require explicit user authorization before agents modify GitHub Actions or CI/CD configuration
- treat an already-published PyPI version check failure as expected without bumping versions or editing release files
- preserve ownership of version updates for the separate release agent

## Verification
- `uv run poe check`
- `git diff --check`
- GitHub: code quality, backend tests, Redis/Celery smoke, business journeys, and Playwright passed
- Codex/human review channels remained clean throughout the 10-minute post-ready window

## Known gaps
- `Check version not on PyPI` fails because version 1.29.0 is already published; this is expected and intentionally left for the separate version-owning agent

## Release artifacts
- No version or release-note update: this is repository agent guidance only, and version ownership is explicitly delegated elsewhere.