### PR TITLE
Add an MVP operations dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ezrules gives fraud, risk, and compliance administrators a web workspace for man
 - **Own the rule lifecycle.** Create rules, keep drafts separate from live logic, pause risky rules, restore older revisions, and promote changes deliberately.
 - **See what happened.** Review canonical served decisions, the outcome returned, every rule that fired, and the exact event version those rules used.
 - **Work the exceptions.** Turn non-neutral decisions into resolvable cases, track rescoring changes, and publish case/evaluation events to external systems.
+- **See queue health at a glance.** Use Operations to track active and unassigned work, resolution flow, false-positive rate, aging cases, and the rules creating the most review work.
 - **React to outcome spikes.** See new alert incidents in the live notification badge and open the affected cases directly from a bounded, scrollable inbox.
 - **Improve rules with evidence.** Use labels, precision/recall reports, backtests, shadow rules, and percentage rollouts before changing production decisions.
 - **Use reproducible historical features.** Computed counts, distinct values, sums, averages, extrema, standard deviation, and days-since features follow documented point-in-time, correction, null, and type semantics.
@@ -62,6 +63,10 @@ Create and maintain the rule set from a reviewable UI. Active rules, drafts, ord
 Switch the dashboard to the 30-day window to review sustained traffic and outcome patterns instead of a single point-in-time snapshot.
 
 ![30-day outcome trends](docs/assets/readme/dashboard-30d-outcomes.png)
+
+### Run Case Operations
+
+Open **Operations** for a bounded 7-, 30-, or 90-day view of the case queue. It combines current active and unassigned totals with daily opened/resolved flow, a false-positive rate based on dispositioned cases, the ten highest-priority aging cases, and the five rules that opened the most cases. Use **Open Cases** when the summary shows work that needs action.
 
 ### Inspect Rule Logic And Performance
 

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -220,6 +220,21 @@ Dashboard analytics source of truth:
 - Time buckets are anchored on `evaluation_decisions.evaluated_at`, so charts show when a decision was served rather than the event's business timestamp.
 - Label analytics and rule-quality endpoints use canonical `event_version_labels` joined to served decisions and event labels; label chart buckets are anchored on served decision time.
 
+### Operations Summary
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| `GET` | `/api/v2/operations/summary` | Bearer + `VIEW_CASES` | Return one organisation-scoped case-operations snapshot; `days` accepts only `7`, `30`, or `90` and defaults to `30` |
+
+Operations metric contract:
+
+- `period_start` is midnight UTC on the first calendar day in the window; `period_end` and `generated_at` are the snapshot time.
+- `active_cases` counts cases currently in `open`, `in_review`, or `reopened`; `unassigned_cases` is the subset with no assignee. These two snapshot totals are not constrained by `days`.
+- `resolved_cases`, `dispositioned_cases`, and `false_positive_cases` use `resolved_at` in the selected period. `false_positive_rate` is `false_positive_cases / dispositioned_cases`, or `null` when no dispositioned cases exist.
+- `case_flow` contains exactly one UTC calendar-day point per requested day, with cases grouped by `created_at` and `resolved_at`.
+- `attention_cases` contains at most ten active cases, ordered by priority descending, creation time ascending, then case ID. `age_seconds` is measured at `generated_at`.
+- `noisy_rules` contains at most five rules ranked by distinct cases opened in the window. Rule identity and description come from the immutable `evaluation_rule_results` snapshot attached to each case's `opened_by_ed_id`, with the current rule record used only as a legacy fallback.
+
 ### Agent Tools
 
 Deterministic agent tools expose bounded evidence packets for future fraud-management agents. They do not provide generic database access and they replay current served decisions through the same rule compiler, field normalization, user-list lookup, and computed-feature resolution paths used by rule analysis.

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -233,7 +233,7 @@ Operations metric contract:
 - `resolved_cases`, `dispositioned_cases`, and `false_positive_cases` use `resolved_at` in the selected period. `false_positive_rate` is `false_positive_cases / dispositioned_cases`, or `null` when no dispositioned cases exist.
 - `case_flow` contains exactly one UTC calendar-day point per requested day, with cases grouped by `created_at` and `resolved_at`.
 - `attention_cases` contains at most ten active cases, ordered by priority descending, creation time ascending, then case ID. `age_seconds` is measured at `generated_at`.
-- `noisy_rules` contains at most five rules ranked by distinct cases opened in the window. Rule identity and description come from the immutable `evaluation_rule_results` snapshot attached to each case's `opened_by_ed_id`, with the current rule record used only as a legacy fallback. If a hard deletion removed both records, the opening decision's immutable `all_rule_results` snapshot preserves the count under `rule_<id>` / `Deleted rule`.
+- `noisy_rules` contains at most five rules ranked by distinct cases opened in the window. A rule is attributed only when its immutable result equals the opening decision's resolved outcome, so neutral or lower-severity results from the same evaluation do not receive credit for the case. Identity and description come from the `evaluation_rule_results` snapshot attached to `opened_by_ed_id`, with the current rule record used only as a legacy fallback. If a hard deletion removed both records, the opening decision's immutable `all_rule_results` snapshot preserves the count under `rule_<id>` / `Deleted rule`.
 
 ### Agent Tools
 

--- a/docs/api-reference/manager-api.md
+++ b/docs/api-reference/manager-api.md
@@ -233,7 +233,7 @@ Operations metric contract:
 - `resolved_cases`, `dispositioned_cases`, and `false_positive_cases` use `resolved_at` in the selected period. `false_positive_rate` is `false_positive_cases / dispositioned_cases`, or `null` when no dispositioned cases exist.
 - `case_flow` contains exactly one UTC calendar-day point per requested day, with cases grouped by `created_at` and `resolved_at`.
 - `attention_cases` contains at most ten active cases, ordered by priority descending, creation time ascending, then case ID. `age_seconds` is measured at `generated_at`.
-- `noisy_rules` contains at most five rules ranked by distinct cases opened in the window. Rule identity and description come from the immutable `evaluation_rule_results` snapshot attached to each case's `opened_by_ed_id`, with the current rule record used only as a legacy fallback.
+- `noisy_rules` contains at most five rules ranked by distinct cases opened in the window. Rule identity and description come from the immutable `evaluation_rule_results` snapshot attached to each case's `opened_by_ed_id`, with the current rule record used only as a legacy fallback. If a hard deletion removed both records, the opening decision's immutable `all_rule_results` snapshot preserves the count under `rule_<id>` / `Deleted rule`.
 
 ### Agent Tools
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -13,7 +13,7 @@ By the end of this page, you should have:
 - one saved rule
 - one allowed outcome used by that rule
 - one successful rule test in UI
-- chart activity in **Dashboard** or **Analytics**, and configure spike notifications in **Alerts**
+- chart activity in **Dashboard** or **Analytics**, case queue health in **Operations**, and spike notifications in **Alerts**
 
 ---
 
@@ -61,7 +61,7 @@ By the end of this page, you should have:
 
 1. Open [http://localhost:4200](http://localhost:4200)
 2. Sign in with your created user
-3. Confirm sidebar shows: **Dashboard**, **Rules**, **Shadow Rules**, **Rule Rollouts**, **Labels**, **Outcomes**, **Analytics**, **Rule Quality**, **Alerts**, **Cases**
+3. Confirm sidebar shows: **Dashboard**, **Operations**, **Rules**, **Shadow Rules**, **Rule Rollouts**, **Labels**, **Outcomes**, **Analytics**, **Rule Quality**, **Alerts**, **Cases**
 
 ---
 

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -2,8 +2,9 @@
 
 Monitoring is where rule quality becomes visible. Use this page for a fast operational check.
 
-You should be able to answer four questions quickly:
+You should be able to answer six questions quickly:
 
+- Is the case queue growing, and which work needs attention first?
 - Are events flowing as expected?
 - Which concrete transactions were just processed, and which rules fired for each one?
 - Which active rules are currently noisy, and which active rules are silent?
@@ -12,7 +13,23 @@ You should be able to answer four questions quickly:
 
 ---
 
-## 1) Check Event Flow (Dashboard)
+## 1) Check Case Queue Health (Operations)
+
+Open **Operations** in the sidebar when you need a compact management view rather than another investigation queue. Choose a 7-, 30-, or 90-day window and review:
+
+- **Active cases now**: all open, in-review, and reopened cases at generation time
+- **Unassigned now**: active cases with no owner at generation time
+- **Resolved in period**: cases whose `resolved_at` falls in the selected calendar-day window
+- **False-positive rate**: false-positive dispositions divided by all dispositioned cases resolved in that window; shown as unavailable when the denominator is zero
+- **Cases opened vs resolved**: daily flow for the selected window
+- **Needs attention**: up to ten active cases, ordered by priority descending and then oldest first
+- **Noisiest rules**: up to five rules ranked by cases opened in the selected window, using the immutable rule metadata stored with each case's opening evaluation
+
+The page is read-only and requires `VIEW_CASES`. Use **Refresh** for a new snapshot and **Open Cases** to assign, investigate, note, or resolve work in the existing Cases workflow. The current active/unassigned totals are not constrained by the selected historical window; the resolved, flow, and noisy-rule metrics are.
+
+---
+
+## 2) Check Event Flow (Dashboard)
 
 Open **Dashboard** in the sidebar and verify:
 
@@ -46,7 +63,7 @@ Use **Alerts** when an outcome needs active attention instead of passive chart r
 
 ---
 
-## 2) Inspect Recent Tested Events
+## 3) Inspect Recent Tested Events
 
 Open **Tested Events** in the sidebar and review the latest stored evaluations.
 
@@ -79,7 +96,7 @@ Healthy signal:
 
 ---
 
-## 3) Check Label Feedback (Analytics)
+## 4) Check Label Feedback (Analytics)
 
 Open **Analytics** in the sidebar and verify:
 
@@ -100,7 +117,7 @@ Healthy signal:
 
 ---
 
-## 4) Rank Rule Quality (Rule Quality Page)
+## 5) Rank Rule Quality (Rule Quality Page)
 
 Open **Rule Quality** in the sidebar and review:
 
@@ -129,7 +146,7 @@ Healthy signal:
 
 ---
 
-## 5) Drill Down via API
+## 6) Drill Down via API
 
 - `GET /api/v2/tested-events?limit=50`
 - `GET /api/v2/analytics/transaction-volume?aggregation=30d`
@@ -143,6 +160,7 @@ Healthy signal:
 - `GET /api/v2/alerts/rules`
 - `GET /api/v2/alerts/incidents`
 - `GET /api/v2/notifications/unread-count`
+- `GET /api/v2/operations/summary?days=30`
 
 Tip: responses are structured for Chart.js (`labels` + dataset series).
 
@@ -180,12 +198,13 @@ ORDER BY hour;
 
 ---
 
-## 6) Common Symptoms
+## 7) Common Symptoms
 
 | Symptom | Likely Cause | Fix |
 |---|---|---|
 | Tested Events page is empty | No events have been persisted yet | Send traffic to `POST /api/v2/evaluate` or seed demo/test data |
 | Dashboard charts are empty | No recent events in selected window | Submit new events and switch aggregation to `30d` |
+| Operations false-positive rate is unavailable | No cases resolved with a disposition in the selected window | Resolve cases with a disposition or choose a wider period |
 | Outcome charts empty but volume exists | Rules return no allowed outcomes | Verify rule returns valid outcomes and outcome exists in **Outcomes** |
 | Label charts empty | No labels marked/uploaded | Add labels via UI workflow or `POST /api/v2/labels/mark-event` |
 | Rule quality page empty | No labeled events or support threshold too high | Label events first, then reduce **Min support** |

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,5 +1,11 @@
 # What's New
 
+## v1.30.0
+
+* **Operations dashboard MVP**: A new read-only Operations page gives case viewers one bounded summary of active and unassigned work, cases resolved in the selected 7-, 30-, or 90-day period, and false-positive rate.
+* **Focused queue triage**: Daily opened-versus-resolved flow, the ten highest-priority aging cases, and the five rules opening the most cases point managers toward the existing Cases workflow without introducing a second queue.
+* **Stable metric contract**: The organisation-scoped summary API uses immutable opening-evaluation rule snapshots, returns explicit generated/window timestamps, and represents rates with no valid denominator as unavailable rather than zero.
+
 ## v1.29.2
 
 * **Live alert visibility**: The sidebar notification badge now refreshes automatically while an analyst remains on the current page, so new outcome-spike incidents become visible without a manual reload or navigation.

--- a/ezrules/backend/api_v2/main.py
+++ b/ezrules/backend/api_v2/main.py
@@ -31,6 +31,7 @@ from ezrules.backend.api_v2.routes import (
     features,
     field_types,
     labels,
+    operations,
     outcomes,
     roles,
     rollouts,
@@ -194,6 +195,9 @@ app.include_router(settings.router)
 
 # Case management and integration event routes: /api/v2/cases/*, /api/v2/integration-*
 app.include_router(cases.router)
+
+# Operations dashboard routes: /api/v2/operations/*
+app.include_router(operations.router)
 
 # Deterministic agent tool routes: /api/v2/agent-tools/*
 app.include_router(agent_tools.router)

--- a/ezrules/backend/api_v2/routes/operations.py
+++ b/ezrules/backend/api_v2/routes/operations.py
@@ -1,6 +1,7 @@
 """Read-only operational case metrics for managers."""
 
-from typing import Any, Literal
+import enum
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 
@@ -18,9 +19,18 @@ from ezrules.models.backend_core import User
 router = APIRouter(prefix="/api/v2/operations", tags=["Operations"])
 
 
+class OperationsDays(enum.IntEnum):
+    SEVEN = 7
+    THIRTY = 30
+    NINETY = 90
+
+
 @router.get("/summary", response_model=OperationsSummaryResponse)
 def get_operations_summary(
-    days: Literal[7, 30, 90] = Query(default=30, description="Calendar-day reporting window"),
+    days: OperationsDays = Query(
+        default=OperationsDays.THIRTY,
+        description="Calendar-day reporting window",
+    ),
     user: User = Depends(get_current_active_user),
     _: None = Depends(require_permission(PermissionAction.VIEW_CASES)),
     current_org_id: int = Depends(get_current_org_id),

--- a/ezrules/backend/api_v2/routes/operations.py
+++ b/ezrules/backend/api_v2/routes/operations.py
@@ -1,0 +1,30 @@
+"""Read-only operational case metrics for managers."""
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, Query
+
+from ezrules.backend.api_v2.auth.dependencies import (
+    get_current_active_user,
+    get_current_org_id,
+    get_db,
+    require_permission,
+)
+from ezrules.backend.api_v2.schemas.operations import OperationsSummaryResponse
+from ezrules.backend.operations_analytics import build_operations_summary
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import User
+
+router = APIRouter(prefix="/api/v2/operations", tags=["Operations"])
+
+
+@router.get("/summary", response_model=OperationsSummaryResponse)
+def get_operations_summary(
+    days: Literal[7, 30, 90] = Query(default=30, description="Calendar-day reporting window"),
+    user: User = Depends(get_current_active_user),
+    _: None = Depends(require_permission(PermissionAction.VIEW_CASES)),
+    current_org_id: int = Depends(get_current_org_id),
+    db: Any = Depends(get_db),
+) -> OperationsSummaryResponse:
+    """Return one bounded operational summary for the caller's organisation."""
+    return OperationsSummaryResponse.model_validate(build_operations_summary(db, o_id=current_org_id, days=days))

--- a/ezrules/backend/api_v2/schemas/operations.py
+++ b/ezrules/backend/api_v2/schemas/operations.py
@@ -1,0 +1,47 @@
+"""Response contracts for the operations dashboard MVP."""
+
+import datetime
+
+from pydantic import BaseModel, Field
+
+
+class OperationsMetrics(BaseModel):
+    active_cases: int = Field(..., ge=0)
+    unassigned_cases: int = Field(..., ge=0)
+    resolved_cases: int = Field(..., ge=0)
+    dispositioned_cases: int = Field(..., ge=0)
+    false_positive_cases: int = Field(..., ge=0)
+    false_positive_rate: float | None = Field(..., ge=0, le=1)
+
+
+class OperationsCaseFlowPoint(BaseModel):
+    date: datetime.date
+    opened: int = Field(..., ge=0)
+    resolved: int = Field(..., ge=0)
+
+
+class OperationsAttentionCase(BaseModel):
+    case_id: int
+    outcome: str | None = None
+    assigned_to_email: str | None = None
+    age_seconds: int = Field(..., ge=0)
+
+
+class OperationsNoisyRule(BaseModel):
+    rid: str
+    description: str
+    case_count: int = Field(..., ge=0)
+    resolved_count: int = Field(..., ge=0)
+    false_positive_count: int = Field(..., ge=0)
+    false_positive_rate: float | None = Field(..., ge=0, le=1)
+
+
+class OperationsSummaryResponse(BaseModel):
+    days: int
+    period_start: datetime.datetime
+    period_end: datetime.datetime
+    generated_at: datetime.datetime
+    summary: OperationsMetrics
+    case_flow: list[OperationsCaseFlowPoint]
+    attention_cases: list[OperationsAttentionCase]
+    noisy_rules: list[OperationsNoisyRule]

--- a/ezrules/backend/operations_analytics.py
+++ b/ezrules/backend/operations_analytics.py
@@ -112,12 +112,13 @@ def _noisy_rules(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[s
             sa.func.max(Case.resolution_disposition).label("resolution_disposition"),
         )
         .join(EvaluationRuleResult, EvaluationRuleResult.ed_id == Case.opened_by_ed_id)
+        .join(EvaluationDecision, EvaluationDecision.ed_id == Case.opened_by_ed_id)
         .outerjoin(Rule, Rule.r_id == EvaluationRuleResult.r_id)
         .filter(
             Case.o_id == o_id,
             Case.created_at >= period.start,
             Case.created_at < period.end,
-            EvaluationRuleResult.rule_result.isnot(None),
+            EvaluationRuleResult.rule_result == EvaluationDecision.resolved_outcome,
         )
         .group_by(Case.case_id, EvaluationRuleResult.r_id)
     )
@@ -153,7 +154,7 @@ def _noisy_rules(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[s
             Case.created_at >= period.start,
             Case.created_at < period.end,
             EvaluationRuleResult.err_id.is_(None),
-            sa.func.jsonb_typeof(expanded_results.c.value) != "null",
+            expanded_results.c.value == sa.func.to_jsonb(EvaluationDecision.resolved_outcome),
         )
     )
     case_rule_pairs = snapshot_pairs.union_all(deleted_rule_pairs).subquery()

--- a/ezrules/backend/operations_analytics.py
+++ b/ezrules/backend/operations_analytics.py
@@ -1,0 +1,227 @@
+"""Bounded operational case metrics for the manager dashboard."""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import Any
+
+import sqlalchemy as sa
+
+from ezrules.backend.cases import ACTIVE_CASE_STATUSES
+from ezrules.models.backend_core import Case, EvaluationRuleResult, Rule, User
+
+ATTENTION_CASE_LIMIT = 10
+NOISY_RULE_LIMIT = 5
+
+
+@dataclass(frozen=True, slots=True)
+class OperationsPeriod:
+    days: int
+    start: datetime.datetime
+    end: datetime.datetime
+    generated_at: datetime.datetime
+
+
+def _utc_datetime(value: datetime.datetime) -> datetime.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.UTC)
+    return value.astimezone(datetime.UTC)
+
+
+def _rate(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return round(numerator / denominator, 4)
+
+
+def build_operations_period(days: int, *, now: datetime.datetime | None = None) -> OperationsPeriod:
+    generated_at = _utc_datetime(now or datetime.datetime.now(datetime.UTC))
+    start_date = generated_at.date() - datetime.timedelta(days=days - 1)
+    start = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=datetime.UTC)
+    return OperationsPeriod(days=days, start=start, end=generated_at, generated_at=generated_at)
+
+
+def _case_flow(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[str, Any]]:
+    opened_day = sa.cast(Case.created_at, sa.Date)
+    opened_rows = (
+        db.query(opened_day.label("day"), sa.func.count(Case.case_id).label("count"))
+        .filter(
+            Case.o_id == o_id,
+            Case.created_at >= period.start,
+            Case.created_at < period.end,
+        )
+        .group_by(opened_day)
+        .all()
+    )
+    resolved_day = sa.cast(Case.resolved_at, sa.Date)
+    resolved_rows = (
+        db.query(resolved_day.label("day"), sa.func.count(Case.case_id).label("count"))
+        .filter(
+            Case.o_id == o_id,
+            Case.resolved_at >= period.start,
+            Case.resolved_at < period.end,
+        )
+        .group_by(resolved_day)
+        .all()
+    )
+    opened_counts = {row.day: int(row.count) for row in opened_rows}
+    resolved_counts = {row.day: int(row.count) for row in resolved_rows}
+    return [
+        {
+            "date": period.start.date() + datetime.timedelta(days=offset),
+            "opened": opened_counts.get(period.start.date() + datetime.timedelta(days=offset), 0),
+            "resolved": resolved_counts.get(period.start.date() + datetime.timedelta(days=offset), 0),
+        }
+        for offset in range(period.days)
+    ]
+
+
+def _attention_cases(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[str, Any]]:
+    rows = (
+        db.query(Case, User.email.label("assignee_email"))
+        .outerjoin(User, User.id == Case.assigned_to_user_id)
+        .filter(Case.o_id == o_id, Case.status.in_(ACTIVE_CASE_STATUSES))
+        .order_by(Case.priority.desc(), Case.created_at.asc(), Case.case_id.asc())
+        .limit(ATTENTION_CASE_LIMIT)
+        .all()
+    )
+    return [
+        {
+            "case_id": int(case.case_id),
+            "outcome": str(case.resolved_outcome) if case.resolved_outcome else None,
+            "assigned_to_email": str(assignee_email) if assignee_email else None,
+            "age_seconds": max(
+                0,
+                int((period.generated_at - _utc_datetime(case.created_at)).total_seconds()),
+            ),
+        }
+        for case, assignee_email in rows
+    ]
+
+
+def _noisy_rules(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[str, Any]]:
+    case_rule_pairs = (
+        db.query(
+            Case.case_id.label("case_id"),
+            EvaluationRuleResult.r_id.label("rule_id"),
+            sa.func.max(sa.func.coalesce(EvaluationRuleResult.rule_rid, Rule.rid)).label("rid"),
+            sa.func.max(sa.func.coalesce(EvaluationRuleResult.rule_description, Rule.description)).label("description"),
+            sa.func.max(Case.resolved_at).label("resolved_at"),
+            sa.func.max(Case.resolution_disposition).label("resolution_disposition"),
+        )
+        .join(EvaluationRuleResult, EvaluationRuleResult.ed_id == Case.opened_by_ed_id)
+        .outerjoin(Rule, Rule.r_id == EvaluationRuleResult.r_id)
+        .filter(
+            Case.o_id == o_id,
+            Case.created_at >= period.start,
+            Case.created_at < period.end,
+            EvaluationRuleResult.rule_result.isnot(None),
+        )
+        .group_by(Case.case_id, EvaluationRuleResult.r_id)
+        .subquery()
+    )
+
+    case_count = sa.func.count(case_rule_pairs.c.case_id)
+    resolved_count = sa.func.sum(sa.case((case_rule_pairs.c.resolved_at.isnot(None), 1), else_=0))
+    dispositioned_count = sa.func.sum(sa.case((case_rule_pairs.c.resolution_disposition.isnot(None), 1), else_=0))
+    false_positive_count = sa.func.sum(
+        sa.case((case_rule_pairs.c.resolution_disposition == "false_positive", 1), else_=0)
+    )
+    rows = (
+        db.query(
+            case_rule_pairs.c.rule_id,
+            sa.func.max(case_rule_pairs.c.rid).label("rid"),
+            sa.func.max(case_rule_pairs.c.description).label("description"),
+            case_count.label("case_count"),
+            resolved_count.label("resolved_count"),
+            dispositioned_count.label("dispositioned_count"),
+            false_positive_count.label("false_positive_count"),
+        )
+        .group_by(case_rule_pairs.c.rule_id)
+        .order_by(case_count.desc(), sa.func.max(case_rule_pairs.c.rid).asc())
+        .limit(NOISY_RULE_LIMIT)
+        .all()
+    )
+    return [
+        {
+            "rid": str(row.rid or f"rule_{row.rule_id}"),
+            "description": str(row.description or "Historical rule"),
+            "case_count": int(row.case_count),
+            "resolved_count": int(row.resolved_count or 0),
+            "false_positive_count": int(row.false_positive_count or 0),
+            "false_positive_rate": _rate(
+                int(row.false_positive_count or 0),
+                int(row.dispositioned_count or 0),
+            ),
+        }
+        for row in rows
+    ]
+
+
+def build_operations_summary(
+    db: Any,
+    *,
+    o_id: int,
+    days: int,
+    now: datetime.datetime | None = None,
+) -> dict[str, Any]:
+    """Return one bounded, org-scoped operational summary."""
+    period = build_operations_period(days, now=now)
+    active_filter = Case.status.in_(ACTIVE_CASE_STATUSES)
+    active_cases = int(db.query(sa.func.count(Case.case_id)).filter(Case.o_id == o_id, active_filter).scalar() or 0)
+    unassigned_cases = int(
+        db.query(sa.func.count(Case.case_id))
+        .filter(Case.o_id == o_id, active_filter, Case.assigned_to_user_id.is_(None))
+        .scalar()
+        or 0
+    )
+    resolved_cases = int(
+        db.query(sa.func.count(Case.case_id))
+        .filter(
+            Case.o_id == o_id,
+            Case.resolved_at >= period.start,
+            Case.resolved_at < period.end,
+        )
+        .scalar()
+        or 0
+    )
+    dispositioned_cases = int(
+        db.query(sa.func.count(Case.case_id))
+        .filter(
+            Case.o_id == o_id,
+            Case.resolved_at >= period.start,
+            Case.resolved_at < period.end,
+            Case.resolution_disposition.isnot(None),
+        )
+        .scalar()
+        or 0
+    )
+    false_positive_cases = int(
+        db.query(sa.func.count(Case.case_id))
+        .filter(
+            Case.o_id == o_id,
+            Case.resolved_at >= period.start,
+            Case.resolved_at < period.end,
+            Case.resolution_disposition == "false_positive",
+        )
+        .scalar()
+        or 0
+    )
+    return {
+        "days": period.days,
+        "period_start": period.start,
+        "period_end": period.end,
+        "generated_at": period.generated_at,
+        "summary": {
+            "active_cases": active_cases,
+            "unassigned_cases": unassigned_cases,
+            "resolved_cases": resolved_cases,
+            "dispositioned_cases": dispositioned_cases,
+            "false_positive_cases": false_positive_cases,
+            "false_positive_rate": _rate(false_positive_cases, dispositioned_cases),
+        },
+        "case_flow": _case_flow(db, o_id=o_id, period=period),
+        "attention_cases": _attention_cases(db, o_id=o_id, period=period),
+        "noisy_rules": _noisy_rules(db, o_id=o_id, period=period),
+    }

--- a/ezrules/backend/operations_analytics.py
+++ b/ezrules/backend/operations_analytics.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass
 from typing import Any
 
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
 
 from ezrules.backend.cases import ACTIVE_CASE_STATUSES
-from ezrules.models.backend_core import Case, EvaluationRuleResult, Rule, User
+from ezrules.models.backend_core import Case, EvaluationDecision, EvaluationRuleResult, Rule, User
 
 ATTENTION_CASE_LIMIT = 10
 NOISY_RULE_LIMIT = 5
@@ -101,7 +102,7 @@ def _attention_cases(db: Any, *, o_id: int, period: OperationsPeriod) -> list[di
 
 
 def _noisy_rules(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[str, Any]]:
-    case_rule_pairs = (
+    snapshot_pairs = (
         db.query(
             Case.case_id.label("case_id"),
             EvaluationRuleResult.r_id.label("rule_id"),
@@ -119,8 +120,43 @@ def _noisy_rules(db: Any, *, o_id: int, period: OperationsPeriod) -> list[dict[s
             EvaluationRuleResult.rule_result.isnot(None),
         )
         .group_by(Case.case_id, EvaluationRuleResult.r_id)
-        .subquery()
     )
+
+    raw_all_rule_results = sa.cast(EvaluationDecision.all_rule_results, JSONB)
+    safe_all_rule_results = sa.case(
+        (sa.func.jsonb_typeof(raw_all_rule_results) == "object", raw_all_rule_results),
+        else_=sa.cast(sa.literal("{}"), JSONB),
+    )
+    expanded_results = sa.func.jsonb_each(safe_all_rule_results).table_valued("key", "value").lateral()
+    expanded_rule_id = sa.cast(expanded_results.c.key, sa.Integer)
+    deleted_rule_pairs = (
+        db.query(
+            Case.case_id.label("case_id"),
+            expanded_rule_id.label("rule_id"),
+            sa.func.coalesce(Rule.rid, sa.func.concat("rule_", expanded_results.c.key)).label("rid"),
+            sa.func.coalesce(Rule.description, sa.literal("Deleted rule")).label("description"),
+            Case.resolved_at.label("resolved_at"),
+            Case.resolution_disposition.label("resolution_disposition"),
+        )
+        .join(EvaluationDecision, EvaluationDecision.ed_id == Case.opened_by_ed_id)
+        .join(expanded_results, sa.true())
+        .outerjoin(
+            EvaluationRuleResult,
+            sa.and_(
+                EvaluationRuleResult.ed_id == EvaluationDecision.ed_id,
+                EvaluationRuleResult.r_id == expanded_rule_id,
+            ),
+        )
+        .outerjoin(Rule, Rule.r_id == expanded_rule_id)
+        .filter(
+            Case.o_id == o_id,
+            Case.created_at >= period.start,
+            Case.created_at < period.end,
+            EvaluationRuleResult.err_id.is_(None),
+            sa.func.jsonb_typeof(expanded_results.c.value) != "null",
+        )
+    )
+    case_rule_pairs = snapshot_pairs.union_all(deleted_rule_pairs).subquery()
 
     case_count = sa.func.count(case_rule_pairs.c.case_id)
     resolved_count = sa.func.sum(sa.case((case_rule_pairs.c.resolved_at.isnot(None), 1), else_=0))

--- a/ezrules/frontend/e2e/pages/operations-dashboard.page.ts
+++ b/ezrules/frontend/e2e/pages/operations-dashboard.page.ts
@@ -1,0 +1,35 @@
+import { Locator, Page } from '@playwright/test';
+
+export class OperationsDashboardPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly period: Locator;
+  readonly refresh: Locator;
+  readonly retry: Locator;
+  readonly activeCases: Locator;
+  readonly unassignedCases: Locator;
+  readonly resolvedCases: Locator;
+  readonly falsePositiveRate: Locator;
+  readonly attentionTable: Locator;
+  readonly rulesTable: Locator;
+  readonly openCases: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: 'Operations', exact: true });
+    this.period = page.getByTestId('operations-period');
+    this.refresh = page.getByTestId('operations-refresh');
+    this.retry = page.getByTestId('operations-retry');
+    this.activeCases = page.getByTestId('operations-active-cases');
+    this.unassignedCases = page.getByTestId('operations-unassigned-cases');
+    this.resolvedCases = page.getByTestId('operations-resolved-cases');
+    this.falsePositiveRate = page.getByTestId('operations-false-positive-rate');
+    this.attentionTable = page.getByTestId('operations-attention-table');
+    this.rulesTable = page.getByTestId('operations-rules-table');
+    this.openCases = page.getByTestId('operations-open-cases');
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/operations');
+  }
+}

--- a/ezrules/frontend/e2e/tests/operations-dashboard.spec.ts
+++ b/ezrules/frontend/e2e/tests/operations-dashboard.spec.ts
@@ -1,0 +1,198 @@
+import { expect, Page, test } from '@playwright/test';
+import type { OperationsSummaryResponse } from '../../src/app/services/operations-dashboard.service';
+import { OperationsDashboardPage } from '../pages/operations-dashboard.page';
+
+async function mockAuth(page: Page, permissions: string[] = ['view_cases']): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('ezrules_access_token', 'operations-spec-token');
+  });
+  await page.route('**/api/v2/auth/me', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      id: 1,
+      email: 'operations.manager@example.com',
+      active: true,
+      roles: [{ id: 1, name: 'operations_manager', description: 'Operations manager' }],
+      permissions,
+      last_login_at: null,
+    }),
+  }));
+  await page.route('**/api/v2/notifications**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(route.request().url().includes('unread-count') ? { unread_count: 0 } : { notifications: [] }),
+  }));
+}
+
+function summary(days = 30): OperationsSummaryResponse {
+  const start = new Date(Date.UTC(2026, 5, 22));
+  return {
+    days,
+    period_start: start.toISOString(),
+    period_end: '2026-07-21T14:32:00Z',
+    generated_at: '2026-07-21T14:32:00Z',
+    summary: {
+      active_cases: 184,
+      unassigned_cases: 37,
+      resolved_cases: 458,
+      dispositioned_cases: 459,
+      false_positive_cases: 146,
+      false_positive_rate: 0.3181,
+    },
+    case_flow: Array.from({ length: days }, (_, index) => ({
+      date: new Date(start.getTime() + index * 86_400_000).toISOString().slice(0, 10),
+      opened: index % 5,
+      resolved: (index + 2) % 4,
+    })),
+    attention_cases: [{
+      case_id: 2841,
+      outcome: 'CANCEL',
+      assigned_to_email: null,
+      age_seconds: 187200,
+    }],
+    noisy_rules: [{
+      rid: 'beneficiary_velocity_24h',
+      description: 'Beneficiary Velocity 24h',
+      case_count: 91,
+      resolved_count: 72,
+      false_positive_count: 35,
+      false_positive_rate: 0.4861,
+    }],
+  };
+}
+
+test.describe('Operations dashboard MVP', () => {
+  test('shows bounded case metrics and the two action tables', async ({ page }) => {
+    await mockAuth(page);
+    await page.route('**/api/v2/operations/summary?**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(summary()),
+    }));
+    const operations = new OperationsDashboardPage(page);
+
+    await operations.goto();
+
+    await expect(operations.heading).toBeVisible();
+    await expect(operations.activeCases).toHaveText('184');
+    await expect(operations.unassignedCases).toHaveText('37');
+    await expect(operations.resolvedCases).toHaveText('458');
+    await expect(operations.falsePositiveRate).toHaveText('31.8%');
+    await expect(operations.attentionTable).toContainText('#2841');
+    await expect(operations.attentionTable).toContainText('Unassigned');
+    await expect(operations.rulesTable).toContainText('Beneficiary Velocity 24h');
+    await expect(page.getByTestId('operations-case-flow-chart')).toBeVisible();
+  });
+
+  test('reloads only when the period changes or the user refreshes', async ({ page }) => {
+    await mockAuth(page);
+    const requestedDays: string[] = [];
+    await page.route('**/api/v2/operations/summary?**', route => {
+      const days = new URL(route.request().url()).searchParams.get('days') || '30';
+      requestedDays.push(days);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(summary(Number(days))),
+      });
+    });
+    const operations = new OperationsDashboardPage(page);
+    await operations.goto();
+    await expect(operations.activeCases).toBeVisible();
+
+    await operations.period.selectOption('7');
+    await expect.poll(() => requestedDays).toEqual(['30', '7']);
+    await operations.refresh.click();
+    await expect.poll(() => requestedDays).toEqual(['30', '7', '7']);
+  });
+
+  test('shows empty states without treating them as errors', async ({ page }) => {
+    await mockAuth(page);
+    const empty = summary();
+    empty.summary.active_cases = 0;
+    empty.summary.unassigned_cases = 0;
+    empty.summary.resolved_cases = 0;
+    empty.summary.dispositioned_cases = 0;
+    empty.summary.false_positive_cases = 0;
+    empty.summary.false_positive_rate = null;
+    empty.attention_cases = [];
+    empty.noisy_rules = [];
+    await page.route('**/api/v2/operations/summary?**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(empty),
+    }));
+    const operations = new OperationsDashboardPage(page);
+
+    await operations.goto();
+
+    await expect(operations.falsePositiveRate).toHaveText('—');
+    await expect(page.getByTestId('operations-attention-empty')).toBeVisible();
+    await expect(page.getByTestId('operations-rules-empty')).toBeVisible();
+  });
+
+  test('offers a retry after a summary failure', async ({ page }) => {
+    await mockAuth(page);
+    let attempt = 0;
+    await page.route('**/api/v2/operations/summary?**', route => {
+      attempt += 1;
+      if (attempt === 1) {
+        return route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"failed"}' });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(summary()),
+      });
+    });
+    const operations = new OperationsDashboardPage(page);
+    await operations.goto();
+
+    await expect(page.getByText('Failed to load operations data.')).toBeVisible();
+    await operations.retry.click();
+    await expect(operations.activeCases).toHaveText('184');
+  });
+
+  test('requires case-view permission', async ({ page }) => {
+    await mockAuth(page, []);
+    const operations = new OperationsDashboardPage(page);
+
+    await operations.goto();
+
+    await expect(page).toHaveURL(/access-denied/);
+    await expect(page.getByRole('heading', { name: 'Access Denied' })).toBeVisible();
+  });
+
+  test('opens the existing Cases workflow', async ({ page }) => {
+    await mockAuth(page);
+    await page.route('**/api/v2/operations/summary?**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(summary()),
+    }));
+    await page.route('**/api/v2/cases?**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ cases: [], total: 0 }),
+    }));
+    await page.route('**/api/v2/cases/assignees', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ users: [] }),
+    }));
+    await page.route('**/api/v2/integration-events?**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ events: [], next_cursor: null }),
+    }));
+    const operations = new OperationsDashboardPage(page);
+    await operations.goto();
+    await expect(operations.activeCases).toBeVisible();
+
+    await operations.openCases.click();
+
+    await expect(page).toHaveURL(/\/cases$/);
+    await expect(page.getByRole('heading', { name: 'Case Review' })).toBeVisible();
+  });
+});

--- a/ezrules/frontend/e2e/tests/operations-dashboard.spec.ts
+++ b/ezrules/frontend/e2e/tests/operations-dashboard.spec.ts
@@ -101,7 +101,7 @@ test.describe('Operations dashboard MVP', () => {
     await operations.goto();
     await expect(operations.activeCases).toBeVisible();
 
-    await operations.period.selectOption('7');
+    await operations.period.selectOption({ label: 'Last 7 days' });
     await expect.poll(() => requestedDays).toEqual(['30', '7']);
     await operations.refresh.click();
     await expect.poll(() => requestedDays).toEqual(['30', '7', '7']);
@@ -193,6 +193,6 @@ test.describe('Operations dashboard MVP', () => {
     await operations.openCases.click();
 
     await expect(page).toHaveURL(/\/cases$/);
-    await expect(page.getByRole('heading', { name: 'Case Review' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Cases', exact: true })).toBeVisible();
   });
 });

--- a/ezrules/frontend/src/app/app.routes.ts
+++ b/ezrules/frontend/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { LabelAnalyticsComponent } from './label-analytics/label-analytics.compo
 import { RuleQualityComponent } from './rule-quality/rule-quality.component';
 import { UserListsComponent } from './user-lists/user-lists.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { OperationsDashboardComponent } from './operations-dashboard/operations-dashboard.component';
 import { UserManagementComponent } from './user-management/user-management.component';
 import { RoleManagementComponent } from './role-management/role-management.component';
 import { RolePermissionsComponent } from './role-permissions/role-permissions.component';
@@ -48,6 +49,12 @@ export const routes: Routes = [
     component: DashboardComponent,
     canActivate: [authGuard, permissionGuard],
     data: { permissionRequirement: ROUTE_PERMISSION_REQUIREMENTS.dashboard }
+  },
+  {
+    path: 'operations',
+    component: OperationsDashboardComponent,
+    canActivate: [authGuard, permissionGuard],
+    data: { permissionRequirement: ROUTE_PERMISSION_REQUIREMENTS.operations }
   },
   {
     path: 'rules',

--- a/ezrules/frontend/src/app/auth/permissions.ts
+++ b/ezrules/frontend/src/app/auth/permissions.ts
@@ -5,6 +5,7 @@ export interface PermissionRequirement {
 
 export const ROUTE_PERMISSION_REQUIREMENTS = {
   dashboard: { allOf: ['view_rules', 'view_outcomes'] },
+  operations: { allOf: ['view_cases'] },
   rules: { allOf: ['view_rules'] },
   ruleCreate: { allOf: ['create_rule'] },
   eventTester: { allOf: ['view_rules', 'submit_test_events'] },

--- a/ezrules/frontend/src/app/components/sidebar.component.ts
+++ b/ezrules/frontend/src/app/components/sidebar.component.ts
@@ -24,6 +24,13 @@ import { NotificationBellComponent } from './notification-bell.component';
           <span>Dashboard</span>
         </a>
 
+        <a *ngIf="canAccess(routePermissions.operations)" href="/operations" [ngClass]="linkClasses('/operations')">
+          <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 19V5m0 14h16M8 16l3-7 3 4 4-8" />
+          </svg>
+          <span>Operations</span>
+        </a>
+
         <a *ngIf="canAccess(routePermissions.rules)" href="/rules" [ngClass]="linkClasses('/rules')">
           <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/ezrules/frontend/src/app/operations-dashboard/operations-dashboard.component.html
+++ b/ezrules/frontend/src/app/operations-dashboard/operations-dashboard.component.html
@@ -1,0 +1,157 @@
+<div class="flex min-h-screen bg-gray-50">
+  <app-sidebar></app-sidebar>
+
+  <main class="ml-64 flex-1 p-8" data-testid="operations-dashboard">
+    <div class="mx-auto max-w-7xl">
+      <div class="flex items-start justify-between gap-6">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-widest text-blue-600">Case operations</p>
+          <h1 class="mt-1 text-2xl font-bold text-gray-900">Operations</h1>
+          <p class="mt-1 text-gray-500">A quick view of queue health and the rules creating review work.</p>
+        </div>
+        <a
+          routerLink="/cases"
+          class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+          data-testid="operations-open-cases"
+        >
+          Open Cases
+        </a>
+      </div>
+
+      <div class="mt-6 flex items-center justify-between rounded-xl border border-gray-200 bg-white p-3 shadow-sm">
+        <div class="flex items-center gap-2">
+          <label for="operations-period" class="text-sm font-medium text-gray-700">Period</label>
+          <select
+            id="operations-period"
+            data-testid="operations-period"
+            class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            [(ngModel)]="selectedDays"
+            (ngModelChange)="loadSummary()"
+          >
+            <option *ngFor="let period of periods" [ngValue]="period.days">{{ period.label }}</option>
+          </select>
+          <button
+            type="button"
+            data-testid="operations-refresh"
+            class="rounded-lg border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+            (click)="loadSummary()"
+            [disabled]="loading"
+          >
+            Refresh
+          </button>
+        </div>
+        <p *ngIf="data && !loading" class="text-xs text-gray-500" data-testid="operations-generated-at">
+          Generated {{ data.generated_at | date:'medium':'UTC' }} UTC
+        </p>
+      </div>
+
+      <div *ngIf="loading" class="mt-16 flex justify-center" data-testid="operations-loading">
+        <div class="h-10 w-10 animate-spin rounded-full border-b-2 border-blue-600"></div>
+      </div>
+
+      <div *ngIf="!loading && error" class="mt-6 rounded-xl border border-red-200 bg-red-50 p-5 text-red-800">
+        <p class="font-semibold">{{ error }}</p>
+        <button
+          type="button"
+          data-testid="operations-retry"
+          class="mt-3 rounded-lg bg-red-700 px-3 py-2 text-sm font-semibold text-white hover:bg-red-800"
+          (click)="loadSummary()"
+        >
+          Retry
+        </button>
+      </div>
+
+      <ng-container *ngIf="!loading && !error && data">
+        <section class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4" aria-label="Case queue summary">
+          <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-sm font-semibold text-gray-500">Active cases now</p>
+            <p class="mt-2 text-4xl font-bold text-gray-900" data-testid="operations-active-cases">{{ data.summary.active_cases }}</p>
+            <p class="mt-1 text-xs text-gray-500">Open, in review, or reopened</p>
+          </article>
+          <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-sm font-semibold text-gray-500">Unassigned now</p>
+            <p class="mt-2 text-4xl font-bold text-red-700" data-testid="operations-unassigned-cases">{{ data.summary.unassigned_cases }}</p>
+            <p class="mt-1 text-xs text-gray-500">Active cases without an owner</p>
+          </article>
+          <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-sm font-semibold text-gray-500">Resolved in period</p>
+            <p class="mt-2 text-4xl font-bold text-gray-900" data-testid="operations-resolved-cases">{{ data.summary.resolved_cases }}</p>
+            <p class="mt-1 text-xs text-gray-500">Selected {{ data.days }}-day window</p>
+          </article>
+          <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-sm font-semibold text-gray-500">False-positive rate</p>
+            <p class="mt-2 text-4xl font-bold text-gray-900" data-testid="operations-false-positive-rate">
+              {{ formatRate(data.summary.false_positive_rate) }}
+            </p>
+            <p class="mt-1 text-xs text-gray-500">
+              {{ data.summary.false_positive_cases }} of {{ data.summary.dispositioned_cases }} dispositioned cases
+            </p>
+          </article>
+        </section>
+
+        <section class="mt-4 grid grid-cols-1 gap-4 xl:grid-cols-5">
+          <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm xl:col-span-3">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900">Cases opened vs resolved</h2>
+              <p class="mt-1 text-sm text-gray-500">Daily totals in the selected period.</p>
+            </div>
+            <div class="mt-5 h-72">
+              <canvas id="operationsCaseFlowChart" data-testid="operations-case-flow-chart"></canvas>
+            </div>
+          </article>
+
+          <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm xl:col-span-2">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-900">Needs attention</h2>
+              <p class="mt-1 text-sm text-gray-500">Oldest active cases, highest priority first.</p>
+            </div>
+            <p *ngIf="data.attention_cases.length === 0" class="mt-8 text-center text-sm text-gray-500" data-testid="operations-attention-empty">
+              No active cases need attention.
+            </p>
+            <div *ngIf="data.attention_cases.length > 0" class="mt-4 overflow-x-auto">
+              <table class="min-w-full text-left text-sm" data-testid="operations-attention-table">
+                <thead class="border-b border-gray-200 text-xs uppercase tracking-wide text-gray-500">
+                  <tr><th class="px-2 py-3">Case</th><th class="px-2 py-3">Outcome</th><th class="px-2 py-3">Owner</th><th class="px-2 py-3">Age</th></tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                  <tr *ngFor="let item of data.attention_cases">
+                    <td class="px-2 py-3 font-semibold text-blue-700">#{{ item.case_id }}</td>
+                    <td class="px-2 py-3">{{ item.outcome || '—' }}</td>
+                    <td class="px-2 py-3">{{ item.assigned_to_email || 'Unassigned' }}</td>
+                    <td class="px-2 py-3 font-medium">{{ formatAge(item.age_seconds) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </section>
+
+        <section class="mt-4 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+          <div>
+            <h2 class="text-lg font-semibold text-gray-900">Noisiest rules</h2>
+            <p class="mt-1 text-sm text-gray-500">Rules that opened the most cases in the selected period.</p>
+          </div>
+          <p *ngIf="data.noisy_rules.length === 0" class="mt-8 text-center text-sm text-gray-500" data-testid="operations-rules-empty">
+            No case-opening rules were recorded in this period.
+          </p>
+          <div *ngIf="data.noisy_rules.length > 0" class="mt-4 overflow-x-auto">
+            <table class="min-w-full text-left text-sm" data-testid="operations-rules-table">
+              <thead class="border-b border-gray-200 text-xs uppercase tracking-wide text-gray-500">
+                <tr><th class="px-3 py-3">Rule</th><th class="px-3 py-3">Cases</th><th class="px-3 py-3">Resolved</th><th class="px-3 py-3">False positives</th><th class="px-3 py-3">FP rate</th></tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                <tr *ngFor="let rule of data.noisy_rules">
+                  <td class="px-3 py-3"><div class="font-semibold text-gray-900">{{ rule.description }}</div><div class="text-xs text-gray-500">{{ rule.rid }}</div></td>
+                  <td class="px-3 py-3 font-semibold">{{ rule.case_count }}</td>
+                  <td class="px-3 py-3">{{ rule.resolved_count }}</td>
+                  <td class="px-3 py-3">{{ rule.false_positive_count }}</td>
+                  <td class="px-3 py-3 font-semibold">{{ formatRate(rule.false_positive_rate) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </ng-container>
+    </div>
+  </main>
+</div>

--- a/ezrules/frontend/src/app/operations-dashboard/operations-dashboard.component.ts
+++ b/ezrules/frontend/src/app/operations-dashboard/operations-dashboard.component.ts
@@ -1,0 +1,150 @@
+import { AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { Chart, registerables } from 'chart.js';
+import { SidebarComponent } from '../components/sidebar.component';
+import {
+  OperationsDashboardService,
+  OperationsSummaryResponse
+} from '../services/operations-dashboard.service';
+
+Chart.register(...registerables);
+
+@Component({
+  selector: 'app-operations-dashboard',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, SidebarComponent],
+  templateUrl: './operations-dashboard.component.html'
+})
+export class OperationsDashboardComponent implements OnInit, AfterViewInit, OnDestroy {
+  readonly periods = [
+    { days: 7, label: 'Last 7 days' },
+    { days: 30, label: 'Last 30 days' },
+    { days: 90, label: 'Last 90 days' }
+  ];
+
+  selectedDays = 30;
+  data: OperationsSummaryResponse | null = null;
+  loading = true;
+  error: string | null = null;
+
+  private chart: Chart | null = null;
+  private canvasReady = false;
+  private requestId = 0;
+
+  constructor(
+    private readonly operationsService: OperationsDashboardService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.loadSummary();
+  }
+
+  ngAfterViewInit(): void {
+    this.canvasReady = true;
+    this.renderChartWhenReady();
+  }
+
+  ngOnDestroy(): void {
+    this.destroyChart();
+  }
+
+  loadSummary(): void {
+    const currentRequestId = ++this.requestId;
+    this.loading = true;
+    this.error = null;
+    this.operationsService.getSummary(this.selectedDays).subscribe({
+      next: (response) => {
+        if (currentRequestId !== this.requestId) {
+          return;
+        }
+        this.data = response;
+        this.loading = false;
+        this.renderChartWhenReady();
+      },
+      error: () => {
+        if (currentRequestId !== this.requestId) {
+          return;
+        }
+        this.error = 'Failed to load operations data.';
+        this.loading = false;
+        this.destroyChart();
+      }
+    });
+  }
+
+  formatRate(value: number | null): string {
+    return value === null ? '—' : `${(value * 100).toFixed(1)}%`;
+  }
+
+  formatAge(totalSeconds: number): string {
+    const totalHours = Math.floor(totalSeconds / 3600);
+    const days = Math.floor(totalHours / 24);
+    const hours = totalHours % 24;
+    if (days > 0) {
+      return `${days}d ${hours}h`;
+    }
+    if (totalHours > 0) {
+      return `${totalHours}h`;
+    }
+    return '<1h';
+  }
+
+  private renderChartWhenReady(): void {
+    if (!this.canvasReady || this.loading || !this.data) {
+      return;
+    }
+    this.cdr.detectChanges();
+    setTimeout(() => this.renderChart(), 0);
+  }
+
+  private renderChart(): void {
+    this.destroyChart();
+    const canvas = document.getElementById('operationsCaseFlowChart') as HTMLCanvasElement | null;
+    if (!canvas || !this.data || this.data.case_flow.length === 0) {
+      return;
+    }
+    this.chart = new Chart(canvas, {
+      type: 'bar',
+      data: {
+        labels: this.data.case_flow.map(point => point.date),
+        datasets: [
+          {
+            label: 'Opened',
+            data: this.data.case_flow.map(point => point.opened),
+            backgroundColor: 'rgba(96, 165, 250, 0.8)',
+            borderColor: 'rgb(59, 130, 246)',
+            borderWidth: 1,
+            borderRadius: 3
+          },
+          {
+            label: 'Resolved',
+            data: this.data.case_flow.map(point => point.resolved),
+            backgroundColor: 'rgba(52, 211, 153, 0.8)',
+            borderColor: 'rgb(16, 185, 129)',
+            borderWidth: 1,
+            borderRadius: 3
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: { beginAtZero: true, ticks: { precision: 0 } },
+          x: { ticks: { maxTicksLimit: 10 } }
+        },
+        plugins: {
+          legend: { position: 'bottom' }
+        }
+      }
+    });
+  }
+
+  private destroyChart(): void {
+    this.chart?.destroy();
+    this.chart = null;
+  }
+}

--- a/ezrules/frontend/src/app/services/operations-dashboard.service.ts
+++ b/ezrules/frontend/src/app/services/operations-dashboard.service.ts
@@ -1,0 +1,59 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface OperationsMetrics {
+  active_cases: number;
+  unassigned_cases: number;
+  resolved_cases: number;
+  dispositioned_cases: number;
+  false_positive_cases: number;
+  false_positive_rate: number | null;
+}
+
+export interface OperationsCaseFlowPoint {
+  date: string;
+  opened: number;
+  resolved: number;
+}
+
+export interface OperationsAttentionCase {
+  case_id: number;
+  outcome: string | null;
+  assigned_to_email: string | null;
+  age_seconds: number;
+}
+
+export interface OperationsNoisyRule {
+  rid: string;
+  description: string;
+  case_count: number;
+  resolved_count: number;
+  false_positive_count: number;
+  false_positive_rate: number | null;
+}
+
+export interface OperationsSummaryResponse {
+  days: number;
+  period_start: string;
+  period_end: string;
+  generated_at: string;
+  summary: OperationsMetrics;
+  case_flow: OperationsCaseFlowPoint[];
+  attention_cases: OperationsAttentionCase[];
+  noisy_rules: OperationsNoisyRule[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class OperationsDashboardService {
+  private readonly summaryUrl = `${environment.apiUrl}/api/v2/operations/summary`;
+
+  constructor(private readonly http: HttpClient) {}
+
+  getSummary(days: number): Observable<OperationsSummaryResponse> {
+    return this.http.get<OperationsSummaryResponse>(this.summaryUrl, {
+      params: new HttpParams().set('days', String(days))
+    });
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ezrules"
-version = "1.29.2"
+version = "1.30.0"
 description = "Open-source transaction monitoring engine for business rules"
 authors = [{name = "Konstantin Sofeikov", email = "sofeykov@gmail.com"}]
 readme = "README.md"

--- a/tests/test_operations_dashboard.py
+++ b/tests/test_operations_dashboard.py
@@ -38,7 +38,12 @@ def _add_case(
     assignee: User | None = None,
     resolved_at: datetime.datetime | None = None,
     disposition: str | None = None,
+    resolved_outcome: str = "HOLD",
+    rule_outcomes: list[str] | None = None,
 ) -> Case:
+    outcomes = rule_outcomes or [resolved_outcome for _rule in rules]
+    if len(outcomes) != len(rules):
+        raise ValueError("rule_outcomes must match rules")
     event = EventVersion(
         o_id=org_id,
         transaction_id=transaction_id,
@@ -61,19 +66,19 @@ def _add_case(
         decision_type="served",
         served=True,
         is_current=True,
-        outcome_counters={"HOLD": len(rules)},
-        resolved_outcome="HOLD",
-        all_rule_results={str(rule.r_id): "HOLD" for rule in rules},
+        outcome_counters={outcome: outcomes.count(outcome) for outcome in set(outcomes)},
+        resolved_outcome=resolved_outcome,
+        all_rule_results={str(rule.r_id): outcome for rule, outcome in zip(rules, outcomes, strict=True)},
         evaluated_at=created_at,
     )
     session.add(decision)
     session.flush()
-    for rule in rules:
+    for rule, outcome in zip(rules, outcomes, strict=True):
         session.add(
             EvaluationRuleResult(
                 ed_id=int(decision.ed_id),
                 r_id=int(rule.r_id),
-                rule_result="HOLD",
+                rule_result=outcome,
                 rule_rid=str(rule.rid),
                 rule_description=str(rule.description),
             )
@@ -84,7 +89,7 @@ def _add_case(
         current_ev_id=int(event.ev_id),
         current_ed_id=int(decision.ed_id),
         opened_by_ed_id=int(decision.ed_id),
-        resolved_outcome="HOLD",
+        resolved_outcome=resolved_outcome,
         status=status,
         priority=priority,
         assigned_to_user_id=int(assignee.id) if assignee else None,
@@ -303,6 +308,26 @@ def test_operations_summary_keeps_deleted_rules_in_case_attribution(session):
             "false_positive_rate": None,
         }
     ]
+
+
+def test_operations_summary_attributes_only_the_case_opening_outcome(session):
+    now = datetime.datetime(2026, 7, 21, 14, 30, tzinfo=datetime.UTC)
+    neutral_rule = _add_rule(session, org_id=1, rid="release_known_customer")
+    case_rule = _add_rule(session, org_id=1, rid="hold_high_value_transfer")
+    _add_case(
+        session,
+        org_id=1,
+        transaction_id="mixed-opening-outcomes",
+        created_at=now - datetime.timedelta(days=1),
+        rules=[neutral_rule, case_rule],
+        resolved_outcome="HOLD",
+        rule_outcomes=["RELEASE", "HOLD"],
+    )
+    session.commit()
+
+    result = build_operations_summary(session, o_id=1, days=7, now=now)
+
+    assert [rule["rid"] for rule in result["noisy_rules"]] == ["hold_high_value_transfer"]
 
 
 def test_operations_endpoint_validates_days_and_requires_view_cases(session):

--- a/tests/test_operations_dashboard.py
+++ b/tests/test_operations_dashboard.py
@@ -1,0 +1,301 @@
+import datetime
+
+from fastapi.testclient import TestClient
+
+from ezrules.backend.api_v2.auth.jwt import create_access_token
+from ezrules.backend.api_v2.main import app
+from ezrules.backend.operations_analytics import build_operations_summary
+from ezrules.core.permissions import PermissionManager
+from ezrules.core.permissions_constants import PermissionAction
+from ezrules.models.backend_core import (
+    Case,
+    EvaluationDecision,
+    EvaluationRuleResult,
+    EventVersion,
+    Organisation,
+    Role,
+    Rule,
+    User,
+)
+
+
+def _add_rule(session, *, org_id: int, rid: str) -> Rule:
+    rule = Rule(rid=rid, logic="return !HOLD", description=f"{rid} description", o_id=org_id)
+    session.add(rule)
+    session.flush()
+    return rule
+
+
+def _add_case(
+    session,
+    *,
+    org_id: int,
+    transaction_id: str,
+    created_at: datetime.datetime,
+    rules: list[Rule],
+    status: str = "open",
+    priority: int = 0,
+    assignee: User | None = None,
+    resolved_at: datetime.datetime | None = None,
+    disposition: str | None = None,
+) -> Case:
+    event = EventVersion(
+        o_id=org_id,
+        transaction_id=transaction_id,
+        event_version=1,
+        effective_at=created_at,
+        observed_at=created_at,
+        event_data={"transaction_id": transaction_id},
+        payload_hash=f"{transaction_id:0<64}"[:64],
+        ingested_at=created_at,
+    )
+    session.add(event)
+    session.flush()
+    decision = EvaluationDecision(
+        ev_id=int(event.ev_id),
+        o_id=org_id,
+        transaction_id=transaction_id,
+        event_version=1,
+        effective_at=created_at,
+        observed_at=created_at,
+        decision_type="served",
+        served=True,
+        is_current=True,
+        outcome_counters={"HOLD": len(rules)},
+        resolved_outcome="HOLD",
+        all_rule_results={str(rule.r_id): "HOLD" for rule in rules},
+        evaluated_at=created_at,
+    )
+    session.add(decision)
+    session.flush()
+    for rule in rules:
+        session.add(
+            EvaluationRuleResult(
+                ed_id=int(decision.ed_id),
+                r_id=int(rule.r_id),
+                rule_result="HOLD",
+                rule_rid=str(rule.rid),
+                rule_description=str(rule.description),
+            )
+        )
+    case = Case(
+        o_id=org_id,
+        transaction_id=transaction_id,
+        current_ev_id=int(event.ev_id),
+        current_ed_id=int(decision.ed_id),
+        opened_by_ed_id=int(decision.ed_id),
+        resolved_outcome="HOLD",
+        status=status,
+        priority=priority,
+        assigned_to_user_id=int(assignee.id) if assignee else None,
+        resolution_disposition=disposition,
+        created_at=created_at,
+        updated_at=resolved_at or created_at,
+        resolved_at=resolved_at,
+    )
+    session.add(case)
+    session.flush()
+    return case
+
+
+def _add_api_user(session, *, has_view_cases: bool) -> str:
+    role = Role(
+        name=f"operations-{'viewer' if has_view_cases else 'blocked'}",
+        description="Operations test role",
+        o_id=1,
+    )
+    user = User(
+        email=f"operations-{'viewer' if has_view_cases else 'blocked'}@example.com",
+        password="unused",
+        active=True,
+        fs_uniquifier=f"operations-{'viewer' if has_view_cases else 'blocked'}@example.com",
+        o_id=1,
+    )
+    user.roles.append(role)
+    session.add_all([role, user])
+    session.commit()
+    PermissionManager.db_session = session
+    PermissionManager.init_default_actions()
+    if has_view_cases:
+        PermissionManager.grant_permission(int(role.id), PermissionAction.VIEW_CASES)
+    return create_access_token(
+        user_id=int(user.id),
+        email=str(user.email),
+        roles=[str(role.name)],
+        org_id=1,
+    )
+
+
+def test_operations_summary_is_org_scoped_and_uses_documented_periods(session):
+    now = datetime.datetime(2026, 7, 21, 14, 30, tzinfo=datetime.UTC)
+    org_one = session.query(Organisation).filter(Organisation.o_id == 1).one()
+    org_two = Organisation(o_id=2, name="Other org")
+    session.add(org_two)
+    session.flush()
+    rule_one = _add_rule(session, org_id=int(org_one.o_id), rid="beneficiary_velocity")
+    rule_two = _add_rule(session, org_id=int(org_two.o_id), rid="other_org_rule")
+    assignee = User(
+        email="analyst@example.com",
+        password="unused",
+        active=True,
+        fs_uniquifier="analyst@example.com",
+        o_id=1,
+    )
+    session.add(assignee)
+    session.flush()
+
+    active_unassigned = _add_case(
+        session,
+        org_id=1,
+        transaction_id="active-unassigned",
+        created_at=now - datetime.timedelta(days=3),
+        rules=[rule_one],
+        status="open",
+        priority=4,
+    )
+    active_assigned = _add_case(
+        session,
+        org_id=1,
+        transaction_id="active-assigned",
+        created_at=now - datetime.timedelta(days=2),
+        rules=[rule_one],
+        status="in_review",
+        priority=2,
+        assignee=assignee,
+    )
+    _add_case(
+        session,
+        org_id=1,
+        transaction_id="resolved-false-positive",
+        created_at=now - datetime.timedelta(days=2),
+        rules=[rule_one],
+        status="resolved",
+        resolved_at=now - datetime.timedelta(days=1),
+        disposition="false_positive",
+    )
+    _add_case(
+        session,
+        org_id=1,
+        transaction_id="resolved-confirmed",
+        created_at=now - datetime.timedelta(days=1),
+        rules=[rule_one],
+        status="resolved",
+        resolved_at=now - datetime.timedelta(hours=2),
+        disposition="confirmed_fraud",
+    )
+    _add_case(
+        session,
+        org_id=1,
+        transaction_id="resolved-before-window",
+        created_at=now - datetime.timedelta(days=10),
+        rules=[rule_one],
+        status="resolved",
+        resolved_at=now - datetime.timedelta(days=8),
+        disposition="false_positive",
+    )
+    _add_case(
+        session,
+        org_id=2,
+        transaction_id="other-org-active",
+        created_at=now - datetime.timedelta(days=1),
+        rules=[rule_two],
+        status="open",
+        priority=99,
+    )
+    rule_one.rid = "renamed_current_rule"
+    rule_one.description = "Current metadata must not replace the opening snapshot"
+    session.commit()
+
+    result = build_operations_summary(session, o_id=1, days=7, now=now)
+
+    assert result["period_start"] == datetime.datetime(2026, 7, 15, tzinfo=datetime.UTC)
+    assert result["period_end"] == now
+    assert result["summary"] == {
+        "active_cases": 2,
+        "unassigned_cases": 1,
+        "resolved_cases": 2,
+        "dispositioned_cases": 2,
+        "false_positive_cases": 1,
+        "false_positive_rate": 0.5,
+    }
+    assert len(result["case_flow"]) == 7
+    assert sum(point["opened"] for point in result["case_flow"]) == 4
+    assert sum(point["resolved"] for point in result["case_flow"]) == 2
+    assert {item["case_id"] for item in result["attention_cases"]} == {
+        int(active_unassigned.case_id),
+        int(active_assigned.case_id),
+    }
+    assert [item["rid"] for item in result["noisy_rules"]] == ["beneficiary_velocity"]
+    assert result["noisy_rules"][0]["case_count"] == 4
+    assert result["noisy_rules"][0]["false_positive_rate"] == 0.5
+
+
+def test_operations_summary_bounds_attention_and_deduplicates_rules(session):
+    now = datetime.datetime(2026, 7, 21, 14, 30, tzinfo=datetime.UTC)
+    rule_one = _add_rule(session, org_id=1, rid="velocity_rule")
+    rule_two = _add_rule(session, org_id=1, rid="amount_rule")
+    for index in range(12):
+        _add_case(
+            session,
+            org_id=1,
+            transaction_id=f"attention-{index:02d}",
+            created_at=now - datetime.timedelta(hours=12 - index),
+            rules=[rule_one, rule_two] if index == 0 else [rule_one],
+            status="reopened" if index == 0 else "open",
+            priority=5 if index < 2 else 1,
+        )
+    session.commit()
+
+    result = build_operations_summary(session, o_id=1, days=30, now=now)
+
+    assert len(result["attention_cases"]) == 10
+    assert [item["age_seconds"] for item in result["attention_cases"][:2]] == [43_200, 39_600]
+    rules = {item["rid"]: item for item in result["noisy_rules"]}
+    assert rules["velocity_rule"]["case_count"] == 12
+    assert rules["amount_rule"]["case_count"] == 1
+
+
+def test_operations_summary_returns_null_rate_without_dispositions(session):
+    result = build_operations_summary(
+        session,
+        o_id=1,
+        days=30,
+        now=datetime.datetime(2026, 7, 21, 14, 30, tzinfo=datetime.UTC),
+    )
+
+    assert result["summary"]["false_positive_rate"] is None
+    assert result["case_flow"] == [
+        {
+            "date": datetime.date(2026, 6, 22) + datetime.timedelta(days=offset),
+            "opened": 0,
+            "resolved": 0,
+        }
+        for offset in range(30)
+    ]
+    assert result["attention_cases"] == []
+    assert result["noisy_rules"] == []
+
+
+def test_operations_endpoint_validates_days_and_requires_view_cases(session):
+    viewer_token = _add_api_user(session, has_view_cases=True)
+    blocked_token = _add_api_user(session, has_view_cases=False)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v2/operations/summary?days=30",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert response.status_code == 200
+        assert response.json()["days"] == 30
+
+        invalid = client.get(
+            "/api/v2/operations/summary?days=14",
+            headers={"Authorization": f"Bearer {viewer_token}"},
+        )
+        assert invalid.status_code == 422
+
+        forbidden = client.get(
+            "/api/v2/operations/summary?days=30",
+            headers={"Authorization": f"Bearer {blocked_token}"},
+        )
+        assert forbidden.status_code == 403

--- a/tests/test_operations_dashboard.py
+++ b/tests/test_operations_dashboard.py
@@ -276,6 +276,35 @@ def test_operations_summary_returns_null_rate_without_dispositions(session):
     assert result["noisy_rules"] == []
 
 
+def test_operations_summary_keeps_deleted_rules_in_case_attribution(session):
+    now = datetime.datetime(2026, 7, 21, 14, 30, tzinfo=datetime.UTC)
+    deleted_rule = _add_rule(session, org_id=1, rid="deleted_velocity_rule")
+    deleted_rule_id = int(deleted_rule.r_id)
+    _add_case(
+        session,
+        org_id=1,
+        transaction_id="opened-before-rule-deletion",
+        created_at=now - datetime.timedelta(days=1),
+        rules=[deleted_rule],
+    )
+    session.query(EvaluationRuleResult).filter(EvaluationRuleResult.r_id == deleted_rule_id).delete()
+    session.delete(deleted_rule)
+    session.commit()
+
+    result = build_operations_summary(session, o_id=1, days=7, now=now)
+
+    assert result["noisy_rules"] == [
+        {
+            "rid": f"rule_{deleted_rule_id}",
+            "description": "Deleted rule",
+            "case_count": 1,
+            "resolved_count": 0,
+            "false_positive_count": 0,
+            "false_positive_rate": None,
+        }
+    ]
+
+
 def test_operations_endpoint_validates_days_and_requires_view_cases(session):
     viewer_token = _add_api_user(session, has_view_cases=True)
     blocked_token = _add_api_user(session, has_view_cases=False)

--- a/uv.lock
+++ b/uv.lock
@@ -502,7 +502,7 @@ wheels = [
 
 [[package]]
 name = "ezrules"
-version = "1.29.2"
+version = "1.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- add one organisation-scoped operations summary endpoint using the existing case and evaluation ledgers
- add one read-only Operations page with four KPIs, daily case flow, ten aging cases, and five noisy rules
- reuse VIEW_CASES, manual refresh, and the existing Cases workflow; defer SLA settings, exports, polling, alerts, scorecards, and deep links
- document the metric contract and bump the feature release to 1.30.0

## Verification

- uv run poe check
- Angular production build
- strict TypeScript check for the new Playwright spec and page object
- backend/PostgreSQL and repeated Chromium coverage are included for GitHub Actions per repository verification policy

## Scope decisions

This is intentionally the smallest useful slice of the broader dashboard ticket. It adds no migration, new permission, audit event, settings model, or parallel investigation queue.

Asana: https://app.asana.com/1/106415343104513/project/1211443964065287/task/1214248687198125