### PR TITLE
Keep live rollout monitoring current

### DIFF
--- a/docs/user-guide/rule-rollouts.md
+++ b/docs/user-guide/rule-rollouts.md
@@ -67,6 +67,8 @@ Open **Rule Rollouts** in the sidebar to see:
 - control outcomes for the compared events
 - candidate outcomes for the same events
 
+The page refreshes the rollout configuration and comparison statistics every five seconds while it remains open. Background refreshes keep the current view visible, so operators can monitor newly served decisions without manually reloading the page.
+
 ![Active rollout rule with traffic split summary](../assets/readme/rollout-active-rule.png)
 
 ![Rollout comparison for served split and candidate outcomes](../assets/readme/rollout-comparison.png)

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -3,7 +3,7 @@
 ## v1.29.3
 
 * **Live rollout monitoring**: The Rule Rollouts page now refreshes its configuration and served-decision statistics every five seconds, so operators can watch candidate and control traffic without manually reloading the page.
-* **Race-safe refreshes**: Newer configuration reads cancel older ones, while best-effort statistics refresh one request at a time so slow aggregations can finish without older responses replacing newer state.
+* **Race-safe refreshes**: Configuration and best-effort statistics each refresh one request at a time, so slow responses can finish without overlapping requests or older data replacing newer state.
 * **Real traffic coverage**: Playwright now verifies that a candidate-served API evaluation appears automatically in an already-open rollout monitor.
 
 ## v1.29.2

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -3,7 +3,7 @@
 ## v1.29.3
 
 * **Live rollout monitoring**: The Rule Rollouts page now refreshes its configuration and served-decision statistics every five seconds, so operators can watch candidate and control traffic without manually reloading the page.
-* **Race-safe refreshes**: A newer rollout refresh cancels any older in-flight request, preventing delayed responses from replacing more recent deployment statistics.
+* **Race-safe refreshes**: Newer configuration reads cancel older ones, while best-effort statistics refresh one request at a time so slow aggregations can finish without older responses replacing newer state.
 * **Real traffic coverage**: Playwright now verifies that a candidate-served API evaluation appears automatically in an already-open rollout monitor.
 
 ## v1.29.2

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.29.3
+
+* **Live rollout monitoring**: The Rule Rollouts page now refreshes its configuration and served-decision statistics every five seconds, so operators can watch candidate and control traffic without manually reloading the page.
+* **Race-safe refreshes**: A newer rollout refresh cancels any older in-flight request, preventing delayed responses from replacing more recent deployment statistics.
+* **Real traffic coverage**: Playwright now verifies that a candidate-served API evaluation appears automatically in an already-open rollout monitor.
+
 ## v1.29.2
 
 * **Live alert visibility**: The sidebar notification badge now refreshes automatically while an analyst remains on the current page, so new outcome-spike incidents become visible without a manual reload or navigation.

--- a/ezrules/frontend/e2e/pages/rollouts.page.ts
+++ b/ezrules/frontend/e2e/pages/rollouts.page.ts
@@ -37,6 +37,10 @@ export class RolloutsPage {
     return this.page.locator('[data-testid="rollouts-table"] > div').count();
   }
 
+  rowForRule(rid: string): Locator {
+    return this.rolloutsTable.locator(':scope > div').filter({ hasText: rid });
+  }
+
   async clickPromoteButton(index: number = 0) {
     await this.page.locator('[data-testid="promote-rollout-button"]').nth(index).click();
   }

--- a/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
+++ b/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
@@ -1,0 +1,273 @@
+import type {
+  APIRequestContext,
+  APIResponse,
+  TestInfo,
+} from '@playwright/test';
+import { RolloutsPage } from '../pages/rollouts.page';
+import {
+  createRule,
+  deleteRuleById,
+  expectApiOk,
+  promoteRule,
+} from '../support/api-helpers';
+import { getApiBaseUrl, getAuthToken } from '../support/config';
+import { expect, test } from '../support/fixtures';
+import {
+  deterministicUnixTimestamp,
+  testResourceName,
+} from '../support/test-data';
+import { STATEFUL_TAG, TEST_DATA_TAG } from '../support/tags';
+
+const API_BASE = getApiBaseUrl();
+
+type ApiKey = {
+  gid: string;
+  raw_key: string;
+};
+
+type EvaluationResponse = {
+  rule_results: Record<string, string>;
+};
+
+type RolloutStats = {
+  rules: Array<{
+    r_id: number;
+    total: number;
+    served_candidate: number;
+    served_control: number;
+  }>;
+};
+
+function authHeaders(): { Authorization: string } {
+  return { Authorization: `Bearer ${getAuthToken()}` };
+}
+
+async function jsonResponse<T>(
+  response: APIResponse,
+  context: string,
+): Promise<T> {
+  await expectApiOk(response, context);
+  return (await response.json()) as T;
+}
+
+async function createOutcome(
+  request: APIRequestContext,
+  outcome: string,
+): Promise<void> {
+  const response = await request.post(`${API_BASE}/api/v2/outcomes`, {
+    headers: authHeaders(),
+    data: { outcome_name: outcome },
+  });
+  const body = await jsonResponse<{ success: boolean; error?: string }>(
+    response,
+    `Create outcome ${outcome}`,
+  );
+  expect(body.success, body.error).toBe(true);
+}
+
+async function createApiKey(
+  request: APIRequestContext,
+  label: string,
+): Promise<ApiKey> {
+  const response = await request.post(`${API_BASE}/api/v2/api-keys`, {
+    headers: authHeaders(),
+    data: { label },
+  });
+  return await jsonResponse<ApiKey>(response, `Create API key ${label}`);
+}
+
+async function evaluate(
+  request: APIRequestContext,
+  apiKey: string,
+  transactionId: string,
+  marker: string,
+  effectiveAt: number,
+): Promise<EvaluationResponse> {
+  const response = await request.post(`${API_BASE}/api/v2/evaluate`, {
+    headers: { 'X-API-Key': apiKey },
+    data: {
+      transaction_id: transactionId,
+      effective_at: effectiveAt,
+      event_data: {
+        rollout_probe: marker,
+        amount: 50,
+        currency: 'USD',
+        txn_type: 'card_purchase',
+        channel: 'web',
+        customer_id: `customer-${transactionId}`,
+        customer_country: 'US',
+        billing_country: 'US',
+        shipping_country: 'US',
+        ip_country: 'US',
+        merchant_id: `merchant-${transactionId}`,
+        merchant_category: 'groceries',
+        merchant_country: 'US',
+        email_domain: 'example.com',
+        account_age_days: 400,
+        email_age_days: 400,
+        customer_avg_amount_30d: 50,
+        customer_std_amount_30d: 10,
+        prior_chargebacks_180d: 0,
+        manual_review_hits_30d: 0,
+        decline_count_24h: 0,
+        txn_velocity_10m: 1,
+        txn_velocity_1h: 1,
+        unique_cards_24h: 1,
+        device_age_days: 400,
+        device_trust_score: 95,
+        has_3ds: 1,
+        card_present: 1,
+        is_guest_checkout: 0,
+        password_reset_age_hours: 720,
+        distance_from_home_km: 5,
+        ip_proxy_score: 0,
+        beneficiary_country: 'US',
+        beneficiary_age_days: 400,
+        local_hour: 12,
+      },
+    },
+  });
+  return await jsonResponse<EvaluationResponse>(
+    response,
+    `Evaluate transaction ${transactionId}`,
+  );
+}
+
+async function getRolloutStats(
+  request: APIRequestContext,
+): Promise<RolloutStats> {
+  const response = await request.get(`${API_BASE}/api/v2/rollouts/stats`, {
+    headers: authHeaders(),
+  });
+  return await jsonResponse<RolloutStats>(response, 'Get rollout stats');
+}
+
+function runToken(testInfo: TestInfo): string {
+  return testResourceName(
+    testInfo,
+    `rollout_${Date.now()}_${testInfo.workerIndex}`,
+    { maxLength: 48 },
+  );
+}
+
+test.describe(`Live rollout monitoring ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => {
+  let apiKeyGid: string | null = null;
+  let controlOutcome: string | null = null;
+  let candidateOutcome: string | null = null;
+  let ruleId: number | null = null;
+
+  test.afterEach(async ({ request }) => {
+    if (ruleId !== null) {
+      const response = await request.delete(
+        `${API_BASE}/api/v2/rules/${ruleId}/rollout`,
+        { headers: authHeaders() },
+      );
+      await expectApiOk(response, `Remove rollout for rule ${ruleId}`);
+      await deleteRuleById(request, ruleId);
+    }
+    if (apiKeyGid !== null) {
+      const response = await request.delete(
+        `${API_BASE}/api/v2/api-keys/${apiKeyGid}`,
+        { headers: authHeaders() },
+      );
+      await expectApiOk(response, `Revoke API key ${apiKeyGid}`);
+    }
+    for (const outcome of [candidateOutcome, controlOutcome]) {
+      if (outcome !== null) {
+        const response = await request.delete(
+          `${API_BASE}/api/v2/outcomes/${outcome}`,
+          { headers: authHeaders() },
+        );
+        await expectApiOk(response, `Delete outcome ${outcome}`);
+      }
+    }
+
+    apiKeyGid = null;
+    controlOutcome = null;
+    candidateOutcome = null;
+    ruleId = null;
+  });
+
+  test('keeps an open rollout monitor synchronized with live served decisions', async ({
+    page,
+    request,
+  }, testInfo) => {
+    const token = runToken(testInfo);
+    const marker = `marker_${token}`;
+    controlOutcome = testResourceName(testInfo, `CONTROL_${token}`, {
+      maxLength: 120,
+      uppercase: true,
+    });
+    candidateOutcome = testResourceName(testInfo, `CANDIDATE_${token}`, {
+      maxLength: 120,
+      uppercase: true,
+    });
+
+    await createOutcome(request, controlOutcome);
+    await createOutcome(request, candidateOutcome);
+    const rule = await createRule(request, {
+      rid: testResourceName(testInfo, `E2E_ROLLOUT_${token}`, {
+        maxLength: 120,
+        uppercase: true,
+      }),
+      description: 'Exercise live rollout monitoring',
+      logic: `if $rollout_probe == '${marker}':\n\treturn !${controlOutcome}`,
+    });
+    ruleId = rule.r_id;
+    await promoteRule(request, ruleId);
+
+    const deployResponse = await request.post(
+      `${API_BASE}/api/v2/rules/${ruleId}/rollout`,
+      {
+        headers: authHeaders(),
+        data: {
+          logic: `if $rollout_probe == '${marker}':\n\treturn !${candidateOutcome}`,
+          description: 'Candidate for live rollout monitoring',
+          traffic_percent: 100,
+        },
+      },
+    );
+    await expectApiOk(deployResponse, `Deploy rollout for rule ${ruleId}`);
+
+    const apiKey = await createApiKey(request, `rollout-live-${token}`);
+    apiKeyGid = apiKey.gid;
+
+    const rolloutsPage = new RolloutsPage(page);
+    await rolloutsPage.goto();
+    await rolloutsPage.waitForLoad();
+    const rolloutRow = rolloutsPage.rowForRule(rule.rid);
+    await expect(rolloutRow).toContainText('0 events compared');
+
+    const evaluation = await evaluate(
+      request,
+      apiKey.raw_key,
+      `rollout-live-${token}`,
+      marker,
+      deterministicUnixTimestamp(testInfo),
+    );
+    expect(evaluation.rule_results[String(ruleId)]).toBe(candidateOutcome);
+
+    await expect
+      .poll(
+        async () => {
+          const stats = await getRolloutStats(request);
+          return stats.rules.find((item) => item.r_id === ruleId);
+        },
+        {
+          message: 'the backend should record the candidate-served decision',
+          timeout: 10_000,
+          intervals: [250, 500, 1_000],
+        },
+      )
+      .toMatchObject({
+        total: 1,
+        served_candidate: 1,
+        served_control: 0,
+      });
+
+    await expect(
+      rolloutRow,
+      'an operator monitoring a live rollout should see newly served decisions without manually refreshing',
+    ).toContainText('1 events compared', { timeout: 10_000 });
+  });
+});

--- a/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
+++ b/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
@@ -280,17 +280,22 @@ test.describe(`Live rollout monitoring ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => 
   });
 
   test('renders rollout configuration without waiting for slow best-effort statistics', async ({ page }) => {
-    let releaseStats!: () => void;
-    const statsBlocked = new Promise<void>((resolve) => {
-      releaseStats = resolve;
-    });
-
     await page.route('**/api/v2/rollouts/stats', async (route) => {
-      await statsBlocked;
+      await new Promise((resolve) => setTimeout(resolve, 5_500));
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ rules: [] }),
+        body: JSON.stringify({
+          rules: [{
+            r_id: mockedRollout.r_id,
+            traffic_percent: mockedRollout.traffic_percent,
+            total: 7,
+            served_candidate: 4,
+            served_control: 3,
+            candidate_outcomes: [],
+            control_outcomes: [],
+          }],
+        }),
       });
     });
     await page.route('**/api/v2/rollouts', async (route) => {
@@ -303,14 +308,11 @@ test.describe(`Live rollout monitoring ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => 
 
     const rolloutsPage = new RolloutsPage(page);
     await rolloutsPage.goto();
-    try {
-      await expect(rolloutsPage.rowForRule(mockedRollout.rid)).toBeVisible({
-        timeout: 2_000,
-      });
-    } finally {
-      releaseStats();
-      await page.unrouteAll({ behavior: 'wait' });
-    }
+    const rolloutRow = rolloutsPage.rowForRule(mockedRollout.rid);
+    await expect(rolloutRow).toBeVisible({ timeout: 2_000 });
+    await expect(rolloutRow).toContainText('7 events compared', {
+      timeout: 7_000,
+    });
   });
 
   test('keeps the last rollout data visible when a background refresh fails', async ({ page }) => {

--- a/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
+++ b/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
@@ -342,6 +342,54 @@ test.describe(`Live rollout monitoring ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => 
     expect(configRequests).toBe(1);
   });
 
+  test('queues a post-action refresh behind an active configuration request', async ({ page }) => {
+    let configRequests = 0;
+    await page.route('**/api/v2/rollouts/stats', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rules: [] }),
+      });
+    });
+    await page.route('**/api/v2/rollouts', async (route) => {
+      configRequests += 1;
+      if (configRequests === 2) {
+        await new Promise((resolve) => setTimeout(resolve, 6_500));
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rules: configRequests < 3 ? [mockedRollout] : [],
+          version: configRequests,
+        }),
+      });
+    });
+    await page.route(`**/api/v2/rules/${mockedRollout.r_id}/rollout`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, message: 'Rollout removed.' }),
+      });
+    });
+
+    const rolloutsPage = new RolloutsPage(page);
+    await rolloutsPage.goto();
+    const rolloutRow = rolloutsPage.rowForRule(mockedRollout.rid);
+    await expect(rolloutRow).toBeVisible();
+    await expect.poll(() => configRequests, { timeout: 7_000 }).toBe(2);
+
+    await rolloutRow.getByTestId('remove-rollout-button').click();
+    await page.getByTestId('confirm-remove-rollout-button').click();
+    await expect(page.getByText('Rollout removed.')).toBeVisible();
+
+    await expect(
+      rolloutsPage.emptyState,
+      'the mutation refresh should run as soon as the active request finishes',
+    ).toBeVisible({ timeout: 8_000 });
+    expect(configRequests).toBe(3);
+  });
+
   test('keeps the last rollout data visible when a background refresh fails', async ({ page }) => {
     let configRequests = 0;
     await page.route('**/api/v2/rollouts/stats', async (route) => {

--- a/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
+++ b/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
@@ -38,6 +38,14 @@ type RolloutStats = {
   }>;
 };
 
+const mockedRollout = {
+  r_id: 999_001,
+  rid: 'E2E_LIVE_MONITOR',
+  description: 'Existing live rollout',
+  logic: 'return !HOLD',
+  traffic_percent: 50,
+};
+
 function authHeaders(): { Authorization: string } {
   return { Authorization: `Bearer ${getAuthToken()}` };
 }
@@ -269,5 +277,91 @@ test.describe(`Live rollout monitoring ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => 
       rolloutRow,
       'an operator monitoring a live rollout should see newly served decisions without manually refreshing',
     ).toContainText('1 events compared', { timeout: 10_000 });
+  });
+
+  test('renders rollout configuration without waiting for slow best-effort statistics', async ({ page }) => {
+    let releaseStats!: () => void;
+    const statsBlocked = new Promise<void>((resolve) => {
+      releaseStats = resolve;
+    });
+
+    await page.route('**/api/v2/rollouts/stats', async (route) => {
+      await statsBlocked;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rules: [] }),
+      });
+    });
+    await page.route('**/api/v2/rollouts', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rules: [mockedRollout], version: 1 }),
+      });
+    });
+
+    const rolloutsPage = new RolloutsPage(page);
+    await rolloutsPage.goto();
+    try {
+      await expect(rolloutsPage.rowForRule(mockedRollout.rid)).toBeVisible({
+        timeout: 2_000,
+      });
+    } finally {
+      releaseStats();
+      await page.unrouteAll({ behavior: 'wait' });
+    }
+  });
+
+  test('keeps the last rollout data visible when a background refresh fails', async ({ page }) => {
+    let configRequests = 0;
+    await page.route('**/api/v2/rollouts/stats', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rules: [{
+            r_id: mockedRollout.r_id,
+            traffic_percent: mockedRollout.traffic_percent,
+            total: 0,
+            served_candidate: 0,
+            served_control: 0,
+            candidate_outcomes: [],
+            control_outcomes: [],
+          }],
+        }),
+      });
+    });
+    await page.route('**/api/v2/rollouts', async (route) => {
+      configRequests += 1;
+      if (configRequests === 1) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ rules: [mockedRollout], version: 1 }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Temporarily unavailable' }),
+      });
+    });
+
+    const rolloutsPage = new RolloutsPage(page);
+    await rolloutsPage.goto();
+    const rolloutRow = rolloutsPage.rowForRule(mockedRollout.rid);
+    await expect(rolloutRow).toBeVisible();
+    await expect
+      .poll(() => configRequests, {
+        message: 'the background rollout refresh should run',
+        timeout: 7_000,
+      })
+      .toBeGreaterThan(1);
+    await expect(page.getByTestId('rollout-refresh-warning')).toContainText(
+      'Rollout configuration could not be refreshed. Showing the last known data.',
+    );
+    await expect(rolloutRow).toBeVisible();
   });
 });

--- a/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
+++ b/ezrules/frontend/e2e/tests/rollout-live-traffic.spec.ts
@@ -315,6 +315,33 @@ test.describe(`Live rollout monitoring ${STATEFUL_TAG} ${TEST_DATA_TAG}`, () => 
     });
   });
 
+  test('allows a rollout configuration request to finish beyond the polling interval', async ({ page }) => {
+    let configRequests = 0;
+    await page.route('**/api/v2/rollouts/stats', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rules: [] }),
+      });
+    });
+    await page.route('**/api/v2/rollouts', async (route) => {
+      configRequests += 1;
+      await new Promise((resolve) => setTimeout(resolve, 5_500));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rules: [mockedRollout], version: 1 }),
+      });
+    });
+
+    const rolloutsPage = new RolloutsPage(page);
+    await rolloutsPage.goto();
+    await expect(rolloutsPage.rowForRule(mockedRollout.rid)).toBeVisible({
+      timeout: 7_000,
+    });
+    expect(configRequests).toBe(1);
+  });
+
   test('keeps the last rollout data visible when a background refresh fails', async ({ page }) => {
     let configRequests = 0;
     await page.route('**/api/v2/rollouts/stats', async (route) => {

--- a/ezrules/frontend/src/app/rollouts/rollouts.component.html
+++ b/ezrules/frontend/src/app/rollouts/rollouts.component.html
@@ -26,6 +26,15 @@
         </div>
       </div>
 
+      <div
+        *ngIf="configRefreshError || statsRefreshError"
+        class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6"
+        data-testid="rollout-refresh-warning"
+      >
+        <p *ngIf="configRefreshError" class="text-sm font-medium text-amber-800">{{ configRefreshError }}</p>
+        <p *ngIf="statsRefreshError" class="text-sm font-medium text-amber-800">{{ statsRefreshError }}</p>
+      </div>
+
       <div *ngIf="loading" class="flex justify-center items-center py-20">
         <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-500"></div>
       </div>

--- a/ezrules/frontend/src/app/rollouts/rollouts.component.ts
+++ b/ezrules/frontend/src/app/rollouts/rollouts.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { Change, diffLines } from 'diff';
-import { catchError, map, merge, Observable, of, Subject, switchMap, tap, timer } from 'rxjs';
+import { catchError, exhaustMap, map, merge, Observable, of, Subject, switchMap, tap, timer } from 'rxjs';
 import { SidebarComponent } from '../components/sidebar.component';
 import { AuthService } from '../services/auth.service';
 import { ACTION_PERMISSION_REQUIREMENTS, hasPermissionRequirement } from '../auth/permissions';
@@ -108,7 +108,7 @@ export class RolloutsComponent implements OnInit {
     });
 
     this.refreshEvents().pipe(
-      switchMap(() => this.ruleService.getRolloutStats().pipe(
+      exhaustMap(() => this.ruleService.getRolloutStats().pipe(
         map(stats => ({ stats, failed: false })),
         catchError(() => of({ stats: null, failed: true }))
       )),

--- a/ezrules/frontend/src/app/rollouts/rollouts.component.ts
+++ b/ezrules/frontend/src/app/rollouts/rollouts.component.ts
@@ -3,7 +3,20 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { Change, diffLines } from 'diff';
-import { catchError, exhaustMap, map, merge, Observable, of, Subject, tap, timer } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  defer,
+  exhaustMap,
+  filter,
+  finalize,
+  map,
+  merge,
+  Observable,
+  of,
+  Subject,
+  timer,
+} from 'rxjs';
 import { SidebarComponent } from '../components/sidebar.component';
 import { AuthService } from '../services/auth.service';
 import { ACTION_PERMISSION_REQUIREMENTS, hasPermissionRequirement } from '../auth/permissions';
@@ -17,6 +30,11 @@ import {
 } from '../services/rule.service';
 
 const ROLLOUT_REFRESH_INTERVAL_MS = 5_000;
+
+type RefreshEvent = {
+  showLoading: boolean;
+  required: boolean;
+};
 
 @Component({
   selector: 'app-rollouts',
@@ -50,8 +68,9 @@ export class RolloutsComponent implements OnInit {
   canModifyRules: boolean = false;
   canPromoteRules: boolean = false;
   private readonly destroyRef = inject(DestroyRef);
-  private readonly manualRefresh$ = new Subject<boolean>();
+  private readonly manualRefresh$ = new Subject<void>();
   private hasLoadedConfig = false;
+  private configRefreshInFlight = false;
 
   constructor(
     private ruleService: RuleService,
@@ -78,20 +97,25 @@ export class RolloutsComponent implements OnInit {
   }
 
   loadData(): void {
-    this.manualRefresh$.next(true);
+    this.manualRefresh$.next();
   }
 
   private startDataRefresh(): void {
     this.refreshEvents().pipe(
-      tap(showLoading => {
-        if (showLoading) {
+      filter(event => event.required || !this.configRefreshInFlight),
+      concatMap(event => defer(() => {
+        this.configRefreshInFlight = true;
+        if (event.showLoading) {
           this.loading = true;
         }
-      }),
-      exhaustMap(() => this.ruleService.getRolloutConfig().pipe(
-        map(config => ({ config, failed: false })),
-        catchError(() => of({ config: null, failed: true }))
-      )),
+        return this.ruleService.getRolloutConfig().pipe(
+          map(config => ({ config, failed: false })),
+          catchError(() => of({ config: null, failed: true })),
+          finalize(() => {
+            this.configRefreshInFlight = false;
+          })
+        );
+      })),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(({ config, failed }) => {
       if (config !== null) {
@@ -123,10 +147,16 @@ export class RolloutsComponent implements OnInit {
     });
   }
 
-  private refreshEvents(): Observable<boolean> {
+  private refreshEvents(): Observable<RefreshEvent> {
     return merge(
-      timer(0, ROLLOUT_REFRESH_INTERVAL_MS).pipe(map(index => index === 0)),
-      this.manualRefresh$
+      timer(0, ROLLOUT_REFRESH_INTERVAL_MS).pipe(map(index => ({
+        showLoading: index === 0,
+        required: false,
+      }))),
+      this.manualRefresh$.pipe(map(() => ({
+        showLoading: true,
+        required: true,
+      })))
     );
   }
 

--- a/ezrules/frontend/src/app/rollouts/rollouts.component.ts
+++ b/ezrules/frontend/src/app/rollouts/rollouts.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { Change, diffLines } from 'diff';
+import { catchError, forkJoin, map, merge, of, Subject, switchMap, tap, timer } from 'rxjs';
 import { SidebarComponent } from '../components/sidebar.component';
 import { AuthService } from '../services/auth.service';
 import { ACTION_PERMISSION_REQUIREMENTS, hasPermissionRequirement } from '../auth/permissions';
@@ -13,6 +15,8 @@ import {
   RuleDetail,
   RuleService,
 } from '../services/rule.service';
+
+const ROLLOUT_REFRESH_INTERVAL_MS = 5_000;
 
 @Component({
   selector: 'app-rollouts',
@@ -43,6 +47,8 @@ export class RolloutsComponent implements OnInit {
   actionError: string | null = null;
   canModifyRules: boolean = false;
   canPromoteRules: boolean = false;
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly manualRefresh$ = new Subject<boolean>();
 
   constructor(
     private ruleService: RuleService,
@@ -52,7 +58,7 @@ export class RolloutsComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadPermissions();
-    this.loadData();
+    this.startDataRefresh();
   }
 
   loadPermissions(): void {
@@ -69,27 +75,39 @@ export class RolloutsComponent implements OnInit {
   }
 
   loadData(): void {
-    this.loading = true;
-    this.error = null;
+    this.manualRefresh$.next(true);
+  }
 
-    this.ruleService.getRolloutConfig().subscribe({
-      next: (config) => {
-        this.rolloutConfig = config;
-        this.loading = false;
-      },
-      error: () => {
-        this.error = 'Failed to load rollout configuration.';
-        this.loading = false;
+  private startDataRefresh(): void {
+    merge(
+      timer(0, ROLLOUT_REFRESH_INTERVAL_MS).pipe(map(index => index === 0)),
+      this.manualRefresh$
+    ).pipe(
+      tap(showLoading => {
+        if (showLoading) {
+          this.loading = true;
+        }
+        this.error = null;
+      }),
+      switchMap(() => forkJoin({
+        config: this.ruleService.getRolloutConfig().pipe(
+          map(value => ({ value, failed: false })),
+          catchError(() => of({ value: null, failed: true }))
+        ),
+        stats: this.ruleService.getRolloutStats().pipe(
+          catchError(() => of(null))
+        )
+      })),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(({ config, stats }) => {
+      if (config.value !== null) {
+        this.rolloutConfig = config.value;
       }
-    });
-
-    this.ruleService.getRolloutStats().subscribe({
-      next: (stats) => {
+      if (stats !== null) {
         this.rolloutStats = stats;
-      },
-      error: () => {
-        // Stats are best-effort; don't block the page.
       }
+      this.error = config.failed ? 'Failed to load rollout configuration.' : null;
+      this.loading = false;
     });
   }
 

--- a/ezrules/frontend/src/app/rollouts/rollouts.component.ts
+++ b/ezrules/frontend/src/app/rollouts/rollouts.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { Change, diffLines } from 'diff';
-import { catchError, forkJoin, map, merge, of, Subject, switchMap, tap, timer } from 'rxjs';
+import { catchError, map, merge, Observable, of, Subject, switchMap, tap, timer } from 'rxjs';
 import { SidebarComponent } from '../components/sidebar.component';
 import { AuthService } from '../services/auth.service';
 import { ACTION_PERMISSION_REQUIREMENTS, hasPermissionRequirement } from '../auth/permissions';
@@ -45,10 +45,13 @@ export class RolloutsComponent implements OnInit {
 
   actionSuccess: string | null = null;
   actionError: string | null = null;
+  configRefreshError: string | null = null;
+  statsRefreshError: string | null = null;
   canModifyRules: boolean = false;
   canPromoteRules: boolean = false;
   private readonly destroyRef = inject(DestroyRef);
   private readonly manualRefresh$ = new Subject<boolean>();
+  private hasLoadedConfig = false;
 
   constructor(
     private ruleService: RuleService,
@@ -79,36 +82,52 @@ export class RolloutsComponent implements OnInit {
   }
 
   private startDataRefresh(): void {
-    merge(
-      timer(0, ROLLOUT_REFRESH_INTERVAL_MS).pipe(map(index => index === 0)),
-      this.manualRefresh$
-    ).pipe(
+    this.refreshEvents().pipe(
       tap(showLoading => {
         if (showLoading) {
           this.loading = true;
         }
-        this.error = null;
       }),
-      switchMap(() => forkJoin({
-        config: this.ruleService.getRolloutConfig().pipe(
-          map(value => ({ value, failed: false })),
-          catchError(() => of({ value: null, failed: true }))
-        ),
-        stats: this.ruleService.getRolloutStats().pipe(
-          catchError(() => of(null))
-        )
-      })),
+      switchMap(() => this.ruleService.getRolloutConfig().pipe(
+        map(config => ({ config, failed: false })),
+        catchError(() => of({ config: null, failed: true }))
+      )),
       takeUntilDestroyed(this.destroyRef)
-    ).subscribe(({ config, stats }) => {
-      if (config.value !== null) {
-        this.rolloutConfig = config.value;
+    ).subscribe(({ config, failed }) => {
+      if (config !== null) {
+        this.rolloutConfig = config;
+        this.hasLoadedConfig = true;
+        this.error = null;
+        this.configRefreshError = null;
+      } else if (failed && this.hasLoadedConfig) {
+        this.configRefreshError = 'Rollout configuration could not be refreshed. Showing the last known data.';
+      } else if (failed) {
+        this.error = 'Failed to load rollout configuration.';
       }
-      if (stats !== null) {
-        this.rolloutStats = stats;
-      }
-      this.error = config.failed ? 'Failed to load rollout configuration.' : null;
       this.loading = false;
     });
+
+    this.refreshEvents().pipe(
+      switchMap(() => this.ruleService.getRolloutStats().pipe(
+        map(stats => ({ stats, failed: false })),
+        catchError(() => of({ stats: null, failed: true }))
+      )),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(({ stats, failed }) => {
+      if (stats !== null) {
+        this.rolloutStats = stats;
+        this.statsRefreshError = null;
+      } else if (failed) {
+        this.statsRefreshError = 'Rollout statistics could not be refreshed. Showing the last known data.';
+      }
+    });
+  }
+
+  private refreshEvents(): Observable<boolean> {
+    return merge(
+      timer(0, ROLLOUT_REFRESH_INTERVAL_MS).pipe(map(index => index === 0)),
+      this.manualRefresh$
+    );
   }
 
   openPromoteDialog(rule: RolloutRuleItem): void {

--- a/ezrules/frontend/src/app/rollouts/rollouts.component.ts
+++ b/ezrules/frontend/src/app/rollouts/rollouts.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
 import { Change, diffLines } from 'diff';
-import { catchError, exhaustMap, map, merge, Observable, of, Subject, switchMap, tap, timer } from 'rxjs';
+import { catchError, exhaustMap, map, merge, Observable, of, Subject, tap, timer } from 'rxjs';
 import { SidebarComponent } from '../components/sidebar.component';
 import { AuthService } from '../services/auth.service';
 import { ACTION_PERMISSION_REQUIREMENTS, hasPermissionRequirement } from '../auth/permissions';
@@ -88,7 +88,7 @@ export class RolloutsComponent implements OnInit {
           this.loading = true;
         }
       }),
-      switchMap(() => this.ruleService.getRolloutConfig().pipe(
+      exhaustMap(() => this.ruleService.getRolloutConfig().pipe(
         map(config => ({ config, failed: false })),
         catchError(() => of({ config: null, failed: true }))
       )),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.29.2"
+version = "1.29.3"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.29.2"
+version = "1.29.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- refresh rollout configuration and served-decision statistics every five seconds while the monitor is open
- cancel superseded refresh requests so delayed responses cannot overwrite newer rollout state
- add a real evaluation-to-browser regression test and document the live behavior
- bump the unreleased project version to 1.29.3

## Verification
- uv run poe check
- uv run mkdocs build --strict
- targeted Chromium Playwright spec: one initial pass
- targeted Chromium Playwright spec with workers=1 and repeat-each=10
- targeted Chromium Playwright spec once more without resetting the private database

## Known gaps
- full Playwright and backend suites were not run locally; GitHub Actions remains the source of truth for broader verification
- no screenshots or GIFs changed because the existing rollout layout is unchanged